### PR TITLE
[feature/matrix-add-vector-outer-product] Add a vector-vector outer product returning a Matrix

### DIFF
--- a/Matrix.C
+++ b/Matrix.C
@@ -1262,5 +1262,14 @@ const
 #endif
 }
 
+Matrix outerProduct(const Vector &v, const Vector &w)
+{
+    int num_rows = v.dim();
+    int num_cols = w.dim();
+    bool is_distributed = (v.distributed() || w.distributed());
+    Matrix result(num_rows, num_cols, is_distributed);
+
+    return result;
+}
 
 } // end namespace CAROM

--- a/Matrix.C
+++ b/Matrix.C
@@ -1273,7 +1273,6 @@ Matrix outerProduct(const Vector &v, const Vector &w)
      * 2) w is distributed
      *
      */
-
     int result_num_rows = v.dim();
     int result_num_cols;
     bool is_distributed = v.distributed();

--- a/Matrix.h
+++ b/Matrix.h
@@ -975,8 +975,10 @@ class Matrix
      * @brief Computes the outer product of two Vectors, v and w.
      *
      * @post The number of rows in the returned matrix equals the dimension of v
-     * @post The number of cols in the returned matrix equals the dimension of w
-     * @post If v or w is distributed, so is the returned matrix.
+     * @post The number of cols in the returned matrix equals the dimension of w,
+     *       if w is not distributed. If w is distributed, the number of columns
+     *       equals the total number of entries of w, summed over all processes.
+     * @post If v is distributed, so is the returned matrix.
      *
      * @param[in] v The first vector in the outer product
      * @param[in] w The second vector in the outer product

--- a/Matrix.h
+++ b/Matrix.h
@@ -971,6 +971,23 @@ class Matrix
       bool d_owns_data;
 };
 
+    /**
+     * @brief Computes the outer product of two Vectors, v and w.
+     *
+     * @post The number of rows in the returned matrix equals the dimension of v
+     * @post The number of cols in the returned matrix equals the dimension of w
+     * @post If v or w is distributed, so is the returned matrix.
+     *
+     * @param[in] v The first vector in the outer product
+     * @param[in] w The second vector in the outer product
+     *
+     * @return The product of v and the transpose of w.
+     */
+    // NOTE(goxberry@gmail.com; oxberry1@llnl.gov): Passing by value is
+    // supposed to be more idiomatic C++11; consider passing by value
+    // instead of passing by reference.
+    Matrix outerProduct(const Vector &v, const Vector &w);
+
 }
 
 #endif

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1284,6 +1284,25 @@ TEST(MatrixSerialTest, Test_transposeMult_Vector_Vector_reference)
   EXPECT_DOUBLE_EQ(w(1), 4.0);
 }
 
+TEST(MatrixOuterProduct, Test_outerProduct_serial)
+{
+  /**
+   *  Build vector [ 1.0 ] and vector [ 3.0 ]
+   *               [ 2.0 ]            [ 4.0 ]
+   *                                  [ 5.0 ]
+   */
+
+   double v_data[2] = { 1.0, 2.0 };
+   double w_data[3] = { 3.0, 4.0, 5.0 };
+
+   CAROM::Vector v(v_data, 2, false, true);
+   CAROM::Vector w(w_data, 3, false, true);
+
+   CAROM::Matrix outer_product_vw = CAROM::outerProduct(v, w);
+   EXPECT_EQ(outer_product_vw.numRows(), 2);
+   EXPECT_EQ(outer_product_vw.numColumns(), 3);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1301,6 +1301,24 @@ TEST(MatrixOuterProduct, Test_outerProduct_serial)
    CAROM::Matrix outer_product_vw = CAROM::outerProduct(v, w);
    EXPECT_EQ(outer_product_vw.numRows(), 2);
    EXPECT_EQ(outer_product_vw.numColumns(), 3);
+   EXPECT_FALSE(outer_product_vw.distributed());
+   EXPECT_DOUBLE_EQ(outer_product_vw(0, 0), 3.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(0, 1), 4.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(0, 2), 5.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(1, 0), 6.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(1, 1), 8.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(1, 2), 10.0);
+
+   CAROM::Matrix outer_product_wv = CAROM::outerProduct(w, v);
+   EXPECT_EQ(outer_product_wv.numRows(), 3);
+   EXPECT_EQ(outer_product_wv.numColumns(), 2);
+   EXPECT_FALSE(outer_product_wv.distributed());
+   EXPECT_DOUBLE_EQ(outer_product_wv(0, 0), 3.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(0, 1), 6.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(1, 0), 4.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(1, 1), 8.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(2, 0), 5.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(2, 1), 10.0);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This pull request adds a function to compute a `CAROM::Matrix` from the outer product of two `CAROM::Vector` objects. This function does not require access to any private data members of `CAROM::Vector` objects, so it is a free function -- not a member function. I would like to keep the interfaces of our classes as small as possible.