### PR TITLE
[bugfix/fix-std-vector-sizing-error-in-IncrementalSVD] IncrementalSVD c'tor: fix `d_proc_dims` vector size

### DIFF
--- a/IncrementalSVD.C
+++ b/IncrementalSVD.C
@@ -70,6 +70,7 @@ IncrementalSVD::IncrementalSVD(
       d_rank = 0;
    }
    d_proc_dims.reserve(d_size);
+   d_proc_dims.resize(d_size);
    if (mpi_init) {
       MPI_Allgather(&d_dim,
          1,


### PR DESCRIPTION
This commit fixes an out-of-bounds access error in
`CAROM::IncrementalSVD(int, double, bool, int, int, const std::string,
bool, bool, bool, bool)` that occurs because `std::vector<int>
d_proc_dims` is size zero at `IncrementalSVD.C:72` before entering the
`if (mpi_init)` conditional at `IncrementalSVD.C:73`. Each branch of
this conditional attempts to access `d_proc_dims[0]` and assign to it,
but in either case, this assignment throws a runtime error because
`d_proc_dims` is still size zero when assignment is attempted, and
such an assignment is out-of-bounds.

To fix this runtime error, `d_proc_dims` is resized after its
capacity (which is NOT its size, but rather the amount of "space
reserved for resizing") is changed, and before the `if (mpi_init)`
conditional.

Fixes the memory bug I found in PR #24.