### PR TITLE
[feature/diagonal-matrix-factory] Add free functions to make diagonal matrices from vectors, identity matrices

### DIFF
--- a/Matrix.C
+++ b/Matrix.C
@@ -1436,4 +1436,10 @@ Matrix DiagonalMatrixFactory(const Vector &v)
     return diagonalMatrix;
 }
 
+Matrix IdentityMatrixFactory(const Vector &v)
+{
+    Vector temporary(v); temporary = 1.0;
+    return DiagonalMatrixFactory(temporary);
+}
+
 } // end namespace CAROM

--- a/Matrix.C
+++ b/Matrix.C
@@ -1363,4 +1363,77 @@ Matrix outerProduct(const Vector &v, const Vector &w)
     return result;
 }
 
+Matrix DiagonalMatrixFactory(const Vector &v)
+{
+    const int resultNumRows = v.dim();
+    int resultNumColumns, processRowStartIndex, processNumColumns;
+    const bool isDistributed = v.distributed();
+
+    /* If v isn't distributed, sizing the output matrix is trivial. */
+    if (false == isDistributed)
+    {
+        resultNumColumns = processNumColumns = resultNumRows;
+        processRowStartIndex = 0;
+    }
+    else /* true == isDistributed */
+    {
+        using sizeType = std::vector<int>::size_type;
+
+        /**
+         * Get the number of rows on each process; these process row
+         * counts must be summed to get the number of columns on each
+         * process.
+         */
+        const MPI_Comm comm = MPI_COMM_WORLD;
+        int numProcesses; MPI_Comm_size(comm, &numProcesses);
+        std::vector<int>
+            numRowsOnProcess(static_cast<sizeType>(numProcesses));
+        const int one = 1; const MPI_Datatype indexType = MPI_INT;
+        MPI_Allgather(&resultNumRows, one, indexType,
+                      numRowsOnProcess.data(), one, indexType, comm);
+
+        /**
+         * Compute the row starting index and total number of rows
+         * over all processes -- which is also the total number of
+         * columns. Also compute the starting row index on each
+         * process.
+         *
+         * Assume that Matrix rows are contiguous sets of row indices,
+         * e.g., if a four row matrix is partititioned over two
+         * processes, then process zero on the MPI_Comm owns rows 0
+         * and 1, and process one on the MPI_Comm owns rows 2 and 3.
+         */
+        std::vector<int> rowStartIndexOnProcess(numProcesses);
+        resultNumColumns = 0;
+        for (sizeType i = 0; i < rowStartIndexOnProcess.size(); i++)
+        {
+            rowStartIndexOnProcess.at(i) = resultNumColumns;
+            resultNumColumns += numRowsOnProcess.at(i);
+        }
+        int processNumber; MPI_Comm_rank(comm, &processNumber);
+        processRowStartIndex =
+            rowStartIndexOnProcess.at(static_cast<sizeType>(processNumber));
+    } /* end (true == isDistributed) */
+
+    /**
+     * Create the diagonal matrix and assign process local entries in v
+     * to process local entries in the diagonal matrix.
+     */
+    Matrix diagonalMatrix(resultNumRows, resultNumColumns, isDistributed);
+    for (int i = 0; i < resultNumRows; i++)
+    {
+        for (int j = 0; j < resultNumColumns; j++)
+        {
+            /**
+             * Off-diagonal matrix entries are zero; diagonal matrix entries
+             * come from the input Vector.
+             */
+            const double entry = (j == (i + processRowStartIndex)) ? v(i) : 0.0;
+            diagonalMatrix(i, j) = entry;
+        }
+    }
+
+    return diagonalMatrix;
+}
+
 } // end namespace CAROM

--- a/Matrix.h
+++ b/Matrix.h
@@ -1005,6 +1005,20 @@ class Matrix
      */
     Matrix DiagonalMatrixFactory(const Vector &v);
 
+    /**
+     * @brief Factory function to make an identity matrix with rows
+     * distributed in the same fashion as its Vector argument. This function
+     * is provided for convenience due to the ubiquity of identity matrices
+     * (and operators) in mathematics.
+     *
+     * @param[in] v Vector of elements that will be on the diagonal of the
+     *              output matrix.
+     * @param[out] diagonalMatrix The diagonal matrix created by this function.
+     *
+     * @post diagonalMatrix.distributed() == v.distributed()
+     * @post diagonalMatrix.numRows() == v.dim()
+     */
+    Matrix IdentityMatrixFactory(const Vector &v);
 
 }
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -990,6 +990,22 @@ class Matrix
     // instead of passing by reference.
     Matrix outerProduct(const Vector &v, const Vector &w);
 
+    /**
+     * @brief Factory function to make a diagonal matrix with nonzero
+     * entries as in its Vector argument. The rows of this diagonal
+     * matrix are distributed in the same fashion as its Vector
+     * argument.
+     *
+     * @param[in] v Vector of elements that will be on the diagonal of the
+     *              output matrix.
+     * @param[out] diagonalMatrix The diagonal matrix created by this function.
+     *
+     * @post diagonalMatrix.distributed() == v.distributed()
+     * @post diagonalMatrix.numRows() == v.dim()
+     */
+    Matrix DiagonalMatrixFactory(const Vector &v);
+
+
 }
 
 #endif

--- a/Vector.h
+++ b/Vector.h
@@ -104,9 +104,10 @@ class Vector
       /**
        * @brief Equal operator.
        *
-       * @param[in] rhs The Vector to add to this.
+       * @param[in] a The double precision number to which every
+       * Vector entry should be set.
        *
-       * @return This after rhs has been added to it.
+       * @return This with every element of the Vector set to a.
        */
       Vector&
       operator = (

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1321,6 +1321,33 @@ TEST(MatrixOuterProduct, Test_outerProduct_serial)
    EXPECT_DOUBLE_EQ(outer_product_wv(2, 1), 10.0);
 }
 
+TEST(DiagonalMatrixFactorySerialTest, Test_123vector)
+{
+    /** Set up a the vector [1, 2, 3]^{T} */
+    CAROM::Vector w(3, false);
+    w(0) = 1.0; w(1) = 2.0; w(2) = 3.0;
+
+    /**
+     *  \diag([1, 2, 3])^{T} = [ 1.0  0.0  0.0 ]
+     *                         [ 0.0  2.0  0.0 ]
+     *                         [ 0.0  0.0  3.0 ]
+     */
+    CAROM::Matrix diagonalMatrix = DiagonalMatrixFactory(w);
+    EXPECT_TRUE(diagonalMatrix.distributed() == w.distributed());
+    EXPECT_TRUE(diagonalMatrix.numRows() == w.dim());
+    EXPECT_TRUE(diagonalMatrix.numColumns() == w.dim());
+    EXPECT_TRUE(diagonalMatrix.numRows() == diagonalMatrix.numColumns());
+    EXPECT_DOUBLE_EQ(diagonalMatrix(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(0, 1), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(0, 2), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(1, 0), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(1, 1), 2.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(1, 2), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(2, 0), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(2, 1), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(2, 2), 3.0);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1323,7 +1323,7 @@ TEST(MatrixOuterProduct, Test_outerProduct_serial)
 
 TEST(DiagonalMatrixFactorySerialTest, Test_123vector)
 {
-    /** Set up a the vector [1, 2, 3]^{T} */
+    /** Set up the vector [1, 2, 3]^{T} */
     CAROM::Vector w(3, false);
     w(0) = 1.0; w(1) = 2.0; w(2) = 3.0;
 
@@ -1346,6 +1346,28 @@ TEST(DiagonalMatrixFactorySerialTest, Test_123vector)
     EXPECT_DOUBLE_EQ(diagonalMatrix(2, 0), 0.0);
     EXPECT_DOUBLE_EQ(diagonalMatrix(2, 1), 0.0);
     EXPECT_DOUBLE_EQ(diagonalMatrix(2, 2), 3.0);
+}
+
+TEST(IdentityMatrixFactorySerialTest, Test_3vector)
+{
+    /** Set up the vector [1, 2, 3]^{T} */
+    CAROM::Vector w(3, false);
+    w(0) = 1.0; w(1) = 2.0; w(2) = 3.0;
+
+    CAROM::Matrix identityMatrix = IdentityMatrixFactory(w);
+    EXPECT_TRUE(identityMatrix.distributed() == w.distributed());
+    EXPECT_TRUE(identityMatrix.numRows() == w.dim());
+    EXPECT_TRUE(identityMatrix.numColumns() == w.dim());
+    EXPECT_TRUE(identityMatrix.numRows() == identityMatrix.numColumns());
+    EXPECT_DOUBLE_EQ(identityMatrix(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(0, 1), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(0, 2), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(1, 0), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(1, 1), 1.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(1, 2), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(2, 0), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(2, 1), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(2, 2), 1.0);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This PR adds some free functions to make diagonal matrices and identity matrices from `CAROM::Vector` objects. These types of matrices are useful when implementing algorithms from numerical linear algebra.

Design notes:

- Motivations:
    - I need diagonal matrices for making random orthogonal matrices.
    - @slmcbane mentioned possibly collapsing diagonal singular value matrices into `CAROM::Vector`s; `DiagonalMatrixFactory` performs the inverse of this operation.
    - I need identity matrices to make Householder reflectors.
- Quirks:
   - `IdentityMatrixFactory` is its own convenience method because identity matrices are common.
   - `IdentityMatrixFactory` takes a `const CAROM::Vector&` argument because the parallel data layout of the `CAROM::Matrix` must be specified somewhere. Inferring this information from a `CAROM::Vector` seemed most expedient.
- Drawbacks:
   - There are no parallel tests at the moment; parallel tests would require extra infrastructure.
   - The design is very C++03; I still haven't learned enough C++11 idioms to be proficient at it.
   - There are some pedantic mistakes that could be fixed for better style/documentation.