### PR TITLE
Bug/carom verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ install:
 
   # Build libROM with GoogleTest
   - cd ${TRAVIS_BUILD_DIR}/build
-  - cmake ..
+  - cmake -DCMAKE_BUILD_TYPE=Debug ..
+  - make 
+  - cmake -DCMAKE_BUILD_TYPE=Optimized ..
   - make
 
 script:

--- a/IncrementalSVD.C
+++ b/IncrementalSVD.C
@@ -47,7 +47,7 @@ IncrementalSVD::IncrementalSVD(
    d_updateRightSV(options.updateRightSV),
    d_state_database(0)
 {
-   CAROM_ASSERT(options.linearity_tol > 0.0);
+   CAROM_VERIFY(options.linearity_tol > 0.0);
 
    // Get the number of processors, the dimensions for each process, and the
    // total dimension.
@@ -186,8 +186,8 @@ IncrementalSVD::takeSample(
    double time,
    bool add_without_increase)
 {
-   CAROM_ASSERT(u_in != 0);
-   CAROM_ASSERT(time >= 0.0);
+   CAROM_VERIFY(u_in != 0);
+   CAROM_VERIFY(time >= 0.0);
 
 
    // Check that u_in is not non-zero.
@@ -295,7 +295,7 @@ bool
 IncrementalSVD::buildIncrementalSVD(
    double* u, bool add_without_increase)
 {
-   CAROM_ASSERT(u != 0);
+   CAROM_VERIFY(u != 0);
 
    // l = basis' * u
    Vector u_vec(u, d_dim, true);
@@ -368,7 +368,7 @@ IncrementalSVD::buildIncrementalSVD(
       if ((linearly_dependent_sample && !d_skip_linearly_dependent) ) {
          // This sample is linearly dependent and we are not skipping linearly
          // dependent samples.
-         if(d_rank == 0) std::cout << "adding linearly dependent sample!\n"; 
+         if(d_rank == 0) std::cout << "adding linearly dependent sample!\n";
          addLinearlyDependentSample(A, W, sigma);
          delete sigma;
       }
@@ -408,8 +408,8 @@ IncrementalSVD::constructQ(
    const Vector* l,
    double k)
 {
-   CAROM_ASSERT(l != 0);
-   CAROM_ASSERT(l->dim() == numSamples());
+   CAROM_VERIFY(l != 0);
+   CAROM_VERIFY(l->dim() == numSamples());
 
    // Create Q.
    Q = new double [(d_num_samples+1)*(d_num_samples+1)];
@@ -439,7 +439,7 @@ IncrementalSVD::svd(
    Matrix*& S,
    Matrix*& V)
 {
-   CAROM_ASSERT(A != 0);
+   CAROM_VERIFY(A != 0);
 
    // Construct U, S, and V.
    U = new Matrix(d_num_samples+1, d_num_samples+1, false);
@@ -541,7 +541,7 @@ void
 IncrementalSVD::reOrthogonalize(
    Matrix* m)
 {
-   CAROM_ASSERT(m != 0);
+   CAROM_VERIFY(m != 0);
 
    int num_rows = m->numRows();
    int num_cols = m->numColumns();

--- a/IncrementalSVDFastUpdate.C
+++ b/IncrementalSVDFastUpdate.C
@@ -164,7 +164,9 @@ IncrementalSVDFastUpdate::computeBasis()
        std::cout << "d_num_rows_of_W = " << d_num_rows_of_W << "\n";
        std::cout << "d_singular_value_tol = " << d_singular_value_tol << "\n";
        std::cout << "smallest SV = " << d_S->item(d_num_samples-1,d_num_samples-1) << "\n";
-       std::cout << "next smallest SV = " << d_S->item(d_num_samples-2,d_num_samples-2) << "\n";
+       if (d_num_samples > 1) {
+            std::cout << "next smallest SV = " << d_S->item(d_num_samples-2,d_num_samples-2) << "\n";
+       }
    }
    // remove the smallest singular value if it is smaller than d_singular_value_tol
    if ( (d_singular_value_tol != 0.0) &&

--- a/IncrementalSVDFastUpdate.C
+++ b/IncrementalSVDFastUpdate.C
@@ -147,12 +147,6 @@ void
 IncrementalSVDFastUpdate::computeBasis()
 {
    d_basis = d_U->mult(d_Up);
-   /*
-   if (fabs(checkOrthogonality(d_basis)) >
-       std::numeric_limits<double>::epsilon()*static_cast<double>(d_num_samples)) {
-      reOrthogonalize(d_basis);
-   }
-   */
    if(d_updateRightSV)
    {
      delete d_basis_right;
@@ -196,6 +190,17 @@ IncrementalSVDFastUpdate::computeBasis()
            d_basis_right = d_basis_right_new;
        }
        --d_num_samples;
+   }
+   if (fabs(checkOrthogonality(d_basis)) >
+       std::numeric_limits<double>::epsilon()*static_cast<double>(d_num_samples)) {
+       reOrthogonalize(d_basis);
+   }
+   if(d_updateRightSV)
+   {
+       if (fabs(checkOrthogonality(d_basis_right)) >
+           std::numeric_limits<double>::epsilon()*d_num_samples) {
+           reOrthogonalize(d_basis_right);
+       }
    }
 
 }
@@ -249,11 +254,6 @@ IncrementalSVDFastUpdate::addLinearlyDependentSample(
      ++d_num_rows_of_W;
    }
 
-   // Reorthogonalize if necessary.
-   if (fabs(checkOrthogonality(d_Up)) >
-       std::numeric_limits<double>::epsilon()*d_num_samples) {
-      reOrthogonalize(d_Up);
-   }
 }
 
 void
@@ -339,22 +339,6 @@ IncrementalSVDFastUpdate::addNewSample(
    }
    else {
       max_U_dim = d_total_dim;
-   }
-
-   if (fabs(checkOrthogonality(d_U)) >
-       std::numeric_limits<double>::epsilon()*static_cast<double>(max_U_dim)) {
-      reOrthogonalize(d_U);
-   }
-   if (fabs(checkOrthogonality(d_Up)) >
-       std::numeric_limits<double>::epsilon()*d_num_samples) {
-      reOrthogonalize(d_Up);
-   }
-
-   if (d_updateRightSV) {
-     if (fabs(checkOrthogonality(d_W)) >
-         std::numeric_limits<double>::epsilon()*d_num_samples) {
-        reOrthogonalize(d_W);
-     }
    }
 
 }

--- a/IncrementalSVDFastUpdate.C
+++ b/IncrementalSVDFastUpdate.C
@@ -191,6 +191,8 @@ IncrementalSVDFastUpdate::computeBasis()
        }
        --d_num_samples;
    }
+
+   // Reorthogonalize if necessary.
    if (fabs(checkOrthogonality(d_basis)) >
        std::numeric_limits<double>::epsilon()*static_cast<double>(d_num_samples)) {
        reOrthogonalize(d_basis);

--- a/IncrementalSVDFastUpdate.C
+++ b/IncrementalSVDFastUpdate.C
@@ -175,7 +175,7 @@ IncrementalSVDFastUpdate::computeBasis()
 
        if (d_rank == 0) std::cout << "removing a small singular value!\n";
 
-       Matrix* d_basis_new = new Matrix(d_dim, d_num_samples-1, false);
+       Matrix* d_basis_new = new Matrix(d_dim, d_num_samples-1, d_basis->distributed());
        for (int row = 0; row < d_dim; ++row) {
           for (int col = 0; col < d_num_samples-1; ++col) {
               d_basis_new->item(row, col) = d_basis->item(row,col);
@@ -186,7 +186,7 @@ IncrementalSVDFastUpdate::computeBasis()
 
        if (d_updateRightSV)
        {
-           Matrix* d_basis_right_new = new Matrix(d_num_rows_of_W, d_num_samples-1, false);
+           Matrix* d_basis_right_new = new Matrix(d_num_rows_of_W, d_num_samples-1, d_basis_right->distributed());
            for (int row = 0; row < d_num_rows_of_W; ++row) {
               for (int col = 0; col < d_num_samples-1; ++col) {
                   d_basis_right_new->item(row, col) = d_basis_right->item(row,col);

--- a/IncrementalSVDFastUpdate.C
+++ b/IncrementalSVDFastUpdate.C
@@ -30,9 +30,9 @@ IncrementalSVDFastUpdate::IncrementalSVDFastUpdate(
    d_Up(0),
    d_singular_value_tol(options.singular_value_tol)
 {
-   CAROM_ASSERT(options.dim > 0);
-   CAROM_ASSERT(options.linearity_tol > 0.0);
-   CAROM_ASSERT(options.samples_per_time_interval > 0);
+   CAROM_VERIFY(options.dim > 0);
+   CAROM_VERIFY(options.linearity_tol > 0.0);
+   CAROM_VERIFY(options.samples_per_time_interval > 0);
 
    // If the state of the SVD is to be restored, do it now.  The base class,
    // IncrementalSVD, has already opened the database and restored the state
@@ -93,8 +93,8 @@ IncrementalSVDFastUpdate::buildInitialSVD(
    double* u,
    double time)
 {
-   CAROM_ASSERT(u != 0);
-   CAROM_ASSERT(time >= 0.0);
+   CAROM_VERIFY(u != 0);
+   CAROM_VERIFY(time >= 0.0);
 
    // We have a new time interval.
 
@@ -204,8 +204,8 @@ IncrementalSVDFastUpdate::addLinearlyDependentSample(
    const Matrix* W,
    const Matrix* sigma)
 {
-   CAROM_ASSERT(A != 0);
-   CAROM_ASSERT(sigma != 0);
+   CAROM_VERIFY(A != 0);
+   CAROM_VERIFY(sigma != 0);
 
    // Chop a row and a column off of A to form Amod.  Also form
    // d_S by chopping a row and a column off of sigma.
@@ -261,9 +261,9 @@ IncrementalSVDFastUpdate::addNewSample(
    const Matrix* W,
    Matrix* sigma)
 {
-   CAROM_ASSERT(j != 0);
-   CAROM_ASSERT(A != 0);
-   CAROM_ASSERT(sigma != 0);
+   CAROM_VERIFY(j != 0);
+   CAROM_VERIFY(A != 0);
+   CAROM_VERIFY(sigma != 0);
 
    // Add j as a new column of d_U.
    Matrix* newU = new Matrix(d_dim, d_num_samples+1, true);

--- a/IncrementalSVDSampler.C
+++ b/IncrementalSVDSampler.C
@@ -34,13 +34,13 @@ IncrementalSVDSampler::IncrementalSVDSampler(
    d_dt(options.initial_dt),
    d_next_sample_time(0.0)
 {
-   CAROM_ASSERT(options.initial_dt > 0.0);
-   CAROM_ASSERT(options.sampling_tol > 0.0);
-   CAROM_ASSERT(options.max_time_between_samples > 0.0);
-   CAROM_ASSERT(options.min_sampling_time_step_scale >= 0.0);
-   CAROM_ASSERT(options.sampling_time_step_scale >= 0.0);
-   CAROM_ASSERT(options.max_sampling_time_step_scale >= 0.0);
-   CAROM_ASSERT(options.min_sampling_time_step_scale <= options.max_sampling_time_step_scale);
+   CAROM_VERIFY(options.initial_dt > 0.0);
+   CAROM_VERIFY(options.sampling_tol > 0.0);
+   CAROM_VERIFY(options.max_time_between_samples > 0.0);
+   CAROM_VERIFY(options.min_sampling_time_step_scale >= 0.0);
+   CAROM_VERIFY(options.sampling_time_step_scale >= 0.0);
+   CAROM_VERIFY(options.max_sampling_time_step_scale >= 0.0);
+   CAROM_VERIFY(options.min_sampling_time_step_scale <= options.max_sampling_time_step_scale);
 
    d_updateRightSV = options.updateRightSV;
 
@@ -88,9 +88,9 @@ IncrementalSVDSampler::computeNextSampleTime(
    double* rhs_in,
    double time)
 {
-   CAROM_ASSERT(u_in != 0);
-   CAROM_ASSERT(rhs_in != 0);
-   CAROM_ASSERT(time >= 0.0);
+   CAROM_VERIFY(u_in != 0);
+   CAROM_VERIFY(rhs_in != 0);
+   CAROM_VERIFY(time >= 0.0);
 
    // Check that u_in is not non-zero.
    int dim = d_svd->getDim();

--- a/IncrementalSVDStandard.C
+++ b/IncrementalSVDStandard.C
@@ -29,9 +29,9 @@ IncrementalSVDStandard::IncrementalSVDStandard(
       options,
       basis_file_name)
 {
-   CAROM_ASSERT(options.dim > 0);
-   CAROM_ASSERT(options.linearity_tol > 0.0);
-   CAROM_ASSERT(options.samples_per_time_interval > 0);
+   CAROM_VERIFY(options.dim > 0);
+   CAROM_VERIFY(options.linearity_tol > 0.0);
+   CAROM_VERIFY(options.samples_per_time_interval > 0);
 
    // If the state of the SVD is to be restored, do it now.  The base class,
    // IncrementalSVD, has already opened the database and restored the state
@@ -68,8 +68,8 @@ IncrementalSVDStandard::buildInitialSVD(
    double* u,
    double time)
 {
-   CAROM_ASSERT(u != 0);
-   CAROM_ASSERT(time >= 0.0);
+   CAROM_VERIFY(u != 0);
+   CAROM_VERIFY(time >= 0.0);
 
    // We have a new time interval.
 
@@ -132,8 +132,8 @@ IncrementalSVDStandard::addLinearlyDependentSample(
    const Matrix* W,
    const Matrix* sigma)
 {
-   CAROM_ASSERT(A != 0);
-   CAROM_ASSERT(sigma != 0);
+   CAROM_VERIFY(A != 0);
+   CAROM_VERIFY(sigma != 0);
 
    // Chop a row and a column off of A to form Amod.  Also form
    // d_S by chopping a row and a column off of sigma.

--- a/Matrix.C
+++ b/Matrix.C
@@ -230,8 +230,8 @@ Matrix::mult(
    const Matrix& other,
    Matrix*& result) const
 {
-   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
-   CAROM_VERIFY(!other.distributed());
+   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
+   CAROM_ASSERT(!other.distributed());
    CAROM_VERIFY(numColumns() == other.numRows());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -260,8 +260,8 @@ Matrix::mult(
    const Matrix& other,
    Matrix& result) const
 {
-   CAROM_VERIFY(result.distributed() == distributed());
-   CAROM_VERIFY(!other.distributed());
+   CAROM_ASSERT(result.distributed() == distributed());
+   CAROM_ASSERT(!other.distributed());
    CAROM_VERIFY(numColumns() == other.numRows());
 
    // Size result correctly.
@@ -284,8 +284,8 @@ Matrix::mult(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
-   CAROM_VERIFY(!other.distributed());
+   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
+   CAROM_ASSERT(!other.distributed());
    CAROM_VERIFY(numColumns() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -312,8 +312,8 @@ Matrix::mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(result.distributed() == distributed());
-   CAROM_VERIFY(!other.distributed());
+   CAROM_ASSERT(result.distributed() == distributed());
+   CAROM_ASSERT(!other.distributed());
    CAROM_VERIFY(numColumns() == other.dim());
 
    // Size result correctly.
@@ -335,9 +335,9 @@ Matrix::pointwise_mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(!result.distributed());
-   CAROM_VERIFY(!distributed());
-   CAROM_VERIFY(!other.distributed());
+   CAROM_ASSERT(!result.distributed());
+   CAROM_ASSERT(!distributed());
+   CAROM_ASSERT(!other.distributed());
    CAROM_VERIFY(numColumns() == other.dim());
 
    // Do the multiplication.
@@ -351,8 +351,8 @@ Matrix::pointwise_mult(
    int this_row,
    Vector& other) const
 {
-   CAROM_VERIFY(!distributed());
-   CAROM_VERIFY(!other.distributed());
+   CAROM_ASSERT(!distributed());
+   CAROM_ASSERT(!other.distributed());
    CAROM_VERIFY(numColumns() == other.dim());
 
    // Do the multiplication.
@@ -367,8 +367,8 @@ Matrix::multPlus(
    const Vector& b,
    double c) const
 {
-   CAROM_VERIFY(a.distributed() == distributed());
-   CAROM_VERIFY(!b.distributed());
+   CAROM_ASSERT(a.distributed() == distributed());
+   CAROM_ASSERT(!b.distributed());
    CAROM_VERIFY(numColumns() == b.dim());
    CAROM_VERIFY(numRows() == a.dim());
 
@@ -386,8 +386,8 @@ Matrix::transposeMult(
    const Matrix& other,
    Matrix*& result) const
 {
-   CAROM_VERIFY(result == 0 || !result->distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result == 0 || !result->distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(numRows() == other.numRows());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -425,8 +425,8 @@ Matrix::transposeMult(
    const Matrix& other,
    Matrix& result) const
 {
-   CAROM_VERIFY(!result.distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(!result.distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(numRows() == other.numRows());
 
    // Size result correctly.
@@ -458,8 +458,8 @@ Matrix::transposeMult(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_VERIFY(result == 0 || !result->distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result == 0 || !result->distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(numRows() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -494,8 +494,8 @@ Matrix::transposeMult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(!result.distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(!result.distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(numRows() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -524,11 +524,11 @@ void
 Matrix::inverse(
    Matrix*& result) const
 {
-   CAROM_VERIFY(result == 0 ||
+   CAROM_ASSERT(result == 0 ||
                 (!result->distributed() &&
                  result->numRows() == numRows() &&
                  result->numColumns() == numColumns()));
-   CAROM_VERIFY(!distributed());
+   CAROM_ASSERT(!distributed());
    CAROM_VERIFY(numRows() == numColumns());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -575,9 +575,9 @@ void
 Matrix::inverse(
    Matrix& result) const
 {
-   CAROM_VERIFY(!result.distributed() && result.numRows() == numRows() &&
+   CAROM_ASSERT(!result.distributed() && result.numRows() == numRows() &&
                 result.numColumns() == numColumns());
-   CAROM_VERIFY(!distributed());
+   CAROM_ASSERT(!distributed());
    CAROM_VERIFY(numRows() == numColumns());
 
    // Size result correctly.
@@ -617,7 +617,7 @@ Matrix::inverse(
 void
 Matrix::inverse()
 {
-   CAROM_VERIFY(!distributed());
+   CAROM_ASSERT(!distributed());
    CAROM_VERIFY(numRows() == numColumns());
 
    // Call lapack routines to do the inversion.
@@ -655,7 +655,7 @@ Matrix::inverse()
 
 void Matrix::transposePseudoinverse()
 {
-   CAROM_VERIFY(!distributed());
+   CAROM_ASSERT(!distributed());
    CAROM_VERIFY(numRows() >= numColumns());
 
    if (numRows() == numColumns())
@@ -810,7 +810,7 @@ Matrix::qrcp_pivots_transpose_serial(int* row_pivot,
 				     int  pivots_requested) const
 {
   // This method assumes this matrix is serial
-  CAROM_VERIFY(!distributed());
+  CAROM_ASSERT(!distributed());
 
   // Number of pivots requested can't exceed the number of rows of the
   // matrix
@@ -900,7 +900,7 @@ const
   // Shim to design interface; not implemented yet
 
   // Check if distributed; otherwise, use serial implementation
-  CAROM_VERIFY(distributed());
+  CAROM_ASSERT(distributed());
 
   // Elemental implementation
   return qrcp_pivots_transpose_distributed_elemental
@@ -919,7 +919,7 @@ const
 {
 #ifdef CAROM_HAS_ELEMENTAL
   // Check if distributed; otherwise, use serial implementation
-  CAROM_VERIFY(distributed());
+  CAROM_ASSERT(distributed());
 
   // Check if balanced
   if (balanced()) {
@@ -963,7 +963,7 @@ const
   // stores more information.
 
   // Check if distributed and balanced
-  CAROM_VERIFY(distributed() && balanced());
+  CAROM_ASSERT(distributed() && balanced());
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
@@ -1117,7 +1117,7 @@ const
   // stores more information.
 
   // Check if distributed and unbalanced
-  CAROM_VERIFY(distributed() && !balanced());
+  CAROM_ASSERT(distributed() && !balanced());
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers

--- a/Matrix.C
+++ b/Matrix.C
@@ -57,8 +57,8 @@ Matrix::Matrix(
    d_distributed(distributed),
    d_owns_data(true)
 {
-   CAROM_ASSERT(num_rows > 0);
-   CAROM_ASSERT(num_cols > 0);
+   CAROM_VERIFY(num_rows > 0);
+   CAROM_VERIFY(num_cols > 0);
    setSize(num_rows, num_cols);
    int mpi_init;
    MPI_Initialized(&mpi_init);
@@ -81,9 +81,9 @@ Matrix::Matrix(
    d_distributed(distributed),
    d_owns_data(copy_data)
 {
-   CAROM_ASSERT(mat != 0);
-   CAROM_ASSERT(num_rows > 0);
-   CAROM_ASSERT(num_cols > 0);
+   CAROM_VERIFY(mat != 0);
+   CAROM_VERIFY(num_rows > 0);
+   CAROM_VERIFY(num_cols > 0);
    if (copy_data) {
       setSize(num_rows, num_cols);
       memcpy(d_mat, mat, d_alloc_size*sizeof(double));
@@ -145,8 +145,8 @@ Matrix&
 Matrix::operator += (
    const Matrix& rhs)
 {
-   CAROM_ASSERT(rhs.d_num_rows == d_num_rows);
-   CAROM_ASSERT(rhs.d_num_cols == d_num_cols);
+   CAROM_VERIFY(rhs.d_num_rows == d_num_rows);
+   CAROM_VERIFY(rhs.d_num_cols == d_num_cols);
    for(int i=0; i<d_num_rows*d_num_cols; ++i) d_mat[i] += rhs.d_mat[i];
    return *this;
 }
@@ -155,8 +155,8 @@ Matrix&
 Matrix::operator -= (
    const Matrix& rhs)
 {
-   CAROM_ASSERT(rhs.d_num_rows == d_num_rows);
-   CAROM_ASSERT(rhs.d_num_cols == d_num_cols);
+   CAROM_VERIFY(rhs.d_num_rows == d_num_rows);
+   CAROM_VERIFY(rhs.d_num_cols == d_num_cols);
    for(int i=0; i<d_num_rows*d_num_cols; ++i) d_mat[i] -= rhs.d_mat[i];
    return *this;
 }
@@ -187,7 +187,7 @@ Matrix::balanced() const
   // Otherwise, get the total number of rows of the matrix.
   int num_total_rows = d_num_rows;
   const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
@@ -196,7 +196,7 @@ Matrix::balanced() const
 
   const int first_rank_with_fewer = num_total_rows % d_num_procs;
   int my_rank;
-  CAROM_ASSERT(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
+  CAROM_VERIFY(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
 
   const int  min_rows_per_rank = num_total_rows / d_num_procs;
   const bool has_extra_row     = my_rank < first_rank_with_fewer;
@@ -205,7 +205,7 @@ Matrix::balanced() const
   const bool has_too_many_rows = (d_num_rows > max_rows_on_rank);
 
   int result = (has_enough_rows && !has_too_many_rows);
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &result,
 			     reduce_count,
 			     MPI_INT,
@@ -230,9 +230,9 @@ Matrix::mult(
    const Matrix& other,
    Matrix*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.numRows());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.numRows());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -260,9 +260,9 @@ Matrix::mult(
    const Matrix& other,
    Matrix& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.numRows());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.numRows());
 
    // Size result correctly.
    result.setSize(d_num_rows, other.d_num_cols);
@@ -284,9 +284,9 @@ Matrix::mult(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -312,9 +312,9 @@ Matrix::mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // Size result correctly.
    result.setSize(d_num_rows);
@@ -335,10 +335,10 @@ Matrix::pointwise_mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(!result.distributed());
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(!result.distributed());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // Do the multiplication.
    for (int entry = 0; entry < d_num_cols; ++entry) {
@@ -351,9 +351,9 @@ Matrix::pointwise_mult(
    int this_row,
    Vector& other) const
 {
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // Do the multiplication.
    for (int entry = 0; entry < d_num_cols; ++entry) {
@@ -367,10 +367,10 @@ Matrix::multPlus(
    const Vector& b,
    double c) const
 {
-   CAROM_ASSERT(a.distributed() == distributed());
-   CAROM_ASSERT(!b.distributed());
-   CAROM_ASSERT(numColumns() == b.dim());
-   CAROM_ASSERT(numRows() == a.dim());
+   CAROM_VERIFY(a.distributed() == distributed());
+   CAROM_VERIFY(!b.distributed());
+   CAROM_VERIFY(numColumns() == b.dim());
+   CAROM_VERIFY(numRows() == a.dim());
 
    for (int this_row = 0; this_row < d_num_rows; ++this_row) {
       double tmp = 0.0;
@@ -386,9 +386,9 @@ Matrix::transposeMult(
    const Matrix& other,
    Matrix*& result) const
 {
-   CAROM_ASSERT(result == 0 || !result->distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.numRows());
+   CAROM_VERIFY(result == 0 || !result->distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.numRows());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -425,9 +425,9 @@ Matrix::transposeMult(
    const Matrix& other,
    Matrix& result) const
 {
-   CAROM_ASSERT(!result.distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.numRows());
+   CAROM_VERIFY(!result.distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.numRows());
 
    // Size result correctly.
    result.setSize(d_num_cols, other.d_num_cols);
@@ -458,9 +458,9 @@ Matrix::transposeMult(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || !result->distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.dim());
+   CAROM_VERIFY(result == 0 || !result->distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -494,9 +494,9 @@ Matrix::transposeMult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(!result.distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.dim());
+   CAROM_VERIFY(!result.distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -524,12 +524,12 @@ void
 Matrix::inverse(
    Matrix*& result) const
 {
-   CAROM_ASSERT(result == 0 ||
+   CAROM_VERIFY(result == 0 ||
                 (!result->distributed() &&
                  result->numRows() == numRows() &&
                  result->numColumns() == numColumns()));
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() == numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() == numColumns());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -575,10 +575,10 @@ void
 Matrix::inverse(
    Matrix& result) const
 {
-   CAROM_ASSERT(!result.distributed() && result.numRows() == numRows() &&
+   CAROM_VERIFY(!result.distributed() && result.numRows() == numRows() &&
                 result.numColumns() == numColumns());
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() == numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() == numColumns());
 
    // Size result correctly.
    result.setSize(d_num_rows, d_num_cols);
@@ -617,8 +617,8 @@ Matrix::inverse(
 void
 Matrix::inverse()
 {
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() == numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() == numColumns());
 
    // Call lapack routines to do the inversion.
    // Set up some stuff the lapack routines need.
@@ -655,8 +655,8 @@ Matrix::inverse()
 
 void Matrix::transposePseudoinverse()
 {
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() >= numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() >= numColumns());
 
    if (numRows() == numColumns())
      {
@@ -810,17 +810,17 @@ Matrix::qrcp_pivots_transpose_serial(int* row_pivot,
 				     int  pivots_requested) const
 {
   // This method assumes this matrix is serial
-  CAROM_ASSERT(!distributed());
+  CAROM_VERIFY(!distributed());
 
   // Number of pivots requested can't exceed the number of rows of the
   // matrix
-  CAROM_ASSERT(pivots_requested <= numRows());
-  CAROM_ASSERT(pivots_requested > 0);
+  CAROM_VERIFY(pivots_requested <= numRows());
+  CAROM_VERIFY(pivots_requested > 0);
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
-  CAROM_ASSERT(row_pivot != NULL);
-  CAROM_ASSERT(row_pivot_owner != NULL);
+  CAROM_VERIFY(row_pivot != NULL);
+  CAROM_VERIFY(row_pivot_owner != NULL);
 
   // Get dimensions of transpose of matrix
   int num_rows_of_transpose = numColumns();
@@ -861,17 +861,17 @@ Matrix::qrcp_pivots_transpose_serial(int* row_pivot,
 	  &info);
 
    // Fail if error in LAPACK routine.
-   CAROM_ASSERT(info == 0);
+   CAROM_VERIFY(info == 0);
 
    // Assume communicator is MPI_COMM_WORLD and get rank of this
    // process
    int is_mpi_initialized, is_mpi_finalized;
-   CAROM_ASSERT(MPI_Initialized(&is_mpi_initialized) == MPI_SUCCESS);
-   CAROM_ASSERT(MPI_Finalized(&is_mpi_finalized) == MPI_SUCCESS);
+   CAROM_VERIFY(MPI_Initialized(&is_mpi_initialized) == MPI_SUCCESS);
+   CAROM_VERIFY(MPI_Finalized(&is_mpi_finalized) == MPI_SUCCESS);
    int my_rank = 0;
    if(is_mpi_initialized && !is_mpi_finalized) {
      const MPI_Comm my_comm = MPI_COMM_WORLD;
-     CAROM_ASSERT(MPI_Comm_rank(my_comm, &my_rank) == MPI_SUCCESS);
+     CAROM_VERIFY(MPI_Comm_rank(my_comm, &my_rank) == MPI_SUCCESS);
    }
 
    // Copy over pivots and subtract one to convert them from a
@@ -900,7 +900,7 @@ const
   // Shim to design interface; not implemented yet
 
   // Check if distributed; otherwise, use serial implementation
-  CAROM_ASSERT(distributed());
+  CAROM_VERIFY(distributed());
 
   // Elemental implementation
   return qrcp_pivots_transpose_distributed_elemental
@@ -919,7 +919,7 @@ const
 {
 #ifdef CAROM_HAS_ELEMENTAL
   // Check if distributed; otherwise, use serial implementation
-  CAROM_ASSERT(distributed());
+  CAROM_VERIFY(distributed());
 
   // Check if balanced
   if (balanced()) {
@@ -963,12 +963,12 @@ const
   // stores more information.
 
   // Check if distributed and balanced
-  CAROM_ASSERT(distributed() && balanced());
+  CAROM_VERIFY(distributed() && balanced());
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
-  CAROM_ASSERT(row_pivot != NULL);
-  CAROM_ASSERT(row_pivot_owner != NULL);
+  CAROM_VERIFY(row_pivot != NULL);
+  CAROM_VERIFY(row_pivot_owner != NULL);
 
   // Compute total number of rows to set global sizes of matrix
   const MPI_Comm comm    = MPI_COMM_WORLD;
@@ -976,7 +976,7 @@ const
 
   int num_total_rows     = d_num_rows;
   const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
@@ -985,8 +985,8 @@ const
 
   // Number of pivots requested can't exceed the total number of rows
   // of the matrix
-  CAROM_ASSERT(pivots_requested <= num_total_rows);
-  CAROM_ASSERT(pivots_requested > 0);
+  CAROM_VERIFY(pivots_requested <= num_total_rows);
+  CAROM_VERIFY(pivots_requested > 0);
 
   // To compute a column-pivoted QRCP using Elemental, we need to
   // first get the data into datatypes Elemental can operate on.
@@ -998,7 +998,7 @@ const
 
   // The row communicator in the grid should have the same number
   // of processes as the comm owned by the Matrix
-  CAROM_ASSERT(El::mpi::Size(grid.RowComm()) == d_num_procs);
+  CAROM_VERIFY(El::mpi::Size(grid.RowComm()) == d_num_procs);
 
   // Instantiate the transposed matrix; Elemental calls the number of
   // rows the "height" of the matrix, and the number of columns the
@@ -1019,11 +1019,11 @@ const
   // the row communicator) that owns j should be process rank (j %
   // d_num_procs).
   //
-  CAROM_ASSERT(scratch.RowOwner(0) == scratch.RowOwner(1));
+  CAROM_VERIFY(scratch.RowOwner(0) == scratch.RowOwner(1));
   int my_rank;
-  CAROM_ASSERT(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
+  CAROM_VERIFY(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
   El::Int rank_as_row = static_cast<El::Int>(my_rank);
-  CAROM_ASSERT(scratch.ColOwner(rank_as_row) == rank_as_row);
+  CAROM_VERIFY(scratch.ColOwner(rank_as_row) == rank_as_row);
 
   // Set up work matrices
   El::DistMatrix<double> householder_scalars(grid);
@@ -1117,12 +1117,12 @@ const
   // stores more information.
 
   // Check if distributed and unbalanced
-  CAROM_ASSERT(distributed() && !balanced());
+  CAROM_VERIFY(distributed() && !balanced());
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
-  CAROM_ASSERT(row_pivot != NULL);
-  CAROM_ASSERT(row_pivot_owner != NULL);
+  CAROM_VERIFY(row_pivot != NULL);
+  CAROM_VERIFY(row_pivot_owner != NULL);
 
   // Compute total number of rows to set global sizes of matrix
   const MPI_Comm comm    = MPI_COMM_WORLD;
@@ -1130,7 +1130,7 @@ const
 
   int num_total_rows     = d_num_rows;
   const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
@@ -1139,8 +1139,8 @@ const
 
   // Number of pivots requested can't exceed the total number of rows
   // of the matrix
-  CAROM_ASSERT(pivots_requested <= num_total_rows);
-  CAROM_ASSERT(pivots_requested > 0);
+  CAROM_VERIFY(pivots_requested <= num_total_rows);
+  CAROM_VERIFY(pivots_requested > 0);
 
   // To compute a column-pivoted QRCP using Elemental, we need to
   // first get the data into datatypes Elemental can operate on.
@@ -1152,7 +1152,7 @@ const
 
   // The row communicator in the grid should have the same number
   // of processes as the comm owned by the Matrix
-  CAROM_ASSERT(El::mpi::Size(grid.RowComm()) == d_num_procs);
+  CAROM_VERIFY(El::mpi::Size(grid.RowComm()) == d_num_procs);
 
   // Instantiate the transposed matrix; Elemental calls the number of
   // rows the "height" of the matrix, and the number of columns the
@@ -1173,11 +1173,11 @@ const
   // the row communicator) that owns j should be process rank (j %
   // d_num_procs).
   //
-  CAROM_ASSERT(scratch.RowOwner(0) == scratch.RowOwner(1));
+  CAROM_VERIFY(scratch.RowOwner(0) == scratch.RowOwner(1));
   int my_rank;
-  CAROM_ASSERT(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
+  CAROM_VERIFY(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
   El::Int rank_as_row = static_cast<El::Int>(my_rank);
-  CAROM_ASSERT(scratch.ColOwner(rank_as_row) == rank_as_row);
+  CAROM_VERIFY(scratch.ColOwner(rank_as_row) == rank_as_row);
 
   // Set up work matrices
   El::DistMatrix<double> householder_scalars(grid);
@@ -1205,7 +1205,7 @@ const
 
   row_offset[my_rank] = d_num_rows;
   const int send_recv_count = 1;
-  CAROM_ASSERT(MPI_Allgather(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allgather(MPI_IN_PLACE,
 			     send_recv_count,
 			     MPI_INT,
 			     row_offset,
@@ -1216,7 +1216,7 @@ const
   for (size_t i = d_num_procs - 1; i >= 0; i--) {
     row_offset[i] = row_offset[i + 1] - row_offset[i];
   }
-  CAROM_ASSERT(row_offset[0] == 0);
+  CAROM_VERIFY(row_offset[0] == 0);
 
   // Use the computed (local <--> global) index map to assign elements
   // to the scratch matrix

--- a/Matrix.h
+++ b/Matrix.h
@@ -242,7 +242,7 @@ class Matrix
       mult(
          const Matrix* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return mult(*other);
       }
 
@@ -333,7 +333,7 @@ class Matrix
       mult(
          const Vector* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return mult(*other);
       }
 
@@ -491,7 +491,7 @@ class Matrix
       transposeMult(
          const Matrix* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return transposeMult(*other);
       }
 
@@ -580,7 +580,7 @@ class Matrix
       transposeMult(
          const Vector* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return transposeMult(*other);
       }
 
@@ -720,8 +720,8 @@ class Matrix
          int row,
          int col) const
       {
-         CAROM_ASSERT((0 <= row) && (row < numRows()));
-         CAROM_ASSERT((0 <= col) && (col < numColumns()));
+         CAROM_VERIFY((0 <= row) && (row < numRows()));
+         CAROM_VERIFY((0 <= col) && (col < numColumns()));
          return d_mat[row*d_num_cols+col];
       }
 
@@ -743,8 +743,8 @@ class Matrix
          int row,
          int col)
       {
-         CAROM_ASSERT((0 <= row) && (row < numRows()));
-         CAROM_ASSERT((0 <= col) && (col < numColumns()));
+         CAROM_VERIFY((0 <= row) && (row < numRows()));
+         CAROM_VERIFY((0 <= col) && (col < numColumns()));
          return d_mat[row*d_num_cols+col];
       }
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -720,8 +720,8 @@ class Matrix
          int row,
          int col) const
       {
-         CAROM_VERIFY((0 <= row) && (row < numRows()));
-         CAROM_VERIFY((0 <= col) && (col < numColumns()));
+         CAROM_ASSERT((0 <= row) && (row < numRows()));
+         CAROM_ASSERT((0 <= col) && (col < numColumns()));
          return d_mat[row*d_num_cols+col];
       }
 
@@ -743,8 +743,8 @@ class Matrix
          int row,
          int col)
       {
-         CAROM_VERIFY((0 <= row) && (row < numRows()));
-         CAROM_VERIFY((0 <= col) && (col < numColumns()));
+         CAROM_ASSERT((0 <= row) && (row < numRows()));
+         CAROM_ASSERT((0 <= col) && (col < numColumns()));
          return d_mat[row*d_num_cols+col];
       }
 

--- a/SVD.C
+++ b/SVD.C
@@ -30,9 +30,9 @@ SVD::SVD(
    d_time_interval_start_times(0),
    d_debug_algorithm(options.debug_algorithm)
 {
-   CAROM_ASSERT(options.dim > 0);
-   CAROM_ASSERT(options.max_time_intervals == -1 || options.max_time_intervals > 0);
-   CAROM_ASSERT(options.samples_per_time_interval > 0);
+   CAROM_VERIFY(options.dim > 0);
+   CAROM_VERIFY(options.max_time_intervals == -1 || options.max_time_intervals > 0);
+   CAROM_VERIFY(options.samples_per_time_interval > 0);
 }
 
 SVD::~SVD()

--- a/SVD.h
+++ b/SVD.h
@@ -180,8 +180,8 @@ class SVD
       getBasisIntervalStartTime(
          int which_interval) const
       {
-         CAROM_ASSERT(0 <= which_interval);
-         CAROM_ASSERT(which_interval < getNumBasisTimeIntervals());
+         CAROM_VERIFY(0 <= which_interval);
+         CAROM_VERIFY(which_interval < getNumBasisTimeIntervals());
 
 	       std::size_t i = static_cast<std::size_t>(which_interval);
          return d_time_interval_start_times[i];

--- a/SVDBasisGenerator.h
+++ b/SVDBasisGenerator.h
@@ -65,7 +65,7 @@ class SVDBasisGenerator
       isNextSample(
          double time)
       {
-         CAROM_ASSERT(time >= 0.0);
+         CAROM_VERIFY(time >= 0.0);
          return d_svdsampler->isNextSample(time);
       }
 
@@ -94,8 +94,8 @@ class SVDBasisGenerator
          double dt,
          bool add_without_increase = false)
       {
-         CAROM_ASSERT(u_in != 0);
-         CAROM_ASSERT(time >= 0);
+         CAROM_VERIFY(u_in != 0);
+         CAROM_VERIFY(time >= 0);
 
          // Check that u_in is not non-zero.
          Vector u_vec(u_in, d_svdsampler->getDim(), true);
@@ -160,7 +160,7 @@ class SVDBasisGenerator
                   Database::formats db_format = Database::HDF5)
       {
          CAROM_ASSERT(!base_file_name.empty());
-         CAROM_ASSERT(kind == "basis" || kind == "snapshot");
+         CAROM_VERIFY(kind == "basis" || kind == "snapshot");
 
          if (d_basis_reader) delete d_basis_reader;
 
@@ -213,9 +213,9 @@ class SVDBasisGenerator
          double* rhs_in,
          double time)
       {
-         CAROM_ASSERT(u_in != 0);
-         CAROM_ASSERT(rhs_in != 0);
-         CAROM_ASSERT(time >= 0);
+         CAROM_VERIFY(u_in != 0);
+         CAROM_VERIFY(rhs_in != 0);
+         CAROM_VERIFY(time >= 0);
 
          return d_svdsampler->computeNextSampleTime(u_in, rhs_in, time);
       }
@@ -293,8 +293,8 @@ class SVDBasisGenerator
       getBasisIntervalStartTime(
          int which_interval) const
       {
-         CAROM_ASSERT(0 <= which_interval);
-         CAROM_ASSERT(which_interval < getNumBasisTimeIntervals());
+         CAROM_VERIFY(0 <= which_interval);
+         CAROM_VERIFY(which_interval < getNumBasisTimeIntervals());
          return d_svdsampler->getBasisIntervalStartTime(which_interval);
       }
 

--- a/SVDSampler.h
+++ b/SVDSampler.h
@@ -137,7 +137,7 @@ class SVDSampler
       {
          return d_svd->getSnapshotMatrix();
       }
-   
+
       /**
        * @brief Returns the number of time intervals on which different sets of
        * basis vectors are defined.
@@ -164,8 +164,8 @@ class SVDSampler
       getBasisIntervalStartTime(
          int which_interval) const
       {
-         CAROM_ASSERT(0 <= which_interval);
-         CAROM_ASSERT(which_interval < getNumBasisTimeIntervals());
+         CAROM_VERIFY(0 <= which_interval);
+         CAROM_VERIFY(which_interval < getNumBasisTimeIntervals());
          return d_svd->getBasisIntervalStartTime(which_interval);
       }
 
@@ -216,7 +216,7 @@ class SVDSampler
       {
 	return d_svd->getNumSamples();
       }
-      
+
    protected:
       /**
        * @brief Pointer to the abstract SVD algorithm object.

--- a/StaticSVD.C
+++ b/StaticSVD.C
@@ -38,10 +38,10 @@ StaticSVD::StaticSVD(
    d_max_basis_dimension(options.max_basis_dimension),
    d_sigma_tol(options.sigma_tolerance)
 {
-   CAROM_ASSERT(options.dim > 0);
-   CAROM_ASSERT(options.samples_per_time_interval > 0);
-   CAROM_ASSERT(options.max_basis_dimension > 0);
-   CAROM_ASSERT(options.sigma_tolerance >= 0);
+   CAROM_VERIFY(options.dim > 0);
+   CAROM_VERIFY(options.samples_per_time_interval > 0);
+   CAROM_VERIFY(options.max_basis_dimension > 0);
+   CAROM_VERIFY(options.sigma_tolerance >= 0);
 
    // Get the rank of this process, and the number of processors.
    int mpi_init;
@@ -97,8 +97,8 @@ StaticSVD::takeSample(
    double time,
    bool add_without_increase)
 {
-   CAROM_ASSERT(u_in != 0);
-   CAROM_ASSERT(time >= 0.0);
+   CAROM_VERIFY(u_in != 0);
+   CAROM_VERIFY(time >= 0.0);
    CAROM_NULL_USE(add_without_increase);
 
    // Check the u_in is not non-zero.
@@ -272,13 +272,13 @@ StaticSVD::computeSVD()
       hard_cutoff = d_max_basis_dimension;
    }
    int ncolumns = hard_cutoff < sigma_cutoff ? hard_cutoff : sigma_cutoff;
-   CAROM_ASSERT(ncolumns >= 0);
+   CAROM_VERIFY(ncolumns >= 0);
 
    // Allocate the appropriate matrices and gather their elements.
    d_basis = new Matrix(d_dim, ncolumns, true);
    d_S = new Matrix(ncolumns, ncolumns, false);
    {
-      CAROM_ASSERT(ncolumns >= 0);
+      CAROM_VERIFY(ncolumns >= 0);
       unsigned nc = static_cast<unsigned>(ncolumns);
       memset(&d_S->item(0, 0), 0, nc*nc*sizeof(double));
    }

--- a/Vector.C
+++ b/Vector.C
@@ -198,7 +198,7 @@ Vector::inner_product(
    const Vector& other) const
 {
    CAROM_VERIFY(dim() == other.dim());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    double ip;
    double local_ip = 0.0;
    for (int i = 0; i < d_dim; ++i) {
@@ -236,8 +236,8 @@ Vector::plus(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -260,8 +260,8 @@ Vector::plus(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(result.distributed() == distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result.distributed() == distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // Size result correctly.
@@ -279,8 +279,8 @@ Vector::plusAx(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -304,8 +304,8 @@ Vector::plusAx(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(result.distributed() == distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result.distributed() == distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // Size result correctly.
@@ -322,7 +322,7 @@ Vector::plusEqAx(
    double factor,
    const Vector& other)
 {
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // Do the addition.
@@ -336,8 +336,8 @@ Vector::minus(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
@@ -360,8 +360,8 @@ Vector::minus(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(result.distributed() == distributed());
-   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_ASSERT(result.distributed() == distributed());
+   CAROM_ASSERT(distributed() == other.distributed());
    CAROM_VERIFY(dim() == other.dim());
 
    // Size result correctly.
@@ -378,7 +378,7 @@ Vector::mult(
    double factor,
    Vector*& result) const
 {
-   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -400,7 +400,7 @@ Vector::mult(
    double factor,
    Vector& result) const
 {
-   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_ASSERT(result.distributed() == distributed());
 
    // Size result correctly.
    result.setSize(d_dim);

--- a/Vector.C
+++ b/Vector.C
@@ -37,7 +37,7 @@ Vector::Vector(
    d_distributed(distributed),
    d_owns_data(true)
 {
-   CAROM_ASSERT(dim > 0);
+   CAROM_VERIFY(dim > 0);
    setSize(dim);
    int mpi_init;
    MPI_Initialized(&mpi_init);
@@ -59,8 +59,8 @@ Vector::Vector(
    d_distributed(distributed),
    d_owns_data(copy_data)
 {
-   CAROM_ASSERT(vec != 0);
-   CAROM_ASSERT(dim > 0);
+   CAROM_VERIFY(vec != 0);
+   CAROM_VERIFY(dim > 0);
    if (copy_data) {
       setSize(dim);
       memcpy(d_vec, vec, d_alloc_size*sizeof(double));
@@ -121,7 +121,7 @@ Vector&
 Vector::operator += (
    const Vector& rhs)
 {
-   CAROM_ASSERT(d_dim == rhs.d_dim);
+   CAROM_VERIFY(d_dim == rhs.d_dim);
    for(int i=0; i<d_dim; ++i) d_vec[i] += rhs.d_vec[i];
    return *this;
 }
@@ -197,8 +197,8 @@ double
 Vector::inner_product(
    const Vector& other) const
 {
-   CAROM_ASSERT(dim() == other.dim());
-   CAROM_ASSERT(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
+   CAROM_VERIFY(distributed() == other.distributed());
    double ip;
    double local_ip = 0.0;
    for (int i = 0; i < d_dim; ++i) {
@@ -236,9 +236,9 @@ Vector::plus(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -260,9 +260,9 @@ Vector::plus(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // Size result correctly.
    result.setSize(d_dim);
@@ -279,9 +279,9 @@ Vector::plusAx(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -304,9 +304,9 @@ Vector::plusAx(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // Size result correctly.
    result.setSize(d_dim);
@@ -322,8 +322,8 @@ Vector::plusEqAx(
    double factor,
    const Vector& other)
 {
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // Do the addition.
    for (int i = 0; i < d_dim; ++i) {
@@ -336,9 +336,9 @@ Vector::minus(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -360,9 +360,9 @@ Vector::minus(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(dim() == other.dim());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(dim() == other.dim());
 
    // Size result correctly.
    result.setSize(d_dim);
@@ -378,7 +378,7 @@ Vector::mult(
    double factor,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -400,7 +400,7 @@ Vector::mult(
    double factor,
    Vector& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
+   CAROM_VERIFY(result.distributed() == distributed());
 
    // Size result correctly.
    result.setSize(d_dim);

--- a/Vector.h
+++ b/Vector.h
@@ -274,7 +274,7 @@ class Vector
       inner_product(
          const Vector* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return inner_product(*other);
       }
 
@@ -332,7 +332,7 @@ class Vector
       plus(
          const Vector* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return plus(*other);
       }
 
@@ -410,7 +410,7 @@ class Vector
          double factor,
          const Vector* other)
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return plusAx(factor, *other);
       }
 
@@ -480,7 +480,7 @@ class Vector
          double factor,
          const Vector* other)
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          plusEqAx(factor, *other);
       }
 
@@ -520,7 +520,7 @@ class Vector
       minus(
          const Vector* other) const
       {
-         CAROM_ASSERT(other != 0);
+         CAROM_VERIFY(other != 0);
          return minus(*other);
       }
 
@@ -617,7 +617,7 @@ class Vector
       item(
          int i) const
       {
-         CAROM_ASSERT((0 <= i) && (i < dim()));
+         CAROM_VERIFY((0 <= i) && (i < dim()));
          return d_vec[i];
       }
 
@@ -636,7 +636,7 @@ class Vector
       item(
          int i)
       {
-         CAROM_ASSERT((0 <= i) && (i < dim()));
+         CAROM_VERIFY((0 <= i) && (i < dim()));
          return d_vec[i];
       }
 

--- a/Vector.h
+++ b/Vector.h
@@ -617,7 +617,7 @@ class Vector
       item(
          int i) const
       {
-         CAROM_VERIFY((0 <= i) && (i < dim()));
+         CAROM_ASSERT((0 <= i) && (i < dim()));
          return d_vec[i];
       }
 
@@ -636,7 +636,7 @@ class Vector
       item(
          int i)
       {
-         CAROM_VERIFY((0 <= i) && (i < dim()));
+         CAROM_ASSERT((0 <= i) && (i < dim()));
          return d_vec[i];
       }
 


### PR DESCRIPTION
1. Fix small cout bug relating to svtol
2. Change CAROM_ASSERT to CAROM_VERIFY for Matrix, Vector, SVD, and BasisGenerator classes.
3. Leave CAROM_ASSERT for any access functions, such as Matrix.item() and Vector.item()