### PR TITLE
[feature/make-householder-reflector] Add functions to compute Householder reflectors and corresponding hyperplane normals

### DIFF
--- a/Matrix.C
+++ b/Matrix.C
@@ -1262,5 +1262,14 @@ const
 #endif
 }
 
+Matrix outerProduct(const Vector &v, const Vector &w)
+{
+    int num_rows = v.dim();
+    int num_cols = w.dim();
+    bool is_distributed = (v.distributed() || w.distributed());
+    Matrix result(num_rows, num_cols, is_distributed);
+
+    return result;
+}
 
 } // end namespace CAROM

--- a/Matrix.C
+++ b/Matrix.C
@@ -1476,4 +1476,21 @@ Matrix MakeHouseholderMatrix(const Vector &v)
     return result;
 }
 
+Vector ComputeHouseholderNormal
+(const Vector &input, const Vector &desiredOutput)
+{
+    CAROM_ASSERT(input.distributed() == desiredOutput.distributed());
+    CAROM_ASSERT(input.dim() == desiredOutput.dim());
+    CAROM_ASSERT(input.norm() == desiredOutput.norm());
+
+    Vector result(desiredOutput);
+    for (int i = 0; i < input.dim(); i++)
+    {
+        result(i) -= input(i);
+    }
+    CAROM_ASSERT(result.norm() > 0.0);
+    result.normalize();
+    return result;
+}
+
 } // end namespace CAROM

--- a/Matrix.C
+++ b/Matrix.C
@@ -23,6 +23,7 @@
 #endif
 
 /* Use Autotools-detected Fortran name-mangling scheme */
+#include "CAROM_config.h"
 #define dgetrf FC_FUNC(dgetrf, DGETRF)
 #define dgetri FC_FUNC(dgetri, DGETRI)
 #define dgeqp3 FC_FUNC(dgeqp3, DGEQP3)

--- a/Matrix.C
+++ b/Matrix.C
@@ -1436,4 +1436,10 @@ Matrix DiagonalMatrixFactory(const Vector &v)
     return diagonalMatrix;
 }
 
+Matrix IdentityMatrixFactory(const Vector &v)
+{
+    Vector temporary(v); temporary = 1.0;
+    return DiagonalMatrixFactory(temporary);
+}
+
 } // end namespace CAROM

--- a/Matrix.C
+++ b/Matrix.C
@@ -1363,4 +1363,77 @@ Matrix outerProduct(const Vector &v, const Vector &w)
     return result;
 }
 
+Matrix DiagonalMatrixFactory(const Vector &v)
+{
+    const int resultNumRows = v.dim();
+    int resultNumColumns, processRowStartIndex, processNumColumns;
+    const bool isDistributed = v.distributed();
+
+    /* If v isn't distributed, sizing the output matrix is trivial. */
+    if (false == isDistributed)
+    {
+        resultNumColumns = processNumColumns = resultNumRows;
+        processRowStartIndex = 0;
+    }
+    else /* true == isDistributed */
+    {
+        using sizeType = std::vector<int>::size_type;
+
+        /**
+         * Get the number of rows on each process; these process row
+         * counts must be summed to get the number of columns on each
+         * process.
+         */
+        const MPI_Comm comm = MPI_COMM_WORLD;
+        int numProcesses; MPI_Comm_size(comm, &numProcesses);
+        std::vector<int>
+            numRowsOnProcess(static_cast<sizeType>(numProcesses));
+        const int one = 1; const MPI_Datatype indexType = MPI_INT;
+        MPI_Allgather(&resultNumRows, one, indexType,
+                      numRowsOnProcess.data(), one, indexType, comm);
+
+        /**
+         * Compute the row starting index and total number of rows
+         * over all processes -- which is also the total number of
+         * columns. Also compute the starting row index on each
+         * process.
+         *
+         * Assume that Matrix rows are contiguous sets of row indices,
+         * e.g., if a four row matrix is partititioned over two
+         * processes, then process zero on the MPI_Comm owns rows 0
+         * and 1, and process one on the MPI_Comm owns rows 2 and 3.
+         */
+        std::vector<int> rowStartIndexOnProcess(numProcesses);
+        resultNumColumns = 0;
+        for (sizeType i = 0; i < rowStartIndexOnProcess.size(); i++)
+        {
+            rowStartIndexOnProcess.at(i) = resultNumColumns;
+            resultNumColumns += numRowsOnProcess.at(i);
+        }
+        int processNumber; MPI_Comm_rank(comm, &processNumber);
+        processRowStartIndex =
+            rowStartIndexOnProcess.at(static_cast<sizeType>(processNumber));
+    } /* end (true == isDistributed) */
+
+    /**
+     * Create the diagonal matrix and assign process local entries in v
+     * to process local entries in the diagonal matrix.
+     */
+    Matrix diagonalMatrix(resultNumRows, resultNumColumns, isDistributed);
+    for (int i = 0; i < resultNumRows; i++)
+    {
+        for (int j = 0; j < resultNumColumns; j++)
+        {
+            /**
+             * Off-diagonal matrix entries are zero; diagonal matrix entries
+             * come from the input Vector.
+             */
+            const double entry = (j == (i + processRowStartIndex)) ? v(i) : 0.0;
+            diagonalMatrix(i, j) = entry;
+        }
+    }
+
+    return diagonalMatrix;
+}
+
 } // end namespace CAROM

--- a/Matrix.C
+++ b/Matrix.C
@@ -1273,7 +1273,6 @@ Matrix outerProduct(const Vector &v, const Vector &w)
      * 2) w is distributed
      *
      */
-
     int result_num_rows = v.dim();
     int result_num_cols;
     bool is_distributed = v.distributed();

--- a/Matrix.h
+++ b/Matrix.h
@@ -1006,6 +1006,20 @@ class Matrix
      */
     Matrix DiagonalMatrixFactory(const Vector &v);
 
+    /**
+     * @brief Factory function to make an identity matrix with rows
+     * distributed in the same fashion as its Vector argument. This function
+     * is provided for convenience due to the ubiquity of identity matrices
+     * (and operators) in mathematics.
+     *
+     * @param[in] v Vector of elements that will be on the diagonal of the
+     *              output matrix.
+     * @param[out] diagonalMatrix The diagonal matrix created by this function.
+     *
+     * @post diagonalMatrix.distributed() == v.distributed()
+     * @post diagonalMatrix.numRows() == v.dim()
+     */
+    Matrix IdentityMatrixFactory(const Vector &v);
 }
 
 #endif

--- a/Matrix.h
+++ b/Matrix.h
@@ -975,8 +975,10 @@ class Matrix
      * @brief Computes the outer product of two Vectors, v and w.
      *
      * @post The number of rows in the returned matrix equals the dimension of v
-     * @post The number of cols in the returned matrix equals the dimension of w
-     * @post If v or w is distributed, so is the returned matrix.
+     * @post The number of cols in the returned matrix equals the dimension of w,
+     *       if w is not distributed. If w is distributed, the number of columns
+     *       equals the total number of entries of w, summed over all processes.
+     * @post If v is distributed, so is the returned matrix.
      *
      * @param[in] v The first vector in the outer product
      * @param[in] w The second vector in the outer product

--- a/Matrix.h
+++ b/Matrix.h
@@ -1036,6 +1036,33 @@ class Matrix
      * @post result.distributed() == v.distributed()
      */
     Matrix MakeHouseholderMatrix(const Vector &v);
+
+    /**
+     * @brief Factory function that computes the normal Vector
+     * required to yield a Householder matrix that reflects the input
+     * Vector to the desiredOutput Vector. Note that because Householder
+     * matrices are unitary, the input and desiredOutput Vector objects
+     * must have the same norm (and belong to the same inner product space,
+     * have the same dimension on each process, and so on).
+     *
+     * @param[in] input Vector to be reflected
+     * @param[in] desiredOutput Vector obtained when applying Householder matrix
+     *                          to input.
+     *
+     * @pre input.distributed() == desiredOutput.distributed()
+     * @pre input.dim() == desiredOutput.dim()
+     * @pre norm of (input - desiredOutput) > 0.0
+     * @pre input.norm() == desiredOutput.norm()
+     *
+     * @return result Vector containing normal of hyperplane
+     *
+     * @post result.norm() == 1.0
+     * @post result.dim() == input.dim() == desiredOutput.dim()
+     * @post result.distributed() == input.distributed()
+     * @post result.distributed() == desiredOutput.distributed()
+     */
+    Vector ComputeHouseholderNormal
+    (const Vector &input, const Vector &desiredOutput);
 }
 
 #endif

--- a/Matrix.h
+++ b/Matrix.h
@@ -972,6 +972,7 @@ class Matrix
 };
 
     /**
+
      * @brief Computes the outer product of two Vectors, v and w.
      *
      * @post The number of rows in the returned matrix equals the dimension of v
@@ -989,6 +990,21 @@ class Matrix
     // supposed to be more idiomatic C++11; consider passing by value
     // instead of passing by reference.
     Matrix outerProduct(const Vector &v, const Vector &w);
+
+    /**
+     * @brief Factory function to make a diagonal matrix with nonzero
+     * entries as in its Vector argument. The rows of this diagonal
+     * matrix are distributed in the same fashion as its Vector
+     * argument.
+     *
+     * @param[in] v Vector of elements that will be on the diagonal of the
+     *              output matrix.
+     * @param[out] diagonalMatrix The diagonal matrix created by this function.
+     *
+     * @post diagonalMatrix.distributed() == v.distributed()
+     * @post diagonalMatrix.numRows() == v.dim()
+     */
+    Matrix DiagonalMatrixFactory(const Vector &v);
 
 }
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -971,6 +971,23 @@ class Matrix
       bool d_owns_data;
 };
 
+    /**
+     * @brief Computes the outer product of two Vectors, v and w.
+     *
+     * @post The number of rows in the returned matrix equals the dimension of v
+     * @post The number of cols in the returned matrix equals the dimension of w
+     * @post If v or w is distributed, so is the returned matrix.
+     *
+     * @param[in] v The first vector in the outer product
+     * @param[in] w The second vector in the outer product
+     *
+     * @return The product of v and the transpose of w.
+     */
+    // NOTE(goxberry@gmail.com; oxberry1@llnl.gov): Passing by value is
+    // supposed to be more idiomatic C++11; consider passing by value
+    // instead of passing by reference.
+    Matrix outerProduct(const Vector &v, const Vector &w);
+
 }
 
 #endif

--- a/Matrix.h
+++ b/Matrix.h
@@ -1020,6 +1020,22 @@ class Matrix
      * @post diagonalMatrix.numRows() == v.dim()
      */
     Matrix IdentityMatrixFactory(const Vector &v);
+
+    /**
+     * @brief Factory function to make a Householder reflector matrix that
+     * reflects over a hyperplane with normal equal to the Vector argument.
+     *
+     * @param[in] v Vector definining the normal of the reflection hyperplane.
+     *
+     * @pre v.norm() != 0.0
+     *
+     * @return result The Householder vector described above, equal to
+     * (IdentityMatrix - 2 * outerProductMatrix(v, v) / v.inner_product(v)).
+     *
+     * @post result.numRows() == v.dim()
+     * @post result.distributed() == v.distributed()
+     */
+    Matrix MakeHouseholderMatrix(const Vector &v);
 }
 
 #endif

--- a/Vector.h
+++ b/Vector.h
@@ -104,9 +104,10 @@ class Vector
       /**
        * @brief Equal operator.
        *
-       * @param[in] rhs The Vector to add to this.
+       * @param[in] a The double precision number to which every
+       * Vector entry should be set.
        *
-       * @return This after rhs has been added to it.
+       * @return This with every element of the Vector set to a.
        */
       Vector&
       operator = (

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1321,6 +1321,33 @@ TEST(MatrixOuterProduct, Test_outerProduct_serial)
    EXPECT_DOUBLE_EQ(outer_product_wv(2, 1), 10.0);
 }
 
+TEST(DiagonalMatrixFactorySerialTest, Test_123vector)
+{
+    /** Set up a the vector [1, 2, 3]^{T} */
+    CAROM::Vector w(3, false);
+    w(0) = 1.0; w(1) = 2.0; w(2) = 3.0;
+
+    /**
+     *  \diag([1, 2, 3])^{T} = [ 1.0  0.0  0.0 ]
+     *                         [ 0.0  2.0  0.0 ]
+     *                         [ 0.0  0.0  3.0 ]
+     */
+    CAROM::Matrix diagonalMatrix = DiagonalMatrixFactory(w);
+    EXPECT_TRUE(diagonalMatrix.distributed() == w.distributed());
+    EXPECT_TRUE(diagonalMatrix.numRows() == w.dim());
+    EXPECT_TRUE(diagonalMatrix.numColumns() == w.dim());
+    EXPECT_TRUE(diagonalMatrix.numRows() == diagonalMatrix.numColumns());
+    EXPECT_DOUBLE_EQ(diagonalMatrix(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(0, 1), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(0, 2), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(1, 0), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(1, 1), 2.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(1, 2), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(2, 0), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(2, 1), 0.0);
+    EXPECT_DOUBLE_EQ(diagonalMatrix(2, 2), 3.0);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1284,6 +1284,25 @@ TEST(MatrixSerialTest, Test_transposeMult_Vector_Vector_reference)
   EXPECT_DOUBLE_EQ(w(1), 4.0);
 }
 
+TEST(MatrixOuterProduct, Test_outerProduct_serial)
+{
+  /**
+   *  Build vector [ 1.0 ] and vector [ 3.0 ]
+   *               [ 2.0 ]            [ 4.0 ]
+   *                                  [ 5.0 ]
+   */
+
+   double v_data[2] = { 1.0, 2.0 };
+   double w_data[3] = { 3.0, 4.0, 5.0 };
+
+   CAROM::Vector v(v_data, 2, false, true);
+   CAROM::Vector w(w_data, 3, false, true);
+
+   CAROM::Matrix outer_product_vw = CAROM::outerProduct(v, w);
+   EXPECT_EQ(outer_product_vw.numRows(), 2);
+   EXPECT_EQ(outer_product_vw.numColumns(), 3);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1301,6 +1301,24 @@ TEST(MatrixOuterProduct, Test_outerProduct_serial)
    CAROM::Matrix outer_product_vw = CAROM::outerProduct(v, w);
    EXPECT_EQ(outer_product_vw.numRows(), 2);
    EXPECT_EQ(outer_product_vw.numColumns(), 3);
+   EXPECT_FALSE(outer_product_vw.distributed());
+   EXPECT_DOUBLE_EQ(outer_product_vw(0, 0), 3.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(0, 1), 4.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(0, 2), 5.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(1, 0), 6.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(1, 1), 8.0);
+   EXPECT_DOUBLE_EQ(outer_product_vw(1, 2), 10.0);
+
+   CAROM::Matrix outer_product_wv = CAROM::outerProduct(w, v);
+   EXPECT_EQ(outer_product_wv.numRows(), 3);
+   EXPECT_EQ(outer_product_wv.numColumns(), 2);
+   EXPECT_FALSE(outer_product_wv.distributed());
+   EXPECT_DOUBLE_EQ(outer_product_wv(0, 0), 3.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(0, 1), 6.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(1, 0), 4.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(1, 1), 8.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(2, 0), 5.0);
+   EXPECT_DOUBLE_EQ(outer_product_wv(2, 1), 10.0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1370,6 +1370,40 @@ TEST(IdentityMatrixFactorySerialTest, Test_3vector)
     EXPECT_DOUBLE_EQ(identityMatrix(2, 2), 1.0);
 }
 
+TEST(MakeHouseholderMatrixTest, Test_VectorOfThreeOnes)
+{
+    /** Set up the vector [1, 1, 1]^{T} */
+    CAROM::Vector w(3, false); w(0) = w(1) = w(2) = 1.0;
+
+    /**
+     * (IdentityMatrix - 2 * outerProduct(w, w) / (w.norm() * w.norm())) =
+     *
+     * Householder matrix =
+     *
+     * [ 1.0 / 3.0  -2.0 / 3.0  -2.0 / 3.0 ]
+     * [-2.0 / 3.0   1.0 / 3.0  -2.0 / 3.0 ]
+     * [-2.0 / 3.0  -2.0 / 3.0   1.0 / 3.0 ]
+     *
+     */
+    const double one_third = 1.0 / 3.0;
+    const double two_thirds = 2.0 / 3.0;
+    CAROM::Matrix householder = CAROM::MakeHouseholderMatrix(w);
+    EXPECT_FALSE(householder.distributed());
+    EXPECT_EQ(householder.numRows(), 3);
+    EXPECT_EQ(householder.numColumns(), 3);
+
+    EXPECT_DOUBLE_EQ(householder(0, 0), one_third);
+    EXPECT_DOUBLE_EQ(householder(1, 1), one_third);
+    EXPECT_DOUBLE_EQ(householder(2, 2), one_third);
+
+    EXPECT_DOUBLE_EQ(householder(0, 1), -two_thirds);
+    EXPECT_DOUBLE_EQ(householder(0, 2), -two_thirds);
+    EXPECT_DOUBLE_EQ(householder(1, 0), -two_thirds);
+    EXPECT_DOUBLE_EQ(householder(1, 2), -two_thirds);
+    EXPECT_DOUBLE_EQ(householder(2, 0), -two_thirds);
+    EXPECT_DOUBLE_EQ(householder(2, 1), -two_thirds);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_Matrix.C
+++ b/tests/test_Matrix.C
@@ -1323,7 +1323,7 @@ TEST(MatrixOuterProduct, Test_outerProduct_serial)
 
 TEST(DiagonalMatrixFactorySerialTest, Test_123vector)
 {
-    /** Set up a the vector [1, 2, 3]^{T} */
+    /** Set up the vector [1, 2, 3]^{T} */
     CAROM::Vector w(3, false);
     w(0) = 1.0; w(1) = 2.0; w(2) = 3.0;
 
@@ -1346,6 +1346,28 @@ TEST(DiagonalMatrixFactorySerialTest, Test_123vector)
     EXPECT_DOUBLE_EQ(diagonalMatrix(2, 0), 0.0);
     EXPECT_DOUBLE_EQ(diagonalMatrix(2, 1), 0.0);
     EXPECT_DOUBLE_EQ(diagonalMatrix(2, 2), 3.0);
+}
+
+TEST(IdentityMatrixFactorySerialTest, Test_3vector)
+{
+    /** Set up the vector [1, 2, 3]^{T} */
+    CAROM::Vector w(3, false);
+    w(0) = 1.0; w(1) = 2.0; w(2) = 3.0;
+
+    CAROM::Matrix identityMatrix = IdentityMatrixFactory(w);
+    EXPECT_TRUE(identityMatrix.distributed() == w.distributed());
+    EXPECT_TRUE(identityMatrix.numRows() == w.dim());
+    EXPECT_TRUE(identityMatrix.numColumns() == w.dim());
+    EXPECT_TRUE(identityMatrix.numRows() == identityMatrix.numColumns());
+    EXPECT_DOUBLE_EQ(identityMatrix(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(0, 1), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(0, 2), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(1, 0), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(1, 1), 1.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(1, 2), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(2, 0), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(2, 1), 0.0);
+    EXPECT_DOUBLE_EQ(identityMatrix(2, 2), 1.0);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This PR builds on PR#9 and PR#13 to add functions that compute Householder reflectors and the normal vectors to the hyperplanes defining Householder reflectors. These two features are needed to compute random orthogonal matrices in serial and parallel for use in testing the SVD algorithms, particularly the incremental SVD.

Design notes:
- I grouped `CAROM::Vector ComputeHouseholderNormal(const CAROM::Vector&, const CAROM::Vector&)` with `CAROM::Matrix MakeHouseholderMatrix(const CAROM::Vector&)` in `Matrix.h` because it seemed like the two related functions should be in the same header, even though the former returns a `CAROM::Vector` and the latter returns a `CAROM::Matrix`.
- The idea is to permit constructing these matrices in serial and in parallel to test the incremental SVD in both serial and parallel. However, for the parallel case, I will need a matrix-matrix product in parallel, and may write a not-terribly-performant algorithm for low process counts, just so the parallel parts of the code can be exercised.

Other notes:
- I rebased my branch on top of PR#9 first, then PR#13, before adding the Householder-related commits. The commit messages where Housholder-related work is done are clearly marked.