### PR TITLE
Matrix bugfix: include header with FC_FUNC macros

### DIFF
--- a/Matrix.C
+++ b/Matrix.C
@@ -23,6 +23,7 @@
 #endif
 
 /* Use Autotools-detected Fortran name-mangling scheme */
+#include "CAROM_config.h"
 #define dgetrf FC_FUNC(dgetrf, DGETRF)
 #define dgetri FC_FUNC(dgetri, DGETRI)
 #define dgeqp3 FC_FUNC(dgeqp3, DGEQP3)


### PR DESCRIPTION
As of this PR, `master:Matrix.C` uses the `FC_FUNC` macros without including `CAROM_config.h`, so these macros are sometimes undefined (depending on order of execution of commands). This commit includes this header in `Matrix.C` so that the `FC_FUNC` macros used for Fortran name-mangling are defined, fixing compile-time errors in some cases.