### PR TITLE
Basis generator options

### DIFF
--- a/IncrementalSVD.C
+++ b/IncrementalSVD.C
@@ -38,7 +38,7 @@ const int IncrementalSVD::COMMUNICATE_U = 666;
 IncrementalSVD::IncrementalSVD(
    IncrementalSVDOptions options,
    const std::string& basis_file_name) :
-   SVD(options.dim, options.samples_per_time_interval, options.debug_algorithm),
+   SVD(options),
    d_linearity_tol(options.linearity_tol),
    d_skip_linearly_dependent(options.skip_linearly_dependent),
    d_max_basis_dimension(options.max_basis_dimension),

--- a/IncrementalSVD.C
+++ b/IncrementalSVD.C
@@ -36,26 +36,18 @@ namespace CAROM {
 const int IncrementalSVD::COMMUNICATE_U = 666;
 
 IncrementalSVD::IncrementalSVD(
-   int dim,
-   double linearity_tol,
-   bool skip_linearly_dependent,
-   int max_basis_dimension,
-   int samples_per_time_interval,
-   const std::string& basis_file_name,
-   bool save_state,
-   bool restore_state,
-   bool updateRightSV,
-   bool debug_algorithm) :
-   SVD(dim, samples_per_time_interval, debug_algorithm),
-   d_linearity_tol(linearity_tol),
-   d_skip_linearly_dependent(skip_linearly_dependent),
-   d_max_basis_dimension(max_basis_dimension),
+   IncrementalSVDOptions options,
+   const std::string& basis_file_name) :
+   SVD(options.dim, options.samples_per_time_interval, options.debug_algorithm),
+   d_linearity_tol(options.linearity_tol),
+   d_skip_linearly_dependent(options.skip_linearly_dependent),
+   d_max_basis_dimension(options.max_basis_dimension),
    d_total_dim(0),
-   d_save_state(save_state),
-   d_updateRightSV(updateRightSV),
+   d_save_state(options.save_state),
+   d_updateRightSV(options.updateRightSV),
    d_state_database(0)
 {
-   CAROM_ASSERT(linearity_tol > 0.0);
+   CAROM_ASSERT(options.linearity_tol > 0.0);
 
    // Get the number of processors, the dimensions for each process, and the
    // total dimension.
@@ -88,13 +80,13 @@ IncrementalSVD::IncrementalSVD(
 
    // If the state of the SVD is to be restored then open the database and
    // restore the necessary data from the database now.
-   if (save_state || restore_state) {
+   if (options.save_state || options.restore_state) {
       std::ostringstream tmp;
       tmp << basis_file_name << ".state." <<
              std::setw(6) << std::setfill('0') << d_rank;
       d_state_file_name = tmp.str();
    }
-   if (restore_state) {
+   if (options.restore_state) {
       // Open state database file.
       d_state_database = new HDFDatabase();
       bool is_good = d_state_database->open(d_state_file_name);

--- a/IncrementalSVD.h
+++ b/IncrementalSVD.h
@@ -81,7 +81,6 @@ struct IncrementalSVDOptions
    sampling_tol(sampling_tol_),
    max_time_between_samples(max_time_between_samples_) {}
 
-
    int dim;
    double linearity_tol;
    int max_basis_dimension;

--- a/IncrementalSVD.h
+++ b/IncrementalSVD.h
@@ -19,7 +19,7 @@
 
 namespace CAROM {
 
-struct IncrementalSVDOptions
+struct IncrementalSVDOptions : virtual public SVDOptions
 {
   /**
    * @brief Constructor.
@@ -72,31 +72,50 @@ struct IncrementalSVDOptions
 
    IncrementalSVDOptions() = delete;
 
-   IncrementalSVDOptions(int dim_, double linearity_tol_, int max_basis_dimension_, double initial_dt_, int samples_per_time_interval_, double sampling_tol_, double max_time_between_samples_) :
-   dim(dim_),
+   IncrementalSVDOptions(int dim_,
+     int samples_per_time_interval_,
+     double linearity_tol_,
+     int max_basis_dimension_,
+     double initial_dt_,
+     double sampling_tol_,
+     double max_time_between_samples_,
+     bool skip_linearly_dependent_ = false,
+     bool fast_update_ = false,
+     bool save_state_ = false,
+     bool restore_state_ = false,
+     bool updateRightSV_ = false,
+     double min_sampling_time_step_scale_ = 0.1,
+     double sampling_time_step_scale_ = 0.8,
+     double max_sampling_time_step_scale_ = 5.0,
+     bool debug_algorithm_ = false
+   ) : SVDOptions(dim_, samples_per_time_interval_, debug_algorithm_),
    linearity_tol(linearity_tol_),
    max_basis_dimension(max_basis_dimension_),
    initial_dt(initial_dt_),
-   samples_per_time_interval(samples_per_time_interval_),
    sampling_tol(sampling_tol_),
-   max_time_between_samples(max_time_between_samples_) {}
+   max_time_between_samples(max_time_between_samples_),
+   skip_linearly_dependent(skip_linearly_dependent_),
+   fast_update(fast_update_),
+   save_state(save_state_),
+   restore_state(restore_state_),
+   updateRightSV(updateRightSV_),
+   min_sampling_time_step_scale(min_sampling_time_step_scale_),
+   sampling_time_step_scale(sampling_time_step_scale_),
+   max_sampling_time_step_scale(max_sampling_time_step_scale_) {};
 
-   int dim;
    double linearity_tol;
    int max_basis_dimension;
    double initial_dt;
-   int samples_per_time_interval;
    double sampling_tol;
    double max_time_between_samples;
-   bool skip_linearly_dependent = false;
-   bool fast_update = false;
-   bool save_state = false;
-   bool restore_state = false;
-   bool updateRightSV = false;
-   double min_sampling_time_step_scale = 0.1;
-   double sampling_time_step_scale = 0.8;
-   double max_sampling_time_step_scale = 5.0;
-   bool debug_algorithm = false;
+   bool skip_linearly_dependent;
+   bool fast_update;
+   bool save_state;
+   bool restore_state;
+   bool updateRightSV;
+   double min_sampling_time_step_scale;
+   double sampling_time_step_scale;
+   double max_sampling_time_step_scale;
 };
 
 /**

--- a/IncrementalSVD.h
+++ b/IncrementalSVD.h
@@ -69,15 +69,28 @@ struct IncrementalSVDOptions
    *                            algorithm will be printed to facilitate
    *                            debugging.
    */
-   int dim = -1;
-   double linearity_tol = -1.0;
+
+   IncrementalSVDOptions() = delete;
+
+   IncrementalSVDOptions(int dim_, double linearity_tol_, int max_basis_dimension_, double initial_dt_, int samples_per_time_interval_, double sampling_tol_, double max_time_between_samples_) :
+   dim(dim_),
+   linearity_tol(linearity_tol_),
+   max_basis_dimension(max_basis_dimension_),
+   initial_dt(initial_dt_),
+   samples_per_time_interval(samples_per_time_interval_),
+   sampling_tol(sampling_tol_),
+   max_time_between_samples(max_time_between_samples_) {}
+
+
+   int dim;
+   double linearity_tol;
+   int max_basis_dimension;
+   double initial_dt;
+   int samples_per_time_interval;
+   double sampling_tol;
+   double max_time_between_samples;
    bool skip_linearly_dependent = false;
    bool fast_update = false;
-   int max_basis_dimension = -1;
-   double initial_dt = -1.0;
-   int samples_per_time_interval = -1;
-   double sampling_tol = -1.0;
-   double max_time_between_samples = -1.0;
    bool save_state = false;
    bool restore_state = false;
    bool updateRightSV = false;

--- a/IncrementalSVD.h
+++ b/IncrementalSVD.h
@@ -19,6 +19,74 @@
 
 namespace CAROM {
 
+struct IncrementalSVDOptions
+{
+  /**
+   * @brief Constructor.
+   *
+   * @pre dim > 0
+   * @pre max_basis_dimension > 0
+   * @pre max_basis_dimension <= dim
+   * @pre linearity_tol > 0.0
+   * @pre initial_dt > 0.0
+   * @pre samples_per_time_interval > 0
+   * @pre sampling_tol > 0.0
+   * @pre max_time_between_samples > 0.0
+   * @pre min_sampling_time_step_scale >= 0.0
+   * @pre sampling_time_step_scale >= 0.0
+   * @pre max_sampling_time_step_scale >= 0.0
+   * @pre min_sampling_time_step_scale <= max_sampling_time_step_scale
+   *
+   * @param[in] dim The dimension of the system on this processor.
+   * @param[in] linearity_tol Tolerance to determine whether or not a
+   *                          sample is linearly dependent.
+   * @param[in] skip_linearly_dependent If true skip linearly dependent
+   *                                    samples.
+   * @param[in] fast_update If true use the fast update algorithm.
+   * @param[in] maximum basis dimension
+   * @param[in] initial_dt Initial simulation time step.
+   * @param[in] samples_per_time_interval The maximum number of samples in
+   *                                      each time interval.
+   * @param[in] sampling_tol Sampling control tolerance.  Limits error in
+   *                         projection of solution into reduced order
+   *                         space.
+   * @param[in] max_time_between_samples Upper bound on time between
+   *                                     samples.
+   * @param[in] save_state If true the state of the SVD will be written to
+   *                       disk when the object is deleted.  If there are
+   *                       multiple time intervals then the state will not
+   *                       be saved as restoring such a state makes no
+   *                       sense.
+   * @param[in] restore_state If true the state of the SVD will be restored
+   *                          when the object is created.
+   * @param[in] min_sampling_time_step_scale Minimum overall scale factor
+   *                                         to apply to time step.
+   * @param[in] sampling_time_step_scale Scale factor to apply to sampling
+   *                                     algorithm.
+   * @param[in] max_sampling_time_step_scale Maximum overall scale factor
+   *                                         to apply to time step.
+   * @param[in] debug_algorithm If true results of incremental svd
+   *                            algorithm will be printed to facilitate
+   *                            debugging.
+   */
+   int dim = -1;
+   double linearity_tol = -1.0;
+   bool skip_linearly_dependent = false;
+   bool fast_update = false;
+   int max_basis_dimension = -1;
+   double initial_dt = -1.0;
+   int samples_per_time_interval = -1;
+   double sampling_tol = -1.0;
+   double max_time_between_samples = -1.0;
+   bool save_state = false;
+   bool restore_state = false;
+   bool updateRightSV = false;
+   double min_sampling_time_step_scale = 0.1;
+   double sampling_time_step_scale = 0.8;
+   double max_sampling_time_step_scale = 5.0;
+   bool debug_algorithm = false;
+};
+
 /**
  * IncrementalSVD is an abstract class defining the internal API of the
  * incremental SVD algorithm.
@@ -29,42 +97,16 @@ namespace CAROM {
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre linearity_tol > 0.0
-       * @pre samples_per_time_interval > 0
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] linearity_tol Tolerance to determine whether or not a
-       *                          sample is linearly dependent.
-       * @param[in] skip_linearly_dependent If true skip linearly dependent
-       *                                    samples.
-       * @param[in] samples_per_time_interval The number of samples to be
-       *                                      collected for each time interval.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        * @param[in] basis_file_name The base part of the name of the file
        *                            containing the basis vectors.  Each process
        *                            will append its process ID to this base
        *                            name.
-       * @param[in] save_state If true the state of the SVD will be written to
-       *                       disk when the object is deleted.  If there are
-       *                       multiple time intervals then the state will not
-       *                       be saved as restoring such a state makes no
-       *                       sense.
-       * @param[in] restore_state If true the state of the SVD will be restored
-       *                          when the object is created.
-       * @param[in] debug_algorithm If true results of algorithm will be
-       *                            printed to facilitate debugging.
        */
       IncrementalSVD(
-         int dim,
-         double linearity_tol,
-         bool skip_linearly_dependent,
-         int max_basis_dimension,
-         int samples_per_time_interval,
-         const std::string& basis_file_name,
-         bool save_state = false,
-         bool restore_state = false,
-         bool updateRightSV = false,
-         bool debug_algorithm = false);
+         IncrementalSVDOptions options,
+         const std::string& basis_file_name);
 
       /**
        * @brief Destructor.

--- a/IncrementalSVDBasisGenerator.C
+++ b/IncrementalSVDBasisGenerator.C
@@ -18,43 +18,28 @@
 namespace CAROM {
 
 IncrementalSVDBasisGenerator::IncrementalSVDBasisGenerator(
-   int dim,
-   double linearity_tol,
-   bool skip_linearly_dependent,
-   bool fast_update,
-   int max_basis_dimension,
-   double initial_dt,
-   int samples_per_time_interval,
-   double sampling_tol,
-   double max_time_between_samples,
+   IncrementalSVDBasisGeneratorOptions options,
    const std::string& basis_file_name,
-   bool save_state,
-   bool restore_state,
-   bool updateRightSV,
-   Database::formats file_format,
-   double min_sampling_time_step_scale,
-   double sampling_time_step_scale,
-   double max_sampling_time_step_scale,
-   bool debug_algorithm) :
+   Database::formats file_format) :
    SVDBasisGenerator(basis_file_name, file_format)
 {
-   d_svdsampler.reset(new IncrementalSVDSampler(dim,
-                                                linearity_tol,
-                                                skip_linearly_dependent,
-                                                fast_update,
-                                                max_basis_dimension,
-                                                initial_dt,
-                                                samples_per_time_interval,
-                                                sampling_tol,
-                                                max_time_between_samples,
+   d_svdsampler.reset(new IncrementalSVDSampler(options.dim,
+                                                options.linearity_tol,
+                                                options.skip_linearly_dependent,
+                                                options.fast_update,
+                                                options.max_basis_dimension,
+                                                options.initial_dt,
+                                                options.samples_per_time_interval,
+                                                options.sampling_tol,
+                                                options.max_time_between_samples,
                                                 basis_file_name,
-                                                save_state,
-                                                restore_state,
-                                                updateRightSV,
-                                                min_sampling_time_step_scale,
-                                                sampling_time_step_scale,
-                                                max_sampling_time_step_scale,
-                                                debug_algorithm));
+                                                options.save_state,
+                                                options.restore_state,
+                                                options.updateRightSV,
+                                                options.min_sampling_time_step_scale,
+                                                options.sampling_time_step_scale,
+                                                options.max_sampling_time_step_scale,
+                                                options.debug_algorithm));
 }
 
 IncrementalSVDBasisGenerator::~IncrementalSVDBasisGenerator()

--- a/IncrementalSVDBasisGenerator.C
+++ b/IncrementalSVDBasisGenerator.C
@@ -18,28 +18,13 @@
 namespace CAROM {
 
 IncrementalSVDBasisGenerator::IncrementalSVDBasisGenerator(
-   IncrementalSVDBasisGeneratorOptions options,
+   IncrementalSVDOptions options,
    const std::string& basis_file_name,
    Database::formats file_format) :
    SVDBasisGenerator(basis_file_name, file_format)
 {
-   d_svdsampler.reset(new IncrementalSVDSampler(options.dim,
-                                                options.linearity_tol,
-                                                options.skip_linearly_dependent,
-                                                options.fast_update,
-                                                options.max_basis_dimension,
-                                                options.initial_dt,
-                                                options.samples_per_time_interval,
-                                                options.sampling_tol,
-                                                options.max_time_between_samples,
-                                                basis_file_name,
-                                                options.save_state,
-                                                options.restore_state,
-                                                options.updateRightSV,
-                                                options.min_sampling_time_step_scale,
-                                                options.sampling_time_step_scale,
-                                                options.max_sampling_time_step_scale,
-                                                options.debug_algorithm));
+   d_svdsampler.reset(new IncrementalSVDSampler(options,
+                                                basis_file_name));
 }
 
 IncrementalSVDBasisGenerator::~IncrementalSVDBasisGenerator()

--- a/IncrementalSVDBasisGenerator.h
+++ b/IncrementalSVDBasisGenerator.h
@@ -19,88 +19,100 @@
 
 namespace CAROM {
 
+struct IncrementalSVDBasisGeneratorOptions
+{
+  /**
+   * @brief Constructor.
+   *
+   * @pre dim > 0
+   * @pre max_basis_dimension > 0
+   * @pre max_basis_dimension <= dim
+   * @pre linearity_tol > 0.0
+   * @pre initial_dt > 0.0
+   * @pre samples_per_time_interval > 0
+   * @pre sampling_tol > 0.0
+   * @pre max_time_between_samples > 0.0
+   * @pre min_sampling_time_step_scale >= 0.0
+   * @pre sampling_time_step_scale >= 0.0
+   * @pre max_sampling_time_step_scale >= 0.0
+   * @pre min_sampling_time_step_scale <= max_sampling_time_step_scale
+   *
+   * @param[in] dim The dimension of the system on this processor.
+   * @param[in] linearity_tol Tolerance to determine whether or not a
+   *                          sample is linearly dependent.
+   * @param[in] skip_linearly_dependent If true skip linearly dependent
+   *                                    samples.
+   * @param[in] fast_update If true use the fast update algorithm.
+   * @param[in] maximum basis dimension
+   * @param[in] initial_dt Initial simulation time step.
+   * @param[in] samples_per_time_interval The maximum number of samples in
+   *                                      each time interval.
+   * @param[in] sampling_tol Sampling control tolerance.  Limits error in
+   *                         projection of solution into reduced order
+   *                         space.
+   * @param[in] max_time_between_samples Upper bound on time between
+   *                                     samples.
+   * @param[in] save_state If true the state of the SVD will be written to
+   *                       disk when the object is deleted.  If there are
+   *                       multiple time intervals then the state will not
+   *                       be saved as restoring such a state makes no
+   *                       sense.
+   * @param[in] restore_state If true the state of the SVD will be restored
+   *                          when the object is created.
+   * @param[in] min_sampling_time_step_scale Minimum overall scale factor
+   *                                         to apply to time step.
+   * @param[in] sampling_time_step_scale Scale factor to apply to sampling
+   *                                     algorithm.
+   * @param[in] max_sampling_time_step_scale Maximum overall scale factor
+   *                                         to apply to time step.
+   * @param[in] debug_algorithm If true results of incremental svd
+   *                            algorithm will be printed to facilitate
+   *                            debugging.
+   */
+   int dim = -1;
+   double linearity_tol = -1.0;
+   bool skip_linearly_dependent = false;
+   bool fast_update = false;
+   int max_basis_dimension = -1;
+   double initial_dt = -1.0;
+   int samples_per_time_interval = -1;
+   double sampling_tol = -1.0;
+   double max_time_between_samples = -1.0;
+   bool save_state = false;
+   bool restore_state = false;
+   bool updateRightSV = false;
+   double min_sampling_time_step_scale = 0.1;
+   double sampling_time_step_scale = 0.8;
+   double max_sampling_time_step_scale = 5.0;
+   bool debug_algorithm = false;
+};
+
 /**
  * Class IncrementalSVDBasisGenerator implements the interface of base class
  * SVDBasisGenerator for the incremental svd algorithm.  Either the fast update
  * or the standard incremental algorithm may be specified through the
  * constructor.
  */
+
 class IncrementalSVDBasisGenerator : public SVDBasisGenerator
 {
    public:
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre max_basis_dimension > 0
-       * @pre max_basis_dimension <= dim
-       * @pre linearity_tol > 0.0
-       * @pre initial_dt > 0.0
-       * @pre samples_per_time_interval > 0
-       * @pre sampling_tol > 0.0
-       * @pre max_time_between_samples > 0.0
-       * @pre min_sampling_time_step_scale >= 0.0
-       * @pre sampling_time_step_scale >= 0.0
-       * @pre max_sampling_time_step_scale >= 0.0
-       * @pre min_sampling_time_step_scale <= max_sampling_time_step_scale
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] linearity_tol Tolerance to determine whether or not a
-       *                          sample is linearly dependent.
-       * @param[in] skip_linearly_dependent If true skip linearly dependent
-       *                                    samples.
-       * @param[in] fast_update If true use the fast update algorithm.
-       * @param[in] maximum basis dimension
-       * @param[in] initial_dt Initial simulation time step.
-       * @param[in] samples_per_time_interval The maximum number of samples in
-       *                                      each time interval.
-       * @param[in] sampling_tol Sampling control tolerance.  Limits error in
-       *                         projection of solution into reduced order
-       *                         space.
-       * @param[in] max_time_between_samples Upper bound on time between
-       *                                     samples.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        * @param[in] basis_file_name The base part of the name of the file
        *                            containing the basis vectors.  Each process
        *                            will append its process ID to this base
        *                            name.
-       * @param[in] save_state If true the state of the SVD will be written to
-       *                       disk when the object is deleted.  If there are
-       *                       multiple time intervals then the state will not
-       *                       be saved as restoring such a state makes no
-       *                       sense.
-       * @param[in] restore_state If true the state of the SVD will be restored
-       *                          when the object is created.
        * @param[in] file_format The format of the file containing the basis
        *                        vectors.
-       * @param[in] min_sampling_time_step_scale Minimum overall scale factor
-       *                                         to apply to time step.
-       * @param[in] sampling_time_step_scale Scale factor to apply to sampling
-       *                                     algorithm.
-       * @param[in] max_sampling_time_step_scale Maximum overall scale factor
-       *                                         to apply to time step.
-       * @param[in] debug_algorithm If true results of incremental svd
-       *                            algorithm will be printed to facilitate
-       *                            debugging.
        */
       IncrementalSVDBasisGenerator(
-         int dim,
-         double linearity_tol,
-         bool skip_linearly_dependent,
-         bool fast_update,
-         int max_basis_dimension,
-         double initial_dt,
-         int samples_per_time_interval,
-         double sampling_tol,
-         double max_time_between_samples,
+         IncrementalSVDBasisGeneratorOptions options,
          const std::string& basis_file_name = "",
-         bool save_state = false,
-         bool restore_state = false,
-         bool updateRightSV = false,
-         Database::formats file_format = Database::HDF5,
-         double min_sampling_time_step_scale = 0.1,
-         double sampling_time_step_scale = 0.8,
-         double max_sampling_time_step_scale = 5.0,
-         bool debug_algorithm = false);
+         Database::formats file_format = Database::HDF5);
 
       /**
        * @brief Destructor.

--- a/IncrementalSVDBasisGenerator.h
+++ b/IncrementalSVDBasisGenerator.h
@@ -16,76 +16,9 @@
 #define included_IncrementalSVDBasisGenerator_h
 
 #include "SVDBasisGenerator.h"
+#include "IncrementalSVD.h"
 
 namespace CAROM {
-
-struct IncrementalSVDBasisGeneratorOptions
-{
-  /**
-   * @brief Constructor.
-   *
-   * @pre dim > 0
-   * @pre max_basis_dimension > 0
-   * @pre max_basis_dimension <= dim
-   * @pre linearity_tol > 0.0
-   * @pre initial_dt > 0.0
-   * @pre samples_per_time_interval > 0
-   * @pre sampling_tol > 0.0
-   * @pre max_time_between_samples > 0.0
-   * @pre min_sampling_time_step_scale >= 0.0
-   * @pre sampling_time_step_scale >= 0.0
-   * @pre max_sampling_time_step_scale >= 0.0
-   * @pre min_sampling_time_step_scale <= max_sampling_time_step_scale
-   *
-   * @param[in] dim The dimension of the system on this processor.
-   * @param[in] linearity_tol Tolerance to determine whether or not a
-   *                          sample is linearly dependent.
-   * @param[in] skip_linearly_dependent If true skip linearly dependent
-   *                                    samples.
-   * @param[in] fast_update If true use the fast update algorithm.
-   * @param[in] maximum basis dimension
-   * @param[in] initial_dt Initial simulation time step.
-   * @param[in] samples_per_time_interval The maximum number of samples in
-   *                                      each time interval.
-   * @param[in] sampling_tol Sampling control tolerance.  Limits error in
-   *                         projection of solution into reduced order
-   *                         space.
-   * @param[in] max_time_between_samples Upper bound on time between
-   *                                     samples.
-   * @param[in] save_state If true the state of the SVD will be written to
-   *                       disk when the object is deleted.  If there are
-   *                       multiple time intervals then the state will not
-   *                       be saved as restoring such a state makes no
-   *                       sense.
-   * @param[in] restore_state If true the state of the SVD will be restored
-   *                          when the object is created.
-   * @param[in] min_sampling_time_step_scale Minimum overall scale factor
-   *                                         to apply to time step.
-   * @param[in] sampling_time_step_scale Scale factor to apply to sampling
-   *                                     algorithm.
-   * @param[in] max_sampling_time_step_scale Maximum overall scale factor
-   *                                         to apply to time step.
-   * @param[in] debug_algorithm If true results of incremental svd
-   *                            algorithm will be printed to facilitate
-   *                            debugging.
-   */
-   int dim = -1;
-   double linearity_tol = -1.0;
-   bool skip_linearly_dependent = false;
-   bool fast_update = false;
-   int max_basis_dimension = -1;
-   double initial_dt = -1.0;
-   int samples_per_time_interval = -1;
-   double sampling_tol = -1.0;
-   double max_time_between_samples = -1.0;
-   bool save_state = false;
-   bool restore_state = false;
-   bool updateRightSV = false;
-   double min_sampling_time_step_scale = 0.1;
-   double sampling_time_step_scale = 0.8;
-   double max_sampling_time_step_scale = 5.0;
-   bool debug_algorithm = false;
-};
 
 /**
  * Class IncrementalSVDBasisGenerator implements the interface of base class
@@ -110,7 +43,7 @@ class IncrementalSVDBasisGenerator : public SVDBasisGenerator
        *                        vectors.
        */
       IncrementalSVDBasisGenerator(
-         IncrementalSVDBasisGeneratorOptions options,
+         IncrementalSVDOptions options,
          const std::string& basis_file_name = "",
          Database::formats file_format = Database::HDF5);
 

--- a/IncrementalSVDFastUpdate.C
+++ b/IncrementalSVDFastUpdate.C
@@ -22,38 +22,23 @@
 namespace CAROM {
 
 IncrementalSVDFastUpdate::IncrementalSVDFastUpdate(
-   int dim,
-   double linearity_tol,
-   bool skip_linearly_dependent,
-   int max_basis_dimension,
-   int samples_per_time_interval,
-   const std::string& basis_file_name,
-   bool save_state,
-   bool restore_state,
-   bool updateRightSV,
-   bool debug_algorithm) :
-   IncrementalSVD(dim,
-      linearity_tol,
-      skip_linearly_dependent,
-      max_basis_dimension,
-      samples_per_time_interval,
-      basis_file_name,
-      save_state,
-      restore_state,
-      updateRightSV,
-      debug_algorithm),
+   IncrementalSVDOptions options,
+   const std::string& basis_file_name) :
+   IncrementalSVD(
+      options,
+      basis_file_name),
    d_Up(0)
 {
-   CAROM_ASSERT(dim > 0);
-   CAROM_ASSERT(linearity_tol > 0.0);
-   CAROM_ASSERT(samples_per_time_interval > 0);
+   CAROM_ASSERT(options.dim > 0);
+   CAROM_ASSERT(options.linearity_tol > 0.0);
+   CAROM_ASSERT(options.samples_per_time_interval > 0);
 
    // If the state of the SVD is to be restored, do it now.  The base class,
    // IncrementalSVD, has already opened the database and restored the state
    // common to all incremental algorithms.  This particular class must also
    // read the state of d_Up and then compute the basis.  If the database could
    // not be found then we can not restore the state.
-   if (restore_state && d_state_database) {
+   if (options.restore_state && d_state_database) {
       // Read d_Up.
       int num_rows;
       d_state_database->getInteger("Up_num_rows", num_rows);

--- a/IncrementalSVDFastUpdate.h
+++ b/IncrementalSVDFastUpdate.h
@@ -29,42 +29,16 @@ class IncrementalSVDFastUpdate : public IncrementalSVD
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre linearity_tol > 0.0
-       * @pre samples_per_time_interval > 0
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] linearity_tol Tolerance to determine whether or not a
-       *                          sample is linearly dependent.
-       * @param[in] skip_linearly_dependent If true skip linearly dependent
-       *                                    samples.
-       * @param[in] samples_per_time_interval The number of samples to be
-       *                                      collected for each time interval.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        * @param[in] basis_file_name The base part of the name of the file
        *                            containing the basis vectors.  Each process
        *                            will append its process ID to this base
        *                            name.
-       * @param[in] save_state If true the state of the SVD will be written to
-       *                       disk when the object is deleted.  If there are
-       *                       multiple time intervals then the state will not
-       *                       be saved as restoring such a state makes no
-       *                       sense.
-       * @param[in] restore_state If true the state of the SVD will be restored
-       *                          when the object is created.
-       * @param[in] debug_algorithm If true results of the algorithm will be
-       *                            printed to facilitate debugging.
        */
       IncrementalSVDFastUpdate(
-         int dim,
-         double linearity_tol,
-         bool skip_linearly_dependent,
-         int max_basis_dimension,
-         int samples_per_time_interval,
-         const std::string& basis_file_name,
-         bool save_state = false,
-         bool restore_state = false,
-         bool updateRightSV = false,
-         bool debug_algorithm = false);
+         IncrementalSVDOptions options,
+         const std::string& basis_file_name);
 
       /**
        * @brief Destructor.

--- a/IncrementalSVDSampler.C
+++ b/IncrementalSVDSampler.C
@@ -24,66 +24,37 @@
 namespace CAROM {
 
 IncrementalSVDSampler::IncrementalSVDSampler(
-   int dim,
-   double linearity_tol,
-   bool skip_linearly_dependent,
-   bool fast_update,
-   int max_basis_dimension,
-   double initial_dt,
-   int samples_per_time_interval,
-   double sampling_tol,
-   double max_time_between_samples,
-   const std::string& basis_file_name,
-   bool save_state,
-   bool restore_state,
-   bool updateRightSV,
-   double min_sampling_time_step_scale,
-   double sampling_time_step_scale,
-   double max_sampling_time_step_scale,
-   bool debug_algorithm) :
-   d_tol(sampling_tol),
-   d_max_time_between_samples(max_time_between_samples),
-   d_min_sampling_time_step_scale(min_sampling_time_step_scale),
-   d_sampling_time_step_scale(sampling_time_step_scale),
-   d_max_sampling_time_step_scale(max_sampling_time_step_scale),
-   d_dt(initial_dt),
+   IncrementalSVDOptions options,
+   const std::string& basis_file_name) :
+   d_tol(options.sampling_tol),
+   d_max_time_between_samples(options.max_time_between_samples),
+   d_min_sampling_time_step_scale(options.min_sampling_time_step_scale),
+   d_sampling_time_step_scale(options.sampling_time_step_scale),
+   d_max_sampling_time_step_scale(options.max_sampling_time_step_scale),
+   d_dt(options.initial_dt),
    d_next_sample_time(0.0)
 {
-   CAROM_ASSERT(initial_dt > 0.0);
-   CAROM_ASSERT(sampling_tol > 0.0);
-   CAROM_ASSERT(max_time_between_samples > 0.0);
-   CAROM_ASSERT(min_sampling_time_step_scale >= 0.0);
-   CAROM_ASSERT(sampling_time_step_scale >= 0.0);
-   CAROM_ASSERT(max_sampling_time_step_scale >= 0.0);
-   CAROM_ASSERT(min_sampling_time_step_scale <= max_sampling_time_step_scale);
+   CAROM_ASSERT(options.initial_dt > 0.0);
+   CAROM_ASSERT(options.sampling_tol > 0.0);
+   CAROM_ASSERT(options.max_time_between_samples > 0.0);
+   CAROM_ASSERT(options.min_sampling_time_step_scale >= 0.0);
+   CAROM_ASSERT(options.sampling_time_step_scale >= 0.0);
+   CAROM_ASSERT(options.max_sampling_time_step_scale >= 0.0);
+   CAROM_ASSERT(options.min_sampling_time_step_scale <= options.max_sampling_time_step_scale);
 
-   d_updateRightSV = updateRightSV;
+   d_updateRightSV = options.updateRightSV;
 
-   if (fast_update) {
+   if (options.fast_update) {
       d_svd.reset(
-         new IncrementalSVDFastUpdate(dim,
-            linearity_tol,
-            skip_linearly_dependent,
-            max_basis_dimension,
-            samples_per_time_interval,
-            basis_file_name,
-            save_state,
-            restore_state,
-            updateRightSV,
-            debug_algorithm));
+         new IncrementalSVDFastUpdate(
+            options,
+            basis_file_name));
    }
    else {
       d_svd.reset(
-         new IncrementalSVDStandard(dim,
-            linearity_tol,
-            skip_linearly_dependent,
-            max_basis_dimension,
-            samples_per_time_interval,
-            basis_file_name,
-            save_state,
-            restore_state,
-            updateRightSV,
-            debug_algorithm));
+         new IncrementalSVDStandard(
+            options,
+            basis_file_name));
    }
 
    // Get the number of processors.

--- a/IncrementalSVDSampler.h
+++ b/IncrementalSVDSampler.h
@@ -34,71 +34,16 @@ class IncrementalSVDSampler : public SVDSampler
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre linearity_tol > 0.0
-       * @pre initial_dt > 0.0
-       * @pre samples_per_time_interval > 0
-       * @pre sampling_tol > 0.0
-       * @pre max_time_between_samples > 0.0
-       * @pre min_sampling_time_step_scale >= 0.0
-       * @pre sampling_time_step_scale >= 0.0
-       * @pre max_sampling_time_step_scale >= 0.0
-       * @pre min_sampling_time_step_scale <= max_sampling_time_step_scale
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] linearity_tol Tolerance to determine whether or not a
-       *                          sample is linearly dependent.
-       * @param[in] skip_linearly_dependent If true skip linearly dependent
-       *                                    samples.
-       * @param[in] fast_update If true use the fast update incremental svd
-       *                        algorithm.
-       * @param[in] initial_dt Initial simulation time step.
-       * @param[in] samples_per_time_interval The maximum number of samples in
-       *                                      each time interval.
-       * @param[in] sampling_tol Sampling control tolerance.  Limits error in
-       *                         projection of sample into reduced order space
-       *                         followed by a lift back to full order space.
-       * @param[in] max_time_between_samples Upper bound on time between
-       *                                     samples.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        * @param[in] basis_file_name The base part of the name of the file
        *                            containing the basis vectors.  Each process
        *                            will append its process ID to this base
        *                            name.
-       * @param[in] save_state If true the state of the SVD will be written to
-       *                       disk when the object is deleted.  If there are
-       *                       multiple time intervals then the state will not
-       *                       be saved as restoring such a state makes no
-       *                       sense.
-       * @param[in] restore_state If true the state of the SVD will be restored
-       *                          when the object is created.
-       * @param[in] min_sampling_time_step_scale Minimum overall scale factor
-       *                                         to apply to time step.
-       * @param[in] sampling_time_step_scale Scale factor to apply to sampling
-       *                                     algorithm.
-       * @param[in] max_sampling_time_step_scale Maximum overall scale factor
-       *                                         to apply to time step.
-       * @param[in] debug_algorithm If true results of incremental svd
-       *                            algorithm will be printed to facilitate
-       *                            debugging.
        */
       IncrementalSVDSampler(
-         int dim,
-         double linearity_tol,
-         bool skip_linearly_dependent,
-         bool fast_update,
-         int max_basis_dimension,
-         double initial_dt,
-         int samples_per_time_interval,
-         double sampling_tol,
-         double max_time_between_samples,
-         const std::string& basis_file_name = "",
-         bool save_state = false,
-         bool restore_state = false,
-         bool updateRightSV = false,
-         double min_sampling_time_step_scale = 0.1,
-         double sampling_time_step_scale = 0.8,
-         double max_sampling_time_step_scale = 5.0,
-         bool debug_algorithm = false);
+         IncrementalSVDOptions options,
+         const std::string& basis_file_name = "");
 
       /**
        * @brief Destructor.

--- a/IncrementalSVDStandard.C
+++ b/IncrementalSVDStandard.C
@@ -23,37 +23,22 @@
 namespace CAROM {
 
 IncrementalSVDStandard::IncrementalSVDStandard(
-   int dim,
-   double linearity_tol,
-   bool skip_linearly_dependent,
-   int max_basis_dimension,
-   int samples_per_time_interval,
-   const std::string& basis_file_name,
-   bool save_state,
-   bool restore_state,
-   bool updateRightSV,
-   bool debug_algorithm) :
-   IncrementalSVD(dim,
-      linearity_tol,
-      skip_linearly_dependent,
-      max_basis_dimension,
-      samples_per_time_interval,
-      basis_file_name,
-      save_state,
-      restore_state,
-      updateRightSV,
-      debug_algorithm)
+   IncrementalSVDOptions options,
+   const std::string& basis_file_name) :
+   IncrementalSVD(
+      options,
+      basis_file_name)
 {
-   CAROM_ASSERT(dim > 0);
-   CAROM_ASSERT(linearity_tol > 0.0);
-   CAROM_ASSERT(samples_per_time_interval > 0);
+   CAROM_ASSERT(options.dim > 0);
+   CAROM_ASSERT(options.linearity_tol > 0.0);
+   CAROM_ASSERT(options.samples_per_time_interval > 0);
 
    // If the state of the SVD is to be restored, do it now.  The base class,
    // IncrementalSVD, has already opened the database and restored the state
    // common to all incremental algorithms.  This particular class has no other
    // state to read and only needs to compute the basis.  If the database could
    // not be found then we can not restore the state.
-   if (restore_state && d_state_database) {
+   if (options.restore_state && d_state_database) {
       // Close and delete the database.
       d_state_database->close();
       delete d_state_database;

--- a/IncrementalSVDStandard.h
+++ b/IncrementalSVDStandard.h
@@ -28,42 +28,16 @@ class IncrementalSVDStandard : public IncrementalSVD
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre linearity_tol > 0.0
-       * @pre samples_per_time_interval > 0
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] linearity_tol Tolerance to determine whether or not a
-       *                          sample is linearly dependent.
-       * @param[in] skip_linearly_dependent If true skip linearly dependent
-       *                                    samples.
-       * @param[in] samples_per_time_interval The number of samples to be
-       *                                      collected for each time interval.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        * @param[in] basis_file_name The base part of the name of the file
        *                            containing the basis vectors.  Each process
        *                            will append its process ID to this base
        *                            name.
-       * @param[in] save_state If true the state of the SVD will be written to
-       *                       disk when the object is deleted.  If there are
-       *                       multiple time intervals then the state will not
-       *                       be saved as restoring such a state makes no
-       *                       sense.
-       * @param[in] restore_state If true the state of the SVD will be restored
-       *                          when the object is created.
-       * @param[in] debug_algorithm If true results of the algorithm will be
-       *                            printed to facilitate debugging.
        */
       IncrementalSVDStandard(
-         int dim,
-         double linearity_tol,
-         bool skip_linearly_dependent,
-         int max_basis_dimension,
-         int samples_per_time_interval,
-         const std::string& basis_file_name,
-         bool save_state = false,
-         bool restore_state = false,
-         bool updateRightSV = false,
-         bool debug_algorithm = false);
+         IncrementalSVDOptions options,
+         const std::string& basis_file_name);
 
       /**
        * @brief Destructor.

--- a/SVD.C
+++ b/SVD.C
@@ -16,12 +16,10 @@
 namespace CAROM {
 
 SVD::SVD(
-   int dim,
-   int samples_per_time_interval,
-   bool debug_algorithm) :
-   d_dim(dim),
+   SVDOptions options) :
+   d_dim(options.dim),
    d_num_samples(0),
-   d_samples_per_time_interval(samples_per_time_interval),
+   d_samples_per_time_interval(options.samples_per_time_interval),
    d_basis(NULL),
    d_basis_right(NULL),
    d_U(NULL),
@@ -29,7 +27,7 @@ SVD::SVD(
    d_S(NULL),
    d_snapshots(NULL),
    d_time_interval_start_times(0),
-   d_debug_algorithm(debug_algorithm)
+   d_debug_algorithm(options.debug_algorithm)
 {
    CAROM_ASSERT(dim > 0);
    CAROM_ASSERT(samples_per_time_interval > 0);

--- a/SVD.h
+++ b/SVD.h
@@ -34,17 +34,16 @@ struct SVDOptions
    *                            will be printed to facilitate debugging.
    */
 
-   int dim;
-   int samples_per_time_interval;
-   bool debug_algorithm;
-
-protected:
    SVDOptions(int dim_,
      int samples_per_time_interval_,
      bool debug_algorithm_ = false
    ): dim(dim_),
    samples_per_time_interval(samples_per_time_interval_),
    debug_algorithm(debug_algorithm_) {};
+
+   int dim;
+   int samples_per_time_interval;
+   bool debug_algorithm;
 
 };
 

--- a/SVD.h
+++ b/SVD.h
@@ -19,6 +19,35 @@
 
 namespace CAROM {
 
+struct SVDOptions
+{
+  /**
+   * @brief Constructor.
+   *
+   * @pre dim > 0
+   * @pre samples_per_time_interval > 0
+   *
+   * @param[in] dim The dimension of the system on this processor.
+   * @param[in] samples_per_time_interval The maximum number of samples in
+   *                                      each time interval.
+   * @param[in] debug_algorithm If true results of static svd algorithm
+   *                            will be printed to facilitate debugging.
+   */
+
+   int dim;
+   int samples_per_time_interval;
+   bool debug_algorithm;
+
+protected:
+   SVDOptions(int dim_,
+     int samples_per_time_interval_,
+     bool debug_algorithm_ = false
+   ): dim(dim_),
+   samples_per_time_interval(samples_per_time_interval_),
+   debug_algorithm(debug_algorithm_) {};
+
+};
+
 /**
  * Class SVD defines the interface to the generic SVD algorithm.  The API is
  * intentionally small.  One may collect the samples, compute the SVD, and get
@@ -41,9 +70,7 @@ class SVD
        *                            printed to facilitate debugging.
        */
       SVD(
-         int dim,
-         int samples_per_time_interval,
-         bool debug_algorithm = false);
+         SVDOptions options);
 
       /**
        * Destructor.
@@ -230,7 +257,7 @@ class SVD
        * exists on each processor.
        */
       Matrix* d_S;
-   
+
       /**
        * @brief The globalized snapshot vectors for the current time interval.
        *

--- a/SVD.h
+++ b/SVD.h
@@ -34,16 +34,17 @@ struct SVDOptions
    *                            will be printed to facilitate debugging.
    */
 
+   int dim;
+   int samples_per_time_interval;
+   bool debug_algorithm;
+
+protected:
    SVDOptions(int dim_,
      int samples_per_time_interval_,
      bool debug_algorithm_ = false
    ): dim(dim_),
    samples_per_time_interval(samples_per_time_interval_),
    debug_algorithm(debug_algorithm_) {};
-
-   int dim;
-   int samples_per_time_interval;
-   bool debug_algorithm;
 
 };
 

--- a/StaticSVD.C
+++ b/StaticSVD.C
@@ -32,7 +32,7 @@ namespace CAROM {
 
 StaticSVD::StaticSVD(
    StaticSVDOptions options) :
-   SVD(options.dim, options.samples_per_time_interval, options.debug_algorithm),
+   SVD(options),
    d_samples(new SLPK_Matrix), d_factorizer(new SVDManager),
    d_this_interval_basis_current(false),
    d_max_basis_dimension(options.max_basis_dimension),

--- a/StaticSVD.C
+++ b/StaticSVD.C
@@ -31,21 +31,17 @@ void dgesdd(char*, int*, int*, double*, int*,
 namespace CAROM {
 
 StaticSVD::StaticSVD(
-   int dim,
-   int samples_per_time_interval,
-   int max_basis_dimension,
-   double sigma_tolerance,
-   bool debug_algorithm) :
-   SVD(dim, samples_per_time_interval, debug_algorithm),
+   StaticSVDOptions options) :
+   SVD(options.dim, options.samples_per_time_interval, options.debug_algorithm),
    d_samples(new SLPK_Matrix), d_factorizer(new SVDManager),
    d_this_interval_basis_current(false),
-   d_max_basis_dimension(max_basis_dimension),
-   d_sigma_tol(sigma_tolerance)
+   d_max_basis_dimension(options.max_basis_dimension),
+   d_sigma_tol(options.sigma_tolerance)
 {
-   CAROM_ASSERT(dim > 0);
-   CAROM_ASSERT(samples_per_time_interval > 0);
-   CAROM_ASSERT(max_basis_dimension > 0);
-   CAROM_ASSERT(sigma_tolerance >= 0);
+   CAROM_ASSERT(options.dim > 0);
+   CAROM_ASSERT(options.samples_per_time_interval > 0);
+   CAROM_ASSERT(options.max_basis_dimension > 0);
+   CAROM_ASSERT(options.sigma_tolerance >= 0);
 
    // Get the rank of this process, and the number of processors.
    int mpi_init;
@@ -114,7 +110,7 @@ StaticSVD::takeSample(
    if (isNewTimeInterval()) {
       // We have a new time interval.
      delete_factorizer();
-      int num_time_intervals = 
+      int num_time_intervals =
          static_cast<int>(d_time_interval_start_times.size());
       if (num_time_intervals > 0) {
          delete d_basis;
@@ -128,7 +124,7 @@ StaticSVD::takeSample(
          delete d_W;
          d_W = nullptr;
          delete d_snapshots;
-         d_snapshots = nullptr;  
+         d_snapshots = nullptr;
     }
       d_num_samples = 0;
       d_time_interval_start_times.resize(
@@ -142,7 +138,7 @@ StaticSVD::takeSample(
    }
    broadcast_sample(u_in);
    ++d_num_samples;
-   
+
    // Build snapshot matrix before SVD is computed
    //d_snapshots = new Matrix(d_dim, d_num_samples, false);
    //for (int rank = 0; rank < d_num_procs; ++rank) {
@@ -230,14 +226,14 @@ StaticSVD::getSingularValues()
    CAROM_ASSERT(thisIntervalBasisCurrent());
    return d_S;
 }
-   
+
 const Matrix*
 StaticSVD::getSnapshotMatrix()
 {
-   
+
    if (d_snapshots) delete d_snapshots;
    d_snapshots = new Matrix(d_dim, d_num_samples, false);
-   
+
    for (int rank = 0; rank < d_num_procs; ++rank) {
       int nrows = d_dims[static_cast<unsigned>(rank)];
       int firstrow = d_istarts[static_cast<unsigned>(rank)] + 1;
@@ -249,7 +245,7 @@ StaticSVD::getSnapshotMatrix()
    CAROM_ASSERT(d_snapshots != 0);
    return d_snapshots;
 }
-   
+
 void
 StaticSVD::computeSVD()
 {

--- a/StaticSVD.h
+++ b/StaticSVD.h
@@ -23,7 +23,7 @@
 
 namespace CAROM {
 
-  struct StaticSVDOptions
+  struct StaticSVDOptions : virtual public SVDOptions
   {
     /**
      * @brief Constructor.
@@ -48,16 +48,20 @@ namespace CAROM {
 
      StaticSVDOptions() = delete;
 
-     StaticSVDOptions(int dim_, int samples_per_time_interval_) :
-     dim(dim_),
-     samples_per_time_interval(samples_per_time_interval_) {}
+     StaticSVDOptions(int dim_,
+       int samples_per_time_interval_,
+       bool output_rightSV_ = false,
+       int max_basis_dimension_ = std::numeric_limits<int>::max(),
+       double sigma_tolerance_ = 0,
+       bool debug_algorithm_ = false
+     ) : SVDOptions(dim_, samples_per_time_interval_, debug_algorithm_),
+     output_rightSV(output_rightSV_),
+     max_basis_dimension(max_basis_dimension_),
+     sigma_tolerance(sigma_tolerance_) {};
 
-     int dim;
-     int samples_per_time_interval;
-     bool output_rightSV = false;
-     int max_basis_dimension = std::numeric_limits<int>::max();
-     double sigma_tolerance = 0;
-     bool debug_algorithm = false;
+     bool output_rightSV;
+     int max_basis_dimension;
+     double sigma_tolerance;
   };
 
 /**

--- a/StaticSVD.h
+++ b/StaticSVD.h
@@ -46,8 +46,14 @@ namespace CAROM {
      *                            will be printed to facilitate debugging.
      */
 
-     int dim = -1;
-     int samples_per_time_interval = -1;
+     StaticSVDOptions() = delete;
+
+     StaticSVDOptions(int dim_, int samples_per_time_interval_) :
+     dim(dim_),
+     samples_per_time_interval(samples_per_time_interval_) {}
+
+     int dim;
+     int samples_per_time_interval;
      bool output_rightSV = false;
      int max_basis_dimension = std::numeric_limits<int>::max();
      double sigma_tolerance = 0;

--- a/StaticSVD.h
+++ b/StaticSVD.h
@@ -23,6 +23,37 @@
 
 namespace CAROM {
 
+  struct StaticSVDOptions
+  {
+    /**
+     * @brief Constructor.
+     *
+     * @pre dim > 0
+     * @pre samples_per_time_interval > 0
+     *
+     * @param[in] dim The dimension of the system on this processor.
+     * @param[in] samples_per_time_interval The maximum number of samples in
+     *                                      each time interval.
+     * @param[in] output_rightSV Whether to output the right SV or not.
+     * @param[in] max_basis_dimension (typemax(int)) The maximum number of
+     *                                vectors returned in the basis.
+     * @param[in] sigma_tolerance This tolerance is based on the ratio of
+     *                            singular values to the largest singular
+     *                            value. If sigma[i] / sigma[0] < sigma_tolerance,
+     *                            the associated vector is dropped from the
+     *                            basis.
+     * @param[in] debug_algorithm If true results of static svd algorithm
+     *                            will be printed to facilitate debugging.
+     */
+
+     int dim = -1;
+     int samples_per_time_interval = -1;
+     bool output_rightSV = false;
+     int max_basis_dimension = std::numeric_limits<int>::max();
+     double sigma_tolerance = 0;
+     bool debug_algorithm = false;
+  };
+
 /**
  * StaticSVD implements the interface of class SVD for the static SVD
  * algorithm.  This algorithm is not scalable and is intended primarily as a
@@ -37,32 +68,12 @@ class StaticSVD : public SVD
        * If both max_basis_dimension and sigma_tolerance would result in
        * truncating the basis, the dimension of the returned basis will be the
        * *minimum* of the number of vectors that is computed from each.
-       * 
-       * @pre dim > 0
-       * @pre sample_per_time_interval > 0
        *
-       * @param[in] dim The dimension of the system distributed to this
-       *                processor.
-       * @param[in] samples_per_time_interval The maximum number of samples
-       *                                      collected in a time interval.
-       * @param[in] max_basis_dimension The maximum dimension of the basis
-       *                                returned by getSpatialBasis or
-       *                                getTemporalBasis. Default: typemax(int).
-       * @param[in] sigma_tolerance This tolerance is based on the ratio of
-       *                            singular values to the largest singular
-       *                            value. If sigma[i] / sigma[0] < sigma_tolerance,
-       *                            the associated vector is dropped from the
-       *                            basis.
-       * @param[in] debug_algorithm (true) Specify whether or not to print
-       *                            information about the algorithm. No effect
-       *                            for this subclass.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        */
       StaticSVD(
-         int dim,
-         int samples_per_time_interval,
-         int max_basis_dimension = std::numeric_limits<int>::max(),
-         double sigma_tolerance = 0,
-         bool debug_algorithm = false
+         StaticSVDOptions options
          );
 
       /**
@@ -130,7 +141,7 @@ class StaticSVD : public SVD
       virtual
       const Matrix*
       getSnapshotMatrix();
-   
+
    private:
       /**
        * @brief Unimplemented default constructor.

--- a/StaticSVDBasisGenerator.C
+++ b/StaticSVDBasisGenerator.C
@@ -17,22 +17,17 @@
 namespace CAROM {
 
 StaticSVDBasisGenerator::StaticSVDBasisGenerator(
-   int dim,
-   int samples_per_time_interval,
+   StaticSVDBasisGeneratorOptions options,
    const std::string& basis_file_name,
-   bool output_rightSV,
-   int max_basis_dimension,
-   double sigma_tolerance,
-   bool debug_algorithm,
    Database::formats file_format) :
    SVDBasisGenerator(basis_file_name, file_format)
 {
-   d_svdsampler.reset(new StaticSVDSampler(dim,
-                                           samples_per_time_interval,
-                                           max_basis_dimension,
-                                           sigma_tolerance,
-                                           debug_algorithm,
-                                           output_rightSV));
+   d_svdsampler.reset(new StaticSVDSampler(options.dim,
+                                           options.samples_per_time_interval,
+                                           options.max_basis_dimension,
+                                           options.sigma_tolerance,
+                                           options.debug_algorithm,
+                                           options.output_rightSV));
 }
 
 StaticSVDBasisGenerator::~StaticSVDBasisGenerator()

--- a/StaticSVDBasisGenerator.C
+++ b/StaticSVDBasisGenerator.C
@@ -17,17 +17,12 @@
 namespace CAROM {
 
 StaticSVDBasisGenerator::StaticSVDBasisGenerator(
-   StaticSVDBasisGeneratorOptions options,
+   StaticSVDOptions options,
    const std::string& basis_file_name,
    Database::formats file_format) :
    SVDBasisGenerator(basis_file_name, file_format)
 {
-   d_svdsampler.reset(new StaticSVDSampler(options.dim,
-                                           options.samples_per_time_interval,
-                                           options.max_basis_dimension,
-                                           options.sigma_tolerance,
-                                           options.debug_algorithm,
-                                           options.output_rightSV));
+   d_svdsampler.reset(new StaticSVDSampler(options));
 }
 
 StaticSVDBasisGenerator::~StaticSVDBasisGenerator()

--- a/StaticSVDBasisGenerator.h
+++ b/StaticSVDBasisGenerator.h
@@ -20,6 +20,37 @@
 
 namespace CAROM {
 
+struct StaticSVDBasisGeneratorOptions
+{
+  /**
+   * @brief Constructor.
+   *
+   * @pre dim > 0
+   * @pre samples_per_time_interval > 0
+   *
+   * @param[in] dim The dimension of the system on this processor.
+   * @param[in] samples_per_time_interval The maximum number of samples in
+   *                                      each time interval.
+   * @param[in] output_rightSV Whether to output the right SV or not.
+   * @param[in] max_basis_dimension (typemax(int)) The maximum number of
+   *                                vectors returned in the basis.
+   * @param[in] sigma_tolerance This tolerance is based on the ratio of
+   *                            singular values to the largest singular
+   *                            value. If sigma[i] / sigma[0] < sigma_tolerance,
+   *                            the associated vector is dropped from the
+   *                            basis.
+   * @param[in] debug_algorithm If true results of static svd algorithm
+   *                            will be printed to facilitate debugging.
+   */
+
+   int dim = -1;
+   int samples_per_time_interval = -1;
+   bool output_rightSV = false;
+   int max_basis_dimension = std::numeric_limits<int>::max();
+   double sigma_tolerance = 0;
+   bool debug_algorithm = false;
+};
+
 /**
  * Class StaticSVDBasisGenerator implements the interface of base class
  * SVDBasisGenerator for the static svd algorithm.
@@ -30,37 +61,18 @@ class StaticSVDBasisGenerator : public SVDBasisGenerator
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre samples_per_time_interval > 0
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] samples_per_time_interval The maximum number of samples in
-       *                                      each time interval.
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        * @param[in] basis_file_name The base part of the name of the file
        *                            containing the basis vectors.  Each process
        *                            will append its process ID to this base
        *                            name.
-       * @param[in] output_rightSV Whether to output the right SV or not.
-       * @param[in] max_basis_dimension (typemax(int)) The maximum number of
-       *                                vectors returned in the basis.
-       * @param[in] sigma_tolerance This tolerance is based on the ratio of
-       *                            singular values to the largest singular
-       *                            value. If sigma[i] / sigma[0] < sigma_tolerance,
-       *                            the associated vector is dropped from the
-       *                            basis.
-       * @param[in] debug_algorithm If true results of static svd algorithm
-       *                            will be printed to facilitate debugging.
        * @param[in] file_format The format of the file containing the basis
        *                        vectors.
        */
       StaticSVDBasisGenerator(
-         int dim,
-         int samples_per_time_interval,
-         const std::string& basis_file_name,
-         bool output_rightSV = false,
-         int max_basis_dimension = std::numeric_limits<int>::max(),
-         double sigma_tolerance = 0,
-         bool debug_algorithm = false,
+         StaticSVDBasisGeneratorOptions options,
+         const std::string& basis_file_name = "",
          Database::formats file_format = Database::HDF5);
 
       /**

--- a/StaticSVDBasisGenerator.h
+++ b/StaticSVDBasisGenerator.h
@@ -15,41 +15,11 @@
 #define included_StaticSVDBasisGenerator_h
 
 #include "SVDBasisGenerator.h"
+#include "StaticSVD.h"
 
 #include <limits>
 
 namespace CAROM {
-
-struct StaticSVDBasisGeneratorOptions
-{
-  /**
-   * @brief Constructor.
-   *
-   * @pre dim > 0
-   * @pre samples_per_time_interval > 0
-   *
-   * @param[in] dim The dimension of the system on this processor.
-   * @param[in] samples_per_time_interval The maximum number of samples in
-   *                                      each time interval.
-   * @param[in] output_rightSV Whether to output the right SV or not.
-   * @param[in] max_basis_dimension (typemax(int)) The maximum number of
-   *                                vectors returned in the basis.
-   * @param[in] sigma_tolerance This tolerance is based on the ratio of
-   *                            singular values to the largest singular
-   *                            value. If sigma[i] / sigma[0] < sigma_tolerance,
-   *                            the associated vector is dropped from the
-   *                            basis.
-   * @param[in] debug_algorithm If true results of static svd algorithm
-   *                            will be printed to facilitate debugging.
-   */
-
-   int dim = -1;
-   int samples_per_time_interval = -1;
-   bool output_rightSV = false;
-   int max_basis_dimension = std::numeric_limits<int>::max();
-   double sigma_tolerance = 0;
-   bool debug_algorithm = false;
-};
 
 /**
  * Class StaticSVDBasisGenerator implements the interface of base class
@@ -71,7 +41,7 @@ class StaticSVDBasisGenerator : public SVDBasisGenerator
        *                        vectors.
        */
       StaticSVDBasisGenerator(
-         StaticSVDBasisGeneratorOptions options,
+         StaticSVDOptions options,
          const std::string& basis_file_name = "",
          Database::formats file_format = Database::HDF5);
 

--- a/StaticSVDSampler.C
+++ b/StaticSVDSampler.C
@@ -17,17 +17,10 @@
 namespace CAROM {
 
 StaticSVDSampler::StaticSVDSampler(
-   int dim,
-   int samples_per_time_interval,
-   int max_basis_dimension,
-   double sigma_tolerance,
-   bool debug_algorithm,
-   bool updateRightSV)
+   StaticSVDOptions options)
 {
-   d_svd.reset(new StaticSVD(dim, samples_per_time_interval,
-                             max_basis_dimension, sigma_tolerance,
-                             debug_algorithm));
-   d_updateRightSV = updateRightSV;
+   d_svd.reset(new StaticSVD(options));
+   d_updateRightSV = options.output_rightSV;
 }
 
 StaticSVDSampler::~StaticSVDSampler()

--- a/StaticSVDSampler.h
+++ b/StaticSVDSampler.h
@@ -32,30 +32,11 @@ class StaticSVDSampler : public SVDSampler
       /**
        * @brief Constructor.
        *
-       * @pre dim > 0
-       * @pre samples_per_time_interval > 0
-       *
-       * @param[in] dim The dimension of the system on this processor.
-       * @param[in] samples_per_time_interval The maximum number of samples
-       *                                      in each time interval.
-       * @param[in] max_basis_dimension (typemax(int)) The maximum number of
-       *                                vectors returned in the basis.
-       * @param[in] sigma_tolerance This tolerance is based on the ratio of
-       *                            singular values to the largest singular
-       *                            value. If sigma[i] / sigma[0] < sigma_tolerance,
-       *                            the associated vector is dropped from the
-       *                            basis.
-       * @param[in] debug_algorithm If true results of static svd algorithm
-       *                            will be printed to facilitate debugging.
-       * @param[in] updateRightSV If true write right singular vectors
+       * @param[in] options The struct containing the options for this basis
+       *                    generator.
        */
       StaticSVDSampler(
-         int dim,
-         int samples_per_time_interval,
-         int max_basis_dimension = std::numeric_limits<int>::max(),
-         double sigma_tolerance = 0,
-         bool debug_algorithm = false,
-         bool updateRightSV = false);
+         StaticSVDOptions options);
 
       /**
        * @brief Destructor.

--- a/load_samples.C
+++ b/load_samples.C
@@ -8,7 +8,7 @@
  *
  *****************************************************************************/
 
-// Description: Simple test of loading precomputed basis or snapshots and 
+// Description: Simple test of loading precomputed basis or snapshots and
 //              computing the static SVD on the loaded samples. Please
 //              run in serial. Assumes this file is located in libROM/build.
 //              If not, please adjust file address of sample data below.
@@ -29,14 +29,19 @@ main(
     if (strcmp(argv[0],"b") || strcmp(argv[0],"basis")) std::string uploaded_data = "basis"; }
 
   int dim = 6;
-  
+
   // Create basis using 1 or 2 already computed bases
   std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator;
-  static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(dim,
-      2,
-      "samples_total",
-      2));
-  
+
+  CAROM::StaticSVDBasisGeneratorOptions static_bg_options;
+  static_bg_options.dim = dim;
+  static_bg_options.samples_per_time_interval = 2;
+  static_bg_options.max_basis_dimension = 2;
+
+  static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(
+      static_bg_options,
+      "samples_total"));
+
   if (uploaded_data == "snapshot") {
     std::cout << "Loading snapshots" << std::endl;
     static_basis_generator->loadSamples("../tests/load_samples_data/sample1_snapshot","snapshot");
@@ -51,14 +56,13 @@ main(
 
   std::cout << "Saving data uploaded as a snapshot" << std::endl;
   static_basis_generator->writeSnapshot();
-  
+
   // Can compute the SVD by calling getSpatialBasis() or endSamples()
   // endSamples() will save the basis file "samples_total..."
   std::cout << "Computing SVD" << std::endl;
   int rom_dim = static_basis_generator->getSpatialBasis()->numColumns();
   std::cout << "U ROM Dimension: " << rom_dim << std::endl;
   static_basis_generator->endSamples();
-  
+
   static_basis_generator = nullptr;
 }
-

--- a/load_samples.C
+++ b/load_samples.C
@@ -33,13 +33,13 @@ main(
   // Create basis using 1 or 2 already computed bases
   std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator;
 
-  CAROM::StaticSVDBasisGeneratorOptions static_bg_options;
-  static_bg_options.dim = dim;
-  static_bg_options.samples_per_time_interval = 2;
-  static_bg_options.max_basis_dimension = 2;
+  CAROM::StaticSVDOptions static_svd_options;
+  static_svd_options.dim = dim;
+  static_svd_options.samples_per_time_interval = 2;
+  static_svd_options.max_basis_dimension = 2;
 
   static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(
-      static_bg_options,
+      static_svd_options,
       "samples_total"));
 
   if (uploaded_data == "snapshot") {

--- a/load_samples.C
+++ b/load_samples.C
@@ -33,9 +33,7 @@ main(
   // Create basis using 1 or 2 already computed bases
   std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator;
 
-  CAROM::StaticSVDOptions static_svd_options;
-  static_svd_options.dim = dim;
-  static_svd_options.samples_per_time_interval = 2;
+  CAROM::StaticSVDOptions static_svd_options(dim, 2);
   static_svd_options.max_basis_dimension = 2;
 
   static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(

--- a/load_samples.C
+++ b/load_samples.C
@@ -33,11 +33,8 @@ main(
   // Create basis using 1 or 2 already computed bases
   std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator;
 
-  CAROM::StaticSVDOptions static_svd_options(dim, 2);
-  static_svd_options.max_basis_dimension = 2;
-
   static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(
-      static_svd_options,
+      CAROM::StaticSVDOptions(dim, 2, false, 2),
       "samples_total"));
 
   if (uploaded_data == "snapshot") {

--- a/random_test.C
+++ b/random_test.C
@@ -123,15 +123,9 @@ main(
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
 
-   CAROM::IncrementalSVDOptions incremental_svd_options;
-   incremental_svd_options.dim = dim;
-   incremental_svd_options.linearity_tol = 1.0e-6;
+   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-6,
+     dim, 1.0e-6, num_samples, 1.0e-2, 0.001);
    incremental_svd_options.fast_update = true;
-   incremental_svd_options.max_basis_dimension = dim;
-   incremental_svd_options.initial_dt = 1.0e-6;
-   incremental_svd_options.samples_per_time_interval = num_samples;
-   incremental_svd_options.sampling_tol = 1.0e-2;
-   incremental_svd_options.max_time_between_samples = 0.001;
    incremental_svd_options.debug_algorithm = true;
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
@@ -141,9 +135,7 @@ main(
    // Construct the static basis generator for the static algorithm and the
    // static sampler.
 
-   CAROM::StaticSVDOptions static_svd_options;
-   static_svd_options.dim = dim;
-   static_svd_options.samples_per_time_interval = num_samples;
+   CAROM::StaticSVDOptions static_svd_options(dim, num_samples);
    static_svd_options.output_rightSV = true;
 
    CAROM::StaticSVDBasisGenerator static_basis_generator(

--- a/random_test.C
+++ b/random_test.C
@@ -122,31 +122,33 @@ main(
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
-   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(dim,
-      1.0e-6,
-      false,
-      true,
-      dim,
-      1.0e-6,
-      num_samples,
-      1.0e-2,
-      0.001,
-      "",
-      false,
-      false,
-      false,
-      CAROM::Database::HDF5,
-      0.1,
-      0.8,
-      5.0,
-      true);
+
+   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
+   inc_bg_options.dim = dim;
+   inc_bg_options.linearity_tol = 1.0e-6;
+   inc_bg_options.fast_update = true;
+   inc_bg_options.max_basis_dimension = dim;
+   inc_bg_options.initial_dt = 1.0e-6;
+   inc_bg_options.samples_per_time_interval = num_samples;
+   inc_bg_options.sampling_tol = 1.0e-2;
+   inc_bg_options.max_time_between_samples = 0.001;
+   inc_bg_options.debug_algorithm = true;
+
+   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
+      inc_bg_options
+    );
 
    // Construct the static basis generator for the static algorithm and the
    // static sampler.
-   CAROM::StaticSVDBasisGenerator static_basis_generator(dim,
-      num_samples,
-      "",
-      true);
+
+   CAROM::StaticSVDBasisGeneratorOptions static_bg_options;
+   static_bg_options.dim = dim;
+   static_bg_options.samples_per_time_interval = num_samples;
+   static_bg_options.output_rightSV = true;
+
+   CAROM::StaticSVDBasisGenerator static_basis_generator(
+     static_bg_options
+   );
 
    // Initialize random number generator.
    srand(1);

--- a/random_test.C
+++ b/random_test.C
@@ -129,17 +129,15 @@ main(
    incremental_svd_options.debug_algorithm = true;
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
-      incremental_svd_options
+      CAROM::IncrementalSVDOptions(dim, num_samples, 1.0e-6, dim, 1.0e-6, 1.0e-2,
+      0.001)
     );
 
    // Construct the static basis generator for the static algorithm and the
    // static sampler.
 
-   CAROM::StaticSVDOptions static_svd_options(dim, num_samples);
-   static_svd_options.output_rightSV = true;
-
    CAROM::StaticSVDBasisGenerator static_basis_generator(
-     static_svd_options
+     CAROM::StaticSVDOptions(dim, num_samples, true)
    );
 
    // Initialize random number generator.

--- a/random_test.C
+++ b/random_test.C
@@ -123,31 +123,31 @@ main(
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
 
-   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
-   inc_bg_options.dim = dim;
-   inc_bg_options.linearity_tol = 1.0e-6;
-   inc_bg_options.fast_update = true;
-   inc_bg_options.max_basis_dimension = dim;
-   inc_bg_options.initial_dt = 1.0e-6;
-   inc_bg_options.samples_per_time_interval = num_samples;
-   inc_bg_options.sampling_tol = 1.0e-2;
-   inc_bg_options.max_time_between_samples = 0.001;
-   inc_bg_options.debug_algorithm = true;
+   CAROM::IncrementalSVDOptions incremental_svd_options;
+   incremental_svd_options.dim = dim;
+   incremental_svd_options.linearity_tol = 1.0e-6;
+   incremental_svd_options.fast_update = true;
+   incremental_svd_options.max_basis_dimension = dim;
+   incremental_svd_options.initial_dt = 1.0e-6;
+   incremental_svd_options.samples_per_time_interval = num_samples;
+   incremental_svd_options.sampling_tol = 1.0e-2;
+   incremental_svd_options.max_time_between_samples = 0.001;
+   incremental_svd_options.debug_algorithm = true;
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
-      inc_bg_options
+      incremental_svd_options
     );
 
    // Construct the static basis generator for the static algorithm and the
    // static sampler.
 
-   CAROM::StaticSVDBasisGeneratorOptions static_bg_options;
-   static_bg_options.dim = dim;
-   static_bg_options.samples_per_time_interval = num_samples;
-   static_bg_options.output_rightSV = true;
+   CAROM::StaticSVDOptions static_svd_options;
+   static_svd_options.dim = dim;
+   static_svd_options.samples_per_time_interval = num_samples;
+   static_svd_options.output_rightSV = true;
 
    CAROM::StaticSVDBasisGenerator static_basis_generator(
-     static_bg_options
+     static_svd_options
    );
 
    // Initialize random number generator.

--- a/smoke_static.C
+++ b/smoke_static.C
@@ -62,9 +62,7 @@ main(
    double vals1[6] = {2.0, 7.0, 4.0, 9.0, 18.0, 10.0};
 
    // Create first static basis generator for snapshot 1
-   CAROM::StaticSVDOptions static_svd_options;
-   static_svd_options.dim = dim;
-   static_svd_options.samples_per_time_interval = 2;
+   CAROM::StaticSVDOptions static_svd_options(dim, 2);
    static_svd_options.max_basis_dimension = 2;
 
    // Create an inner scope so destructors are called when out of scope

--- a/smoke_static.C
+++ b/smoke_static.C
@@ -62,17 +62,17 @@ main(
    double vals1[6] = {2.0, 7.0, 4.0, 9.0, 18.0, 10.0};
 
    // Create first static basis generator for snapshot 1
-   CAROM::StaticSVDBasisGeneratorOptions static_bg_options;
-   static_bg_options.dim = dim;
-   static_bg_options.samples_per_time_interval = 2;
-   static_bg_options.max_basis_dimension = 2;
+   CAROM::StaticSVDOptions static_svd_options;
+   static_svd_options.dim = dim;
+   static_svd_options.samples_per_time_interval = 2;
+   static_svd_options.max_basis_dimension = 2;
 
    // Create an inner scope so destructors are called when out of scope
    if (true) {
 
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator;
    static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(
-      static_bg_options,
+      static_svd_options,
       "static_smoke1"));
 
    // Take the first sample.
@@ -85,7 +85,7 @@ main(
    // FOM would then close and restart ... create 2nd basis generator
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator2;
    static_basis_generator2.reset(new CAROM::StaticSVDBasisGenerator(
-      static_bg_options,
+      static_svd_options,
       "static_smoke2"));
 
    // Take the second sample.
@@ -101,7 +101,7 @@ main(
    // Create basis using 2 already computed snapshots
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator3;
    static_basis_generator3.reset(new CAROM::StaticSVDBasisGenerator(
-      static_bg_options,
+      static_svd_options,
       "static_smoke_final"));
 
    static_basis_generator3->loadSamples("static_smoke1_snapshot","snapshot");
@@ -118,7 +118,7 @@ main(
    // Recreate basis using 1 basis generator as a check
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator4;
    static_basis_generator4.reset(new CAROM::StaticSVDBasisGenerator(
-      static_bg_options,
+      static_svd_options,
       "static_smoke_check"));
 
    static_basis_generator4->takeSample(&vals0[dim*rank],0,0.1);
@@ -130,7 +130,7 @@ main(
 
    // Create basis using 2 already computed bases
    static_basis_generator3.reset(new CAROM::StaticSVDBasisGenerator(
-      static_bg_options,
+      static_svd_options,
       "static_smoke_final_frombasis"));
 
    static_basis_generator3->loadSamples("static_smoke1","basis");

--- a/smoke_static.C
+++ b/smoke_static.C
@@ -52,23 +52,28 @@ main(
       }
       return 1;
    }
-  
+
    bool status = false;
- 
+
    // Define the values for the first sample.
    double vals0[6] = {1.0, 6.0, 3.0, 8.0, 17.0, 9.0};
 
    // Define the values for the second sample.
    double vals1[6] = {2.0, 7.0, 4.0, 9.0, 18.0, 10.0};
 
+   // Create first static basis generator for snapshot 1
+   CAROM::StaticSVDBasisGeneratorOptions static_bg_options;
+   static_bg_options.dim = dim;
+   static_bg_options.samples_per_time_interval = 2;
+   static_bg_options.max_basis_dimension = 2;
+
    // Create an inner scope so destructors are called when out of scope
    if (true) {
-   // Create first static basis generator for snapshot 1
+
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator;
-   static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(dim,
-      2,
-      "static_smoke1",
-      2));
+   static_basis_generator.reset(new CAROM::StaticSVDBasisGenerator(
+      static_bg_options,
+      "static_smoke1"));
 
    // Take the first sample.
    static_basis_generator->takeSample(&vals0[dim*rank],0,0.1);
@@ -79,10 +84,9 @@ main(
 
    // FOM would then close and restart ... create 2nd basis generator
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator2;
-   static_basis_generator2.reset(new CAROM::StaticSVDBasisGenerator(dim,
-      2,
-      "static_smoke2",
-      2));
+   static_basis_generator2.reset(new CAROM::StaticSVDBasisGenerator(
+      static_bg_options,
+      "static_smoke2"));
 
    // Take the second sample.
    static_basis_generator2->takeSample(&vals1[dim*rank],0,0.1);
@@ -96,10 +100,9 @@ main(
 
    // Create basis using 2 already computed snapshots
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator3;
-   static_basis_generator3.reset(new CAROM::StaticSVDBasisGenerator(dim,
-      2,
-      "static_smoke_final",
-      2));
+   static_basis_generator3.reset(new CAROM::StaticSVDBasisGenerator(
+      static_bg_options,
+      "static_smoke_final"));
 
    static_basis_generator3->loadSamples("static_smoke1_snapshot","snapshot");
    static_basis_generator3->loadSamples("static_smoke2_snapshot","snapshot");
@@ -107,17 +110,16 @@ main(
    static_basis_generator3->writeSnapshot();
    int rom_dim = static_basis_generator3->getSpatialBasis()->numColumns();
    std::cout << "U ROM dimension = " << rom_dim << std::endl;
-   
+
    static_basis_generator3->endSamples();
    static_basis_generator3 = nullptr;
 
 
    // Recreate basis using 1 basis generator as a check
    std::unique_ptr<CAROM::SVDBasisGenerator> static_basis_generator4;
-   static_basis_generator4.reset(new CAROM::StaticSVDBasisGenerator(dim,
-      2,
-      "static_smoke_check",
-      2));
+   static_basis_generator4.reset(new CAROM::StaticSVDBasisGenerator(
+      static_bg_options,
+      "static_smoke_check"));
 
    static_basis_generator4->takeSample(&vals0[dim*rank],0,0.1);
    static_basis_generator4->takeSample(&vals1[dim*rank],0,0.1);
@@ -127,10 +129,9 @@ main(
 
 
    // Create basis using 2 already computed bases
-   static_basis_generator3.reset(new CAROM::StaticSVDBasisGenerator(dim,
-      2,
-      "static_smoke_final_frombasis",
-      2));
+   static_basis_generator3.reset(new CAROM::StaticSVDBasisGenerator(
+      static_bg_options,
+      "static_smoke_final_frombasis"));
 
    static_basis_generator3->loadSamples("static_smoke1","basis");
    static_basis_generator3->loadSamples("static_smoke2","basis");
@@ -138,7 +139,7 @@ main(
    static_basis_generator3->writeSnapshot();
    rom_dim = static_basis_generator3->getSpatialBasis()->numColumns();
    std::cout << "U ROM dimension = " << rom_dim << std::endl;
-   
+
    static_basis_generator3->endSamples();
    static_basis_generator3 = nullptr;
 

--- a/smoke_test.C
+++ b/smoke_test.C
@@ -55,24 +55,21 @@ main(
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
-   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(dim,
-      1.0e-2,
-      false,
-      true,
-      2,
-      1.0e-6,
-      2,
-      1.0e-2,
-      0.11,
-      "",
-      false,
-      false,
-      false,
-      CAROM::Database::HDF5,
-      0.1,
-      0.8,
-      5.0,
-      true);
+   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
+   inc_bg_options.dim = dim;
+   inc_bg_options.linearity_tol = 1.0e-2;
+   inc_bg_options.fast_update = true;
+   inc_bg_options.max_basis_dimension = 2;
+   inc_bg_options.initial_dt = 1.0e-6;
+   inc_bg_options.samples_per_time_interval = 2;
+   inc_bg_options.sampling_tol = 1.0e-2;
+   inc_bg_options.max_time_between_samples = 0.11;
+   inc_bg_options.debug_algorithm = true;
+
+
+   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
+     inc_bg_options
+   );
 
    // Define the values for the first sample.
    double vals0[6] = {1.0, 6.0, 3.0, 8.0, 17.0, 9.0};

--- a/smoke_test.C
+++ b/smoke_test.C
@@ -55,15 +55,9 @@ main(
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
-   CAROM::IncrementalSVDOptions incremental_svd_options;
-   incremental_svd_options.dim = dim;
-   incremental_svd_options.linearity_tol = 1.0e-2;
+   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-2, 2, 1.0e-6,
+   2, 1.0e-2, 0.11);
    incremental_svd_options.fast_update = true;
-   incremental_svd_options.max_basis_dimension = 2;
-   incremental_svd_options.initial_dt = 1.0e-6;
-   incremental_svd_options.samples_per_time_interval = 2;
-   incremental_svd_options.sampling_tol = 1.0e-2;
-   incremental_svd_options.max_time_between_samples = 0.11;
    incremental_svd_options.debug_algorithm = true;
 
 

--- a/smoke_test.C
+++ b/smoke_test.C
@@ -55,8 +55,8 @@ main(
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
-   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-2, 2, 1.0e-6,
-   2, 1.0e-2, 0.11);
+   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 2, 1.0e-2, 2, 1.0e-6,
+   1.0e-2, 0.11);
    incremental_svd_options.fast_update = true;
    incremental_svd_options.debug_algorithm = true;
 

--- a/smoke_test.C
+++ b/smoke_test.C
@@ -55,20 +55,20 @@ main(
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
-   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
-   inc_bg_options.dim = dim;
-   inc_bg_options.linearity_tol = 1.0e-2;
-   inc_bg_options.fast_update = true;
-   inc_bg_options.max_basis_dimension = 2;
-   inc_bg_options.initial_dt = 1.0e-6;
-   inc_bg_options.samples_per_time_interval = 2;
-   inc_bg_options.sampling_tol = 1.0e-2;
-   inc_bg_options.max_time_between_samples = 0.11;
-   inc_bg_options.debug_algorithm = true;
+   CAROM::IncrementalSVDOptions incremental_svd_options;
+   incremental_svd_options.dim = dim;
+   incremental_svd_options.linearity_tol = 1.0e-2;
+   incremental_svd_options.fast_update = true;
+   incremental_svd_options.max_basis_dimension = 2;
+   incremental_svd_options.initial_dt = 1.0e-6;
+   incremental_svd_options.samples_per_time_interval = 2;
+   incremental_svd_options.sampling_tol = 1.0e-2;
+   incremental_svd_options.max_time_between_samples = 0.11;
+   incremental_svd_options.debug_algorithm = true;
 
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
-     inc_bg_options
+     incremental_svd_options
    );
 
    // Define the values for the first sample.

--- a/tests/test_IncrementalSVD.C
+++ b/tests/test_IncrementalSVD.C
@@ -46,6 +46,8 @@ public:
           options,
 			    basis_file_name)
   {
+    dim = options.dim;
+    
     /* Construct a fake d_U, d_S, d_basis */
     d_basis = new CAROM::Matrix(dim, dim, false);
     d_S = new CAROM::Matrix(dim, dim, false);

--- a/tests/test_IncrementalSVD.C
+++ b/tests/test_IncrementalSVD.C
@@ -39,21 +39,12 @@ class FakeIncrementalSVD : public CAROM::IncrementalSVD
 public:
 
   FakeIncrementalSVD
-  (int dim,
-   double linearity_tol,
-   bool skip_linearly_dependent,
-   int max_basis_dimension,
-   int samples_per_time_interval,
+  (
+   CAROM::IncrementalSVDOptions options,
    const std::string& basis_file_name)
-    : CAROM::IncrementalSVD(dim,
-			    linearity_tol,
-			    skip_linearly_dependent,
-			    max_basis_dimension,
-			    samples_per_time_interval,
-			    basis_file_name,
-			    false,
-			    false,
-			    false)
+    : CAROM::IncrementalSVD(
+          options,
+			    basis_file_name)
   {
     /* Construct a fake d_U, d_S, d_basis */
     d_basis = new CAROM::Matrix(dim, dim, false);
@@ -108,11 +99,14 @@ public:
 
 TEST(IncrementalSVDSerialTest, Test_getBasis)
 {
-  FakeIncrementalSVD svd(3,
-			 1e-1,
-			 false,
-			 3,
-			 4,
+  CAROM::IncrementalSVDOptions incremental_svd_options;
+  incremental_svd_options.dim = 3;
+  incremental_svd_options.linearity_tol = 1e-1;
+  incremental_svd_options.max_basis_dimension = 3;
+  incremental_svd_options.samples_per_time_interval = 4;
+
+  FakeIncrementalSVD svd(
+       incremental_svd_options,
 			 "irrelevant.txt");
 
   const CAROM::Matrix *B = svd.getSpatialBasis();
@@ -129,11 +123,14 @@ TEST(IncrementalSVDSerialTest, Test_getBasis)
 
 TEST(IncrementalSVDSerialTest, Test_getSingularValues)
 {
-  FakeIncrementalSVD svd(3,
-			 1e-1,
-			 false,
-			 3,
-			 4,
+  CAROM::IncrementalSVDOptions incremental_svd_options;
+  incremental_svd_options.dim = 3;
+  incremental_svd_options.linearity_tol = 1e-1;
+  incremental_svd_options.max_basis_dimension = 3;
+  incremental_svd_options.samples_per_time_interval = 4;
+
+  FakeIncrementalSVD svd(
+       incremental_svd_options,
 			 "irrelevant.txt");
 
   const CAROM::Matrix *S = svd.getSingularValues();

--- a/tests/test_IncrementalSVD.C
+++ b/tests/test_IncrementalSVD.C
@@ -121,7 +121,7 @@ TEST(IncrementalSVDSerialTest, Test_getBasis)
 
 TEST(IncrementalSVDSerialTest, Test_getSingularValues)
 {
-  CAROM::IncrementalSVDOptions incremental_svd_options(3, 1e-1, 3, -1, 4, -1.0, -1.0);
+  CAROM::IncrementalSVDOptions incremental_svd_options(3, 4, 1e-1, 3, -1, -1.0, -1.0);
 
   FakeIncrementalSVD svd(
        incremental_svd_options,

--- a/tests/test_IncrementalSVD.C
+++ b/tests/test_IncrementalSVD.C
@@ -46,8 +46,8 @@ public:
           options,
 			    basis_file_name)
   {
-    dim = options.dim;
-    
+    int dim = options.dim;
+
     /* Construct a fake d_U, d_S, d_basis */
     d_basis = new CAROM::Matrix(dim, dim, false);
     d_S = new CAROM::Matrix(dim, dim, false);

--- a/tests/test_IncrementalSVD.C
+++ b/tests/test_IncrementalSVD.C
@@ -101,11 +101,7 @@ public:
 
 TEST(IncrementalSVDSerialTest, Test_getBasis)
 {
-  CAROM::IncrementalSVDOptions incremental_svd_options;
-  incremental_svd_options.dim = 3;
-  incremental_svd_options.linearity_tol = 1e-1;
-  incremental_svd_options.max_basis_dimension = 3;
-  incremental_svd_options.samples_per_time_interval = 4;
+  CAROM::IncrementalSVDOptions incremental_svd_options(3, 1e-1, 3, -1, 4, -1.0, -1.0);
 
   FakeIncrementalSVD svd(
        incremental_svd_options,
@@ -125,11 +121,7 @@ TEST(IncrementalSVDSerialTest, Test_getBasis)
 
 TEST(IncrementalSVDSerialTest, Test_getSingularValues)
 {
-  CAROM::IncrementalSVDOptions incremental_svd_options;
-  incremental_svd_options.dim = 3;
-  incremental_svd_options.linearity_tol = 1e-1;
-  incremental_svd_options.max_basis_dimension = 3;
-  incremental_svd_options.samples_per_time_interval = 4;
+  CAROM::IncrementalSVDOptions incremental_svd_options(3, 1e-1, 3, -1, 4, -1.0, -1.0);
 
   FakeIncrementalSVD svd(
        incremental_svd_options,

--- a/tests/test_SVD.C
+++ b/tests/test_SVD.C
@@ -31,13 +31,23 @@ TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
  *  referring to an implementation that simulates the behavior of
  *  real objects.)
  */
+
+struct FakeSVDOptions : virtual public CAROM::SVDOptions
+{
+
+  FakeSVDOptions(int dim_,
+    int samples_per_time_interval_,
+    bool debug_algorithm_ = false
+  ): SVDOptions(dim_, samples_per_time_interval_, debug_algorithm_) {};
+
+};
+
 class FakeSVD : public CAROM::SVD
 {
 public:
 
-  FakeSVD(int dim,
-	  int samples_per_time_interval)
-    : SVD(dim, samples_per_time_interval, false)
+  FakeSVD(FakeSVDOptions options)
+    : SVD(options)
   {
   }
 
@@ -117,13 +127,13 @@ public:
 
 TEST(SVDSerialTest, Test_getDim)
 {
-  FakeSVD svd(5, 2);
+  FakeSVD svd(FakeSVDOptions(5, 2));
   EXPECT_EQ(svd.getDim(), 5);
 }
 
 TEST(SVDSerialTest, Test_isNewTimeInterval)
 {
-  FakeSVD svd(5, 2);
+  FakeSVD svd(FakeSVDOptions(5, 2));
 
   /* 0 samples, so taking a sample will create a new time interval */
   EXPECT_TRUE(svd.isNewTimeInterval());
@@ -151,7 +161,7 @@ TEST(SVDSerialTest, Test_isNewTimeInterval)
 
 TEST(SVDSerialTest, Test_getNumBasisTimeIntervals)
 {
-  FakeSVD svd(5, 2);
+  FakeSVD svd(FakeSVDOptions(5, 2));
 
   /* Number of time intervals starts at zero. */
   EXPECT_EQ(svd.getNumBasisTimeIntervals(), 0);
@@ -175,7 +185,7 @@ TEST(SVDSerialTest, Test_getNumBasisTimeIntervals)
 
 TEST(SVDSerialTest, Test_getBasisIntervalStartTime)
 {
-  FakeSVD svd(5, 2);
+  FakeSVD svd(FakeSVDOptions(5, 2));
 
   /* 1st time interval starts at time 0 */
   svd.takeSample(NULL, 0, true);

--- a/tests/test_StaticSVD.C
+++ b/tests/test_StaticSVD.C
@@ -50,7 +50,12 @@ int main(int argc, char* argv[])
 
     // Construct an SVDSampler to send our matrix. I take V = I for simplicity,
     // so the matrix A that we factor is just the columns scaled by the sigmas.
-    CAROM::StaticSVDSampler sampler(12, 4, 4, 0, true);
+    CAROM::StaticSVDOptions static_svd_options;
+    static_svd_options.dim = 12;
+    static_svd_options.samples_per_time_interval = 4;
+    static_svd_options.max_basis_dimension = 4;
+    static_svd_options.debug_algorithm = true;
+    CAROM::StaticSVDSampler sampler(static_svd_options);
     for (unsigned j = 0; j < 4; ++j) {
         std::vector<double> similar(columns[j]);
         for (unsigned i = 0; i < 12; ++i)

--- a/uneven_dist.C
+++ b/uneven_dist.C
@@ -119,24 +119,20 @@ main(
    // Construct the incremental basis generator given the dimension just
    // computed to use the fast update incremental algorithm and the incremental
    // sampler.
-   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(dim,
-      1.0e-2,
-      false,
-      true,
-      2,
-      1.0e-6,
-      2,
-      1.0e-2,
-      0.11,
-      "",
-      false,
-      false,
-      false,
-      CAROM::Database::HDF5,
-      0.1,
-      0.8,
-      5.0,
-      true);
+   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
+   inc_bg_options.dim = dim;
+   inc_bg_options.linearity_tol = 1.0e-2;
+   inc_bg_options.fast_update = true;
+   inc_bg_options.max_basis_dimension = 2;
+   inc_bg_options.initial_dt = 1.0e-6;
+   inc_bg_options.samples_per_time_interval = 2;
+   inc_bg_options.sampling_tol = 1.0e-2;
+   inc_bg_options.max_time_between_samples = 0.111;
+   inc_bg_options.debug_algorithm = true;
+
+   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
+      inc_bg_options
+   );
 
    // Define the values for the first sample.
    double vals0[6] = {1.0, 6.0, 3.0, 8.0, 17.0, 9.0};

--- a/uneven_dist.C
+++ b/uneven_dist.C
@@ -119,15 +119,9 @@ main(
    // Construct the incremental basis generator given the dimension just
    // computed to use the fast update incremental algorithm and the incremental
    // sampler.
-   CAROM::IncrementalSVDOptions incremental_svd_options;
-   incremental_svd_options.dim = dim;
-   incremental_svd_options.linearity_tol = 1.0e-2;
+   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-2,
+     2, 1.0e-6, 2, 1.0e-2, 0.11);
    incremental_svd_options.fast_update = true;
-   incremental_svd_options.max_basis_dimension = 2;
-   incremental_svd_options.initial_dt = 1.0e-6;
-   incremental_svd_options.samples_per_time_interval = 2;
-   incremental_svd_options.sampling_tol = 1.0e-2;
-   incremental_svd_options.max_time_between_samples = 0.11;
    incremental_svd_options.debug_algorithm = true;
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(

--- a/uneven_dist.C
+++ b/uneven_dist.C
@@ -119,19 +119,19 @@ main(
    // Construct the incremental basis generator given the dimension just
    // computed to use the fast update incremental algorithm and the incremental
    // sampler.
-   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
-   inc_bg_options.dim = dim;
-   inc_bg_options.linearity_tol = 1.0e-2;
-   inc_bg_options.fast_update = true;
-   inc_bg_options.max_basis_dimension = 2;
-   inc_bg_options.initial_dt = 1.0e-6;
-   inc_bg_options.samples_per_time_interval = 2;
-   inc_bg_options.sampling_tol = 1.0e-2;
-   inc_bg_options.max_time_between_samples = 0.11;
-   inc_bg_options.debug_algorithm = true;
+   CAROM::IncrementalSVDOptions incremental_svd_options;
+   incremental_svd_options.dim = dim;
+   incremental_svd_options.linearity_tol = 1.0e-2;
+   incremental_svd_options.fast_update = true;
+   incremental_svd_options.max_basis_dimension = 2;
+   incremental_svd_options.initial_dt = 1.0e-6;
+   incremental_svd_options.samples_per_time_interval = 2;
+   incremental_svd_options.sampling_tol = 1.0e-2;
+   incremental_svd_options.max_time_between_samples = 0.11;
+   incremental_svd_options.debug_algorithm = true;
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
-      inc_bg_options
+      incremental_svd_options
    );
 
    // Define the values for the first sample.

--- a/uneven_dist.C
+++ b/uneven_dist.C
@@ -127,7 +127,7 @@ main(
    inc_bg_options.initial_dt = 1.0e-6;
    inc_bg_options.samples_per_time_interval = 2;
    inc_bg_options.sampling_tol = 1.0e-2;
-   inc_bg_options.max_time_between_samples = 0.111;
+   inc_bg_options.max_time_between_samples = 0.11;
    inc_bg_options.debug_algorithm = true;
 
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(

--- a/uneven_dist.C
+++ b/uneven_dist.C
@@ -119,8 +119,8 @@ main(
    // Construct the incremental basis generator given the dimension just
    // computed to use the fast update incremental algorithm and the incremental
    // sampler.
-   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-2,
-     2, 1.0e-6, 2, 1.0e-2, 0.11);
+   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 2, 1.0e-2,
+     2, 1.0e-6, 1.0e-2, 0.11);
    incremental_svd_options.fast_update = true;
    incremental_svd_options.debug_algorithm = true;
 

--- a/weak_scaling.C
+++ b/weak_scaling.C
@@ -38,15 +38,9 @@ main(
    int dim = 10000;
    int num_samples = 10;
 
-   CAROM::IncrementalSVDOptions incremental_svd_options;
-   incremental_svd_options.dim = dim;
-   incremental_svd_options.linearity_tol = 1.0e-6;
+   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-6, num_samples,
+   1.0e-2, num_samples, 1.0e-20, 10.001);
    incremental_svd_options.fast_update = true;
-   incremental_svd_options.max_basis_dimension = num_samples;
-   incremental_svd_options.initial_dt = 1.0e-2;
-   incremental_svd_options.samples_per_time_interval = num_samples;
-   incremental_svd_options.sampling_tol = 1.0e-20;
-   incremental_svd_options.max_time_between_samples = 10.001;
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.

--- a/weak_scaling.C
+++ b/weak_scaling.C
@@ -38,20 +38,20 @@ main(
    int dim = 10000;
    int num_samples = 10;
 
-   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
-   inc_bg_options.dim = dim;
-   inc_bg_options.linearity_tol = 1.0e-6;
-   inc_bg_options.fast_update = true;
-   inc_bg_options.max_basis_dimension = num_samples;
-   inc_bg_options.initial_dt = 1.0e-2;
-   inc_bg_options.samples_per_time_interval = num_samples;
-   inc_bg_options.sampling_tol = 1.0e-20;
-   inc_bg_options.max_time_between_samples = 10.001;
+   CAROM::IncrementalSVDOptions incremental_svd_options;
+   incremental_svd_options.dim = dim;
+   incremental_svd_options.linearity_tol = 1.0e-6;
+   incremental_svd_options.fast_update = true;
+   incremental_svd_options.max_basis_dimension = num_samples;
+   incremental_svd_options.initial_dt = 1.0e-2;
+   incremental_svd_options.samples_per_time_interval = num_samples;
+   incremental_svd_options.sampling_tol = 1.0e-20;
+   incremental_svd_options.max_time_between_samples = 10.001;
 
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
-     inc_bg_options
+     incremental_svd_options
    );
 
    // Initialize random number generator.

--- a/weak_scaling.C
+++ b/weak_scaling.C
@@ -38,17 +38,21 @@ main(
    int dim = 10000;
    int num_samples = 10;
 
+   CAROM::IncrementalSVDBasisGeneratorOptions inc_bg_options;
+   inc_bg_options.dim = dim;
+   inc_bg_options.linearity_tol = 1.0e-6;
+   inc_bg_options.fast_update = true;
+   inc_bg_options.max_basis_dimension = num_samples;
+   inc_bg_options.initial_dt = 1.0e-2;
+   inc_bg_options.samples_per_time_interval = num_samples;
+   inc_bg_options.sampling_tol = 1.0e-20;
+   inc_bg_options.max_time_between_samples = 10.001;
+
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
-   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(dim,
-      1.0e-6,
-      false,
-      true,
-      num_samples,
-      1.0e-2,
-      num_samples,
-      1.0e-20,
-      10.001);
+   CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
+     inc_bg_options
+   );
 
    // Initialize random number generator.
    srand(1);

--- a/weak_scaling.C
+++ b/weak_scaling.C
@@ -38,14 +38,11 @@ main(
    int dim = 10000;
    int num_samples = 10;
 
-   CAROM::IncrementalSVDOptions incremental_svd_options(dim, 1.0e-6, num_samples,
-   1.0e-2, num_samples, 1.0e-20, 10.001);
-   incremental_svd_options.fast_update = true;
-
    // Construct the incremental basis generator to use the fast update
    // incremental algorithm and the incremental sampler.
    CAROM::IncrementalSVDBasisGenerator inc_basis_generator(
-     incremental_svd_options
+     CAROM::IncrementalSVDOptions(dim, num_samples,
+       1.0e-6, num_samples, 1.0e-2, 1.0e-20, 10.001, false, true)
    );
 
    // Initialize random number generator.


### PR DESCRIPTION
Put StaticSVDBasisGenerator and IncrementalSVDBasisGenerator options into a struct. I debated adding a constructor to the struct options, but if we did, the backwards compatibility problems would still exist once we added new parameters and Laghos/Ardra still used the old constructor. So, the user will have to put in the options into a struct one-by-one, similar to how it is done in Laghos.