### PR TITLE
QDEIM with QR via scalapack

### DIFF
--- a/Matrix.C
+++ b/Matrix.C
@@ -337,8 +337,9 @@ Matrix::pointwise_mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_VERIFY(!result.distributed());
-   CAROM_VERIFY(!distributed());
+   // TODO: change the CAROM_ASSERTs to CAROM_VERIFYs or generalize and eliminate the checks.
+   CAROM_ASSERT(!result.distributed());
+   CAROM_ASSERT(!distributed());
    CAROM_VERIFY(!other.distributed());
    CAROM_VERIFY(numColumns() == other.dim());
 

--- a/Matrix.C
+++ b/Matrix.C
@@ -1044,7 +1044,7 @@ const
   else
     {
       for (int i=0; i<scount; ++i)
-	row_pivot[i] = QRmgr.ipiv[i]-1;  // make it 0-based. TODO: is this used on non-root processes?
+	row_pivot[i] = QRmgr.ipiv[i]-1;  // make it 0-based. TODO: is this used on non-root processes? Not in QDEIM!
     }
   
   free_matrix_data(&slpk);

--- a/Matrix.C
+++ b/Matrix.C
@@ -59,8 +59,8 @@ Matrix::Matrix(
    d_distributed(distributed),
    d_owns_data(true)
 {
-   CAROM_ASSERT(num_rows > 0);
-   CAROM_ASSERT(num_cols > 0);
+   CAROM_VERIFY(num_rows > 0);
+   CAROM_VERIFY(num_cols > 0);
    setSize(num_rows, num_cols);
    int mpi_init;
    MPI_Initialized(&mpi_init);
@@ -83,9 +83,9 @@ Matrix::Matrix(
    d_distributed(distributed),
    d_owns_data(copy_data)
 {
-   CAROM_ASSERT(mat != 0);
-   CAROM_ASSERT(num_rows > 0);
-   CAROM_ASSERT(num_cols > 0);
+   CAROM_VERIFY(mat != 0);
+   CAROM_VERIFY(num_rows > 0);
+   CAROM_VERIFY(num_cols > 0);
    if (copy_data) {
       setSize(num_rows, num_cols);
       memcpy(d_mat, mat, d_alloc_size*sizeof(double));
@@ -147,8 +147,8 @@ Matrix&
 Matrix::operator += (
    const Matrix& rhs)
 {
-   CAROM_ASSERT(rhs.d_num_rows == d_num_rows);
-   CAROM_ASSERT(rhs.d_num_cols == d_num_cols);
+   CAROM_VERIFY(rhs.d_num_rows == d_num_rows);
+   CAROM_VERIFY(rhs.d_num_cols == d_num_cols);
    for(int i=0; i<d_num_rows*d_num_cols; ++i) d_mat[i] += rhs.d_mat[i];
    return *this;
 }
@@ -157,8 +157,8 @@ Matrix&
 Matrix::operator -= (
    const Matrix& rhs)
 {
-   CAROM_ASSERT(rhs.d_num_rows == d_num_rows);
-   CAROM_ASSERT(rhs.d_num_cols == d_num_cols);
+   CAROM_VERIFY(rhs.d_num_rows == d_num_rows);
+   CAROM_VERIFY(rhs.d_num_cols == d_num_cols);
    for(int i=0; i<d_num_rows*d_num_cols; ++i) d_mat[i] -= rhs.d_mat[i];
    return *this;
 }
@@ -189,7 +189,7 @@ Matrix::balanced() const
   // Otherwise, get the total number of rows of the matrix.
   int num_total_rows = d_num_rows;
   const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
@@ -198,7 +198,7 @@ Matrix::balanced() const
 
   const int first_rank_with_fewer = num_total_rows % d_num_procs;
   int my_rank;
-  CAROM_ASSERT(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
+  CAROM_VERIFY(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
 
   const int  min_rows_per_rank = num_total_rows / d_num_procs;
   const bool has_extra_row     = my_rank < first_rank_with_fewer;
@@ -207,7 +207,7 @@ Matrix::balanced() const
   const bool has_too_many_rows = (d_num_rows > max_rows_on_rank);
 
   int result = (has_enough_rows && !has_too_many_rows);
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &result,
 			     reduce_count,
 			     MPI_INT,
@@ -232,9 +232,9 @@ Matrix::mult(
    const Matrix& other,
    Matrix*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.numRows());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.numRows());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -262,9 +262,9 @@ Matrix::mult(
    const Matrix& other,
    Matrix& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.numRows());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.numRows());
 
    // Size result correctly.
    result.setSize(d_num_rows, other.d_num_cols);
@@ -286,9 +286,9 @@ Matrix::mult(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || result->distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(result == 0 || result->distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -314,9 +314,9 @@ Matrix::mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(result.distributed() == distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(result.distributed() == distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // Size result correctly.
    result.setSize(d_num_rows);
@@ -337,10 +337,10 @@ Matrix::pointwise_mult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(!result.distributed());
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(!result.distributed());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // Do the multiplication.
    for (int entry = 0; entry < d_num_cols; ++entry) {
@@ -353,9 +353,9 @@ Matrix::pointwise_mult(
    int this_row,
    Vector& other) const
 {
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(!other.distributed());
-   CAROM_ASSERT(numColumns() == other.dim());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(!other.distributed());
+   CAROM_VERIFY(numColumns() == other.dim());
 
    // Do the multiplication.
    for (int entry = 0; entry < d_num_cols; ++entry) {
@@ -369,10 +369,10 @@ Matrix::multPlus(
    const Vector& b,
    double c) const
 {
-   CAROM_ASSERT(a.distributed() == distributed());
-   CAROM_ASSERT(!b.distributed());
-   CAROM_ASSERT(numColumns() == b.dim());
-   CAROM_ASSERT(numRows() == a.dim());
+   CAROM_VERIFY(a.distributed() == distributed());
+   CAROM_VERIFY(!b.distributed());
+   CAROM_VERIFY(numColumns() == b.dim());
+   CAROM_VERIFY(numRows() == a.dim());
 
    for (int this_row = 0; this_row < d_num_rows; ++this_row) {
       double tmp = 0.0;
@@ -388,9 +388,9 @@ Matrix::transposeMult(
    const Matrix& other,
    Matrix*& result) const
 {
-   CAROM_ASSERT(result == 0 || !result->distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.numRows());
+   CAROM_VERIFY(result == 0 || !result->distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.numRows());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -427,9 +427,9 @@ Matrix::transposeMult(
    const Matrix& other,
    Matrix& result) const
 {
-   CAROM_ASSERT(!result.distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.numRows());
+   CAROM_VERIFY(!result.distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.numRows());
 
    // Size result correctly.
    result.setSize(d_num_cols, other.d_num_cols);
@@ -460,9 +460,9 @@ Matrix::transposeMult(
    const Vector& other,
    Vector*& result) const
 {
-   CAROM_ASSERT(result == 0 || !result->distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.dim());
+   CAROM_VERIFY(result == 0 || !result->distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -496,9 +496,9 @@ Matrix::transposeMult(
    const Vector& other,
    Vector& result) const
 {
-   CAROM_ASSERT(!result.distributed());
-   CAROM_ASSERT(distributed() == other.distributed());
-   CAROM_ASSERT(numRows() == other.dim());
+   CAROM_VERIFY(!result.distributed());
+   CAROM_VERIFY(distributed() == other.distributed());
+   CAROM_VERIFY(numRows() == other.dim());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -526,12 +526,12 @@ void
 Matrix::inverse(
    Matrix*& result) const
 {
-   CAROM_ASSERT(result == 0 ||
+   CAROM_VERIFY(result == 0 ||
                 (!result->distributed() &&
                  result->numRows() == numRows() &&
                  result->numColumns() == numColumns()));
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() == numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() == numColumns());
 
    // If the result has not been allocated then do so.  Otherwise size it
    // correctly.
@@ -577,10 +577,10 @@ void
 Matrix::inverse(
    Matrix& result) const
 {
-   CAROM_ASSERT(!result.distributed() && result.numRows() == numRows() &&
+   CAROM_VERIFY(!result.distributed() && result.numRows() == numRows() &&
                 result.numColumns() == numColumns());
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() == numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() == numColumns());
 
    // Size result correctly.
    result.setSize(d_num_rows, d_num_cols);
@@ -618,7 +618,7 @@ Matrix::inverse(
 
 void Matrix::transpose()
 {
-  CAROM_ASSERT(numRows() == numColumns());  // Avoid resizing
+  CAROM_VERIFY(numRows() == numColumns());  // Avoid resizing
   const int n = numRows();
   for (int i=0; i<n; ++i)
     {
@@ -634,8 +634,8 @@ void Matrix::transpose()
 void
 Matrix::inverse()
 {
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() == numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() == numColumns());
 
    // Call lapack routines to do the inversion.
    // Set up some stuff the lapack routines need.
@@ -672,8 +672,8 @@ Matrix::inverse()
 
 void Matrix::transposePseudoinverse()
 {
-   CAROM_ASSERT(!distributed());
-   CAROM_ASSERT(numRows() >= numColumns());
+   CAROM_VERIFY(!distributed());
+   CAROM_VERIFY(numRows() >= numColumns());
 
    if (numRows() == numColumns())
      {
@@ -710,7 +710,7 @@ Matrix::print(const char * prefix)
 {
    int my_rank;
    const bool success = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-   CAROM_ASSERT(success);
+   CAROM_VERIFY(success);
 
    std::string filename_str = prefix + std::to_string(my_rank);
    const char * filename = filename_str.c_str();
@@ -727,7 +727,7 @@ Matrix::print(const char * prefix)
 void
 Matrix::write(const std::string& base_file_name)
 {
-   CAROM_ASSERT(!base_file_name.empty());
+   CAROM_VERIFY(!base_file_name.empty());
 
    int mpi_init;
    MPI_Initialized(&mpi_init);
@@ -759,7 +759,7 @@ Matrix::write(const std::string& base_file_name)
 void
 Matrix::read(const std::string& base_file_name)
 {
-   CAROM_ASSERT(!base_file_name.empty());
+   CAROM_VERIFY(!base_file_name.empty());
 
    int mpi_init;
    MPI_Initialized(&mpi_init);
@@ -816,7 +816,7 @@ Matrix::qrcp_pivots_transpose(int* row_pivot,
 					     row_pivot_owner,
 					     pivots_requested);
     //#else
-    //    CAROM_ASSERT(false);
+    //    CAROM_VERIFY(false);
     //#endif
   }
 }
@@ -827,17 +827,17 @@ Matrix::qrcp_pivots_transpose_serial(int* row_pivot,
 				     int  pivots_requested) const
 {
   // This method assumes this matrix is serial
-  CAROM_ASSERT(!distributed());
+  CAROM_VERIFY(!distributed());
 
   // Number of pivots requested can't exceed the number of rows of the
   // matrix
-  CAROM_ASSERT(pivots_requested <= numRows());
-  CAROM_ASSERT(pivots_requested > 0);
+  CAROM_VERIFY(pivots_requested <= numRows());
+  CAROM_VERIFY(pivots_requested > 0);
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
-  CAROM_ASSERT(row_pivot != NULL);
-  CAROM_ASSERT(row_pivot_owner != NULL);
+  CAROM_VERIFY(row_pivot != NULL);
+  CAROM_VERIFY(row_pivot_owner != NULL);
 
   // Get dimensions of transpose of matrix
   int num_rows_of_transpose = numColumns();
@@ -878,17 +878,17 @@ Matrix::qrcp_pivots_transpose_serial(int* row_pivot,
 	  &info);
 
    // Fail if error in LAPACK routine.
-   CAROM_ASSERT(info == 0);
+   CAROM_VERIFY(info == 0);
 
    // Assume communicator is MPI_COMM_WORLD and get rank of this
    // process
    int is_mpi_initialized, is_mpi_finalized;
-   CAROM_ASSERT(MPI_Initialized(&is_mpi_initialized) == MPI_SUCCESS);
-   CAROM_ASSERT(MPI_Finalized(&is_mpi_finalized) == MPI_SUCCESS);
+   CAROM_VERIFY(MPI_Initialized(&is_mpi_initialized) == MPI_SUCCESS);
+   CAROM_VERIFY(MPI_Finalized(&is_mpi_finalized) == MPI_SUCCESS);
    int my_rank = 0;
    if(is_mpi_initialized && !is_mpi_finalized) {
      const MPI_Comm my_comm = MPI_COMM_WORLD;
-     CAROM_ASSERT(MPI_Comm_rank(my_comm, &my_rank) == MPI_SUCCESS);
+     CAROM_VERIFY(MPI_Comm_rank(my_comm, &my_rank) == MPI_SUCCESS);
    }
 
    // Copy over pivots and subtract one to convert them from a
@@ -914,7 +914,7 @@ Matrix::qrcp_pivots_transpose_distributed(int* row_pivot,
 const
 {
   // Check if distributed; otherwise, use serial implementation
-  CAROM_ASSERT(distributed());
+  CAROM_VERIFY(distributed());
   
 #ifdef CAROM_HAS_ELEMENTAL
   // Shim to design interface; not implemented yet
@@ -934,39 +934,38 @@ Matrix::qrcp_pivots_transpose_distributed_scalapack
 const
 {
   // Check if distributed; otherwise, use serial implementation
-  CAROM_ASSERT(distributed());
+  CAROM_VERIFY(distributed());
 
-  int num_total_rows     = d_num_rows;
-  const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  int num_total_rows = d_num_rows;
+  int reduce_count = 1;
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
 			     MPI_SUM,
-			     comm) == MPI_SUCCESS);
+			     MPI_COMM_WORLD) == MPI_SUCCESS);
 
   int *row_offset = new int[d_num_procs + 1];
-  row_offset[d_num_procs + 1] = num_total_rows;
+  row_offset[d_num_procs] = num_total_rows;
 
   int my_rank;
-  const bool success = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-  CAROM_ASSERT(success);
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
   
   row_offset[my_rank] = d_num_rows;
 
   const int send_recv_count = 1;
-  CAROM_ASSERT(MPI_Allgather(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allgather(MPI_IN_PLACE,
 			     send_recv_count,
 			     MPI_INT,
 			     row_offset,
 			     send_recv_count,
 			     MPI_INT,
-			     comm) == MPI_SUCCESS);
+			     MPI_COMM_WORLD) == MPI_SUCCESS);
 
-  for (size_t i = d_num_procs - 1; i >= 0; i--) {
+  for (int i = d_num_procs - 1; i >= 0; i--) {
     row_offset[i] = row_offset[i + 1] - row_offset[i];
   }
-  CAROM_ASSERT(row_offset[0] == 0);
+  CAROM_VERIFY(row_offset[0] == 0);
   
   SLPK_Matrix slpk;
   int blocksize = row_offset[d_num_procs] / d_num_procs;
@@ -974,7 +973,7 @@ const
   
   initialize_matrix(&slpk, d_num_cols, row_offset[d_num_procs], 1, d_num_procs, 1, blocksize);  // transposed
 
-  CAROM_ASSERT(d_num_cols == pivots_requested); // Otherwise, should we just find the QR of the submatrix consisting of the first (pivots_requested) columns?
+  CAROM_VERIFY(d_num_cols == pivots_requested); // Otherwise, should we just find the QR of the submatrix consisting of the first (pivots_requested) columns?
   
   for (int rank = 0; rank < d_num_procs; ++rank) {
     // Take the row-major data in d_mat and put it in a transposed column-major array in slpk
@@ -989,14 +988,14 @@ const
   qrfactorize(&QRmgr);
 
   // Just gather the pivots to root and discard the factorization
-  CAROM_ASSERT(pivots_requested <= QRmgr.ipivSize);
-  CAROM_ASSERT(pivots_requested <= std::min(d_num_rows, d_num_cols));
+  CAROM_VERIFY(pivots_requested <= QRmgr.ipivSize);
+  CAROM_VERIFY(pivots_requested <= std::min(d_num_rows, d_num_cols));
 
   const int scount = std::max(0, std::min(pivots_requested, row_offset[my_rank+1]) - row_offset[my_rank]);
   int *mypivots = (scount > 0) ? new int[scount] : NULL;
 
   for (int i=0; i<scount; ++i)
-    mypivots[i] = QRmgr.ipiv[i];
+    mypivots[i] = QRmgr.ipiv[i]-1;  // make it 0-based
   
   MPI_Gather(mypivots, scount, MPI_INT, row_pivot, pivots_requested, MPI_INT, 0, MPI_COMM_WORLD);
 
@@ -1015,14 +1014,14 @@ const
 		  break;
 		}
 	    }
-	  CAROM_ASSERT(row_pivot_owner[i] >= 0);
-	  CAROM_ASSERT(row_offset[row_pivot_owner[i]] <= i && i < row_offset[row_pivot_owner[i]+1]);
+	  CAROM_VERIFY(row_pivot_owner[i] >= 0);
+	  CAROM_VERIFY(row_offset[row_pivot_owner[i]] <= i && i < row_offset[row_pivot_owner[i]+1]);
 	}
     }
   else
     {
       for (int i=0; i<scount; ++i)
-	row_pivot[i] = QRmgr.ipiv[i];  // TODO: is this used on non-root processes?
+	row_pivot[i] = QRmgr.ipiv[i]-1;  // make it 0-based. TODO: is this used on non-root processes?
     }
   
   free_matrix_data(&slpk);
@@ -1041,7 +1040,7 @@ const
 {
 #ifdef CAROM_HAS_ELEMENTAL
   // Check if distributed; otherwise, use serial implementation
-  CAROM_ASSERT(distributed());
+  CAROM_VERIFY(distributed());
 
   // Check if balanced
   if (balanced()) {
@@ -1053,7 +1052,7 @@ const
       (row_pivot, row_pivot_owner, pivots_requested);
   }
 #else
-  CAROM_ASSERT(false);
+  CAROM_VERIFY(false);
 #endif
 }
 
@@ -1085,12 +1084,12 @@ const
   // stores more information.
 
   // Check if distributed and balanced
-  CAROM_ASSERT(distributed() && balanced());
+  CAROM_VERIFY(distributed() && balanced());
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
-  CAROM_ASSERT(row_pivot != NULL);
-  CAROM_ASSERT(row_pivot_owner != NULL);
+  CAROM_VERIFY(row_pivot != NULL);
+  CAROM_VERIFY(row_pivot_owner != NULL);
 
   // Compute total number of rows to set global sizes of matrix
   const MPI_Comm comm    = MPI_COMM_WORLD;
@@ -1098,7 +1097,7 @@ const
 
   int num_total_rows     = d_num_rows;
   const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
@@ -1107,8 +1106,8 @@ const
 
   // Number of pivots requested can't exceed the total number of rows
   // of the matrix
-  CAROM_ASSERT(pivots_requested <= num_total_rows);
-  CAROM_ASSERT(pivots_requested > 0);
+  CAROM_VERIFY(pivots_requested <= num_total_rows);
+  CAROM_VERIFY(pivots_requested > 0);
 
   // To compute a column-pivoted QRCP using Elemental, we need to
   // first get the data into datatypes Elemental can operate on.
@@ -1120,7 +1119,7 @@ const
 
   // The row communicator in the grid should have the same number
   // of processes as the comm owned by the Matrix
-  CAROM_ASSERT(El::mpi::Size(grid.RowComm()) == d_num_procs);
+  CAROM_VERIFY(El::mpi::Size(grid.RowComm()) == d_num_procs);
 
   // Instantiate the transposed matrix; Elemental calls the number of
   // rows the "height" of the matrix, and the number of columns the
@@ -1141,11 +1140,11 @@ const
   // the row communicator) that owns j should be process rank (j %
   // d_num_procs).
   //
-  CAROM_ASSERT(scratch.RowOwner(0) == scratch.RowOwner(1));
+  CAROM_VERIFY(scratch.RowOwner(0) == scratch.RowOwner(1));
   int my_rank;
-  CAROM_ASSERT(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
+  CAROM_VERIFY(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
   El::Int rank_as_row = static_cast<El::Int>(my_rank);
-  CAROM_ASSERT(scratch.ColOwner(rank_as_row) == rank_as_row);
+  CAROM_VERIFY(scratch.ColOwner(rank_as_row) == rank_as_row);
 
   // Set up work matrices
   El::DistMatrix<double> householder_scalars(grid);
@@ -1214,7 +1213,7 @@ const
     row_pivot_owner[i] = owner;
   }
 #else
-  CAROM_ASSERT(false);
+  CAROM_VERIFY(false);
 #endif
 }
 
@@ -1239,12 +1238,12 @@ const
   // stores more information.
 
   // Check if distributed and unbalanced
-  CAROM_ASSERT(distributed() && !balanced());
+  CAROM_VERIFY(distributed() && !balanced());
 
   // Make sure arrays are allocated before entry; this method does not
   // own the input pointers
-  CAROM_ASSERT(row_pivot != NULL);
-  CAROM_ASSERT(row_pivot_owner != NULL);
+  CAROM_VERIFY(row_pivot != NULL);
+  CAROM_VERIFY(row_pivot_owner != NULL);
 
   // Compute total number of rows to set global sizes of matrix
   const MPI_Comm comm    = MPI_COMM_WORLD;
@@ -1252,7 +1251,7 @@ const
 
   int num_total_rows     = d_num_rows;
   const int reduce_count = 1;
-  CAROM_ASSERT(MPI_Allreduce(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &num_total_rows,
 			     reduce_count,
 			     MPI_INT,
@@ -1261,8 +1260,8 @@ const
 
   // Number of pivots requested can't exceed the total number of rows
   // of the matrix
-  CAROM_ASSERT(pivots_requested <= num_total_rows);
-  CAROM_ASSERT(pivots_requested > 0);
+  CAROM_VERIFY(pivots_requested <= num_total_rows);
+  CAROM_VERIFY(pivots_requested > 0);
 
   // To compute a column-pivoted QRCP using Elemental, we need to
   // first get the data into datatypes Elemental can operate on.
@@ -1274,7 +1273,7 @@ const
 
   // The row communicator in the grid should have the same number
   // of processes as the comm owned by the Matrix
-  CAROM_ASSERT(El::mpi::Size(grid.RowComm()) == d_num_procs);
+  CAROM_VERIFY(El::mpi::Size(grid.RowComm()) == d_num_procs);
 
   // Instantiate the transposed matrix; Elemental calls the number of
   // rows the "height" of the matrix, and the number of columns the
@@ -1295,11 +1294,11 @@ const
   // the row communicator) that owns j should be process rank (j %
   // d_num_procs).
   //
-  CAROM_ASSERT(scratch.RowOwner(0) == scratch.RowOwner(1));
+  CAROM_VERIFY(scratch.RowOwner(0) == scratch.RowOwner(1));
   int my_rank;
-  CAROM_ASSERT(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
+  CAROM_VERIFY(MPI_Comm_rank(comm, &my_rank) == MPI_SUCCESS);
   El::Int rank_as_row = static_cast<El::Int>(my_rank);
-  CAROM_ASSERT(scratch.ColOwner(rank_as_row) == rank_as_row);
+  CAROM_VERIFY(scratch.ColOwner(rank_as_row) == rank_as_row);
 
   // Set up work matrices
   El::DistMatrix<double> householder_scalars(grid);
@@ -1327,7 +1326,7 @@ const
 
   row_offset[my_rank] = d_num_rows;
   const int send_recv_count = 1;
-  CAROM_ASSERT(MPI_Allgather(MPI_IN_PLACE,
+  CAROM_VERIFY(MPI_Allgather(MPI_IN_PLACE,
 			     send_recv_count,
 			     MPI_INT,
 			     row_offset,
@@ -1335,10 +1334,10 @@ const
 			     MPI_INT,
 			     comm) == MPI_SUCCESS);
 
-  for (size_t i = d_num_procs - 1; i >= 0; i--) {
+  for (int i = d_num_procs - 1; i >= 0; i--) {
     row_offset[i] = row_offset[i + 1] - row_offset[i];
   }
-  CAROM_ASSERT(row_offset[0] == 0);
+  CAROM_VERIFY(row_offset[0] == 0);
 
   // Use the computed (local <--> global) index map to assign elements
   // to the scratch matrix
@@ -1386,7 +1385,7 @@ const
   // Free arrays
   delete [] row_offset;
 #else
-  CAROM_ASSERT(false);
+  CAROM_VERIFY(false);
 #endif
 }
 

--- a/Matrix.C
+++ b/Matrix.C
@@ -616,6 +616,21 @@ Matrix::inverse(
    delete [] work;
 }
 
+void Matrix::transpose()
+{
+  CAROM_ASSERT(numRows() == numColumns());  // Avoid resizing
+  const int n = numRows();
+  for (int i=0; i<n; ++i)
+    {
+      for (int j=0; j<n; ++j)
+	{
+	  double t = d_mat[i*n+j];
+	  d_mat[i*n+j] = d_mat[j*n+i];
+	  d_mat[j*n+i] = t;
+	}
+    }
+}
+
 void
 Matrix::inverse()
 {

--- a/Matrix.C
+++ b/Matrix.C
@@ -1037,7 +1037,6 @@ Matrix::qrcp_pivots_transpose_distributed_scalapack
   release_context(&slpk);
 
   free(QRmgr.ipiv);
-  free(QRmgr.tau);
   
   delete [] rcount;
   delete [] rdisp;

--- a/Matrix.h
+++ b/Matrix.h
@@ -685,6 +685,8 @@ class Matrix
       void
       inverse();
 
+      void transpose();
+      
       /**
        * @brief Compute the leading numColumns() column pivots from a
        * QR decomposition with column pivots (QRCP) of the transpose

--- a/Matrix.h
+++ b/Matrix.h
@@ -806,7 +806,7 @@ class Matrix
       */
      void read(const std::string& base_file_name);
 
-     double *getData()
+     double *getData() const
      {
        return d_mat;
      }

--- a/Matrix.h
+++ b/Matrix.h
@@ -937,6 +937,15 @@ class Matrix
 		       const int,
 		       const int);
 
+      friend void QDEIM(const Matrix*,
+			const int,
+			int*,
+			int*,
+			Matrix&,
+			const int,
+			const int,
+			const int);
+
       /**
        * @brief The storage for the Matrix's values on this processor.
        */

--- a/Matrix.h
+++ b/Matrix.h
@@ -804,6 +804,11 @@ class Matrix
       */
      void read(const std::string& base_file_name);
 
+     double *getData()
+     {
+       return d_mat;
+     }
+     
    private:
       /**
        * @brief Default constructor is not implemented.
@@ -845,6 +850,11 @@ class Matrix
        */
       void
       qrcp_pivots_transpose_distributed(int* row_pivot,
+					int* row_pivot_owner,
+					int  pivots_requested) const;
+
+      void
+      qrcp_pivots_transpose_distributed_scalapack(int* row_pivot,
 					int* row_pivot_owner,
 					int  pivots_requested) const;
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -685,8 +685,15 @@ class Matrix
       void
       inverse();
 
+      /**
+       * @brief Replaces this Matrix with its transpose (in place),
+       * in the serial square case only.
+       *
+       * @pre !distributed()
+       * @pre numRows() == numColumns()
+       */
       void transpose();
-      
+
       /**
        * @brief Compute the leading numColumns() column pivots from a
        * QR decomposition with column pivots (QRCP) of the transpose

--- a/QDEIM.C
+++ b/QDEIM.C
@@ -58,8 +58,7 @@ QDEIM(const Matrix* f_basis,
 
       int rank, num_procs;
       {
-	const bool success = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-	CAROM_ASSERT(success);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	CAROM_ASSERT(rank == myid);
 	MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
       }
@@ -114,7 +113,7 @@ QDEIM(const Matrix* f_basis,
 				 MPI_INT, MPI_COMM_WORLD) == MPI_SUCCESS);
 
       int os = 0;
-      for (int i=0; i<rank; ++i)
+      for (int i=0; i<num_procs; ++i)
 	{
 	  os += row_offset[i];
 	  row_offset[i] = os - row_offset[i];
@@ -140,18 +139,18 @@ QDEIM(const Matrix* f_basis,
       
       MPI_Gatherv(my_sampled_row_data, count*num_basis_vectors_used, MPI_DOUBLE, f_basis_sampled_inv.getData(), n, disp, MPI_DOUBLE, 0, MPI_COMM_WORLD);
       
-      delete [] n;
-      delete [] disp;
-      delete [] my_sampled_rows;
-      delete [] all_sampled_rows;
-      delete [] row_offset;
-
       // Subtract row_offset to convert f_sampled_row from global to local indices
       os = row_offset[rank];
       for (int i=0; i<num_basis_vectors_used; ++i)
 	{
 	  f_sampled_row[i] -= os;
 	}
+
+      delete [] n;
+      delete [] disp;
+      delete [] my_sampled_rows;
+      delete [] all_sampled_rows;
+      delete [] row_offset;
     }
   else
     {

--- a/QDEIM.C
+++ b/QDEIM.C
@@ -29,7 +29,7 @@ QDEIM(const Matrix* f_basis,
       int* f_sampled_row,
       int* f_sampled_row_owner,
       Matrix& f_basis_sampled,
-      int myid)
+      const int myid)
 {
   // This algorithm determines the rows of f that should be sampled, the
   // processor that owns each sampled row, and fills f_basis_sampled with the
@@ -37,8 +37,8 @@ QDEIM(const Matrix* f_basis,
 
   // Compute the number of basis vectors used; this number can't
   // exceed the number of columns of the matrix.
-  int num_basis_vectors_used = std::min(num_f_basis_vectors_used,
-					f_basis->numColumns());
+  const int num_basis_vectors_used = std::min(num_f_basis_vectors_used,
+					      f_basis->numColumns());
 
   // QDEIM computes selection/interpolation indices by taking a
   // column-pivoted QR-decomposition of the transpose of its input
@@ -47,14 +47,107 @@ QDEIM(const Matrix* f_basis,
 				 f_sampled_row_owner,
 				 num_basis_vectors_used);
 
-  // With the known interpolation (sample) indices, copy over the
-  // rows of the sampled basis
-  for (int i = 0; i < num_basis_vectors_used; i++) {
-    for (int j = 0; j < num_basis_vectors_used; j++) {
-      f_basis_sampled.item(i, j) = f_basis->item(f_sampled_row[i], j);
-    }
-  }
+  if (f_basis->distributed())
+    {
+      // Gather the sampled rows to root process in f_basis_sampled
 
+      // On root, f_sampled_row* contains all global pivots.
+      // On non-root processes, they contain the local pivots.
+
+      int rank, num_procs;
+      {
+	const bool success = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	CAROM_ASSERT(success);
+	CAROM_ASSERT(rank == myid);
+	MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+      }
+      
+      int * n = (rank == 0) ? new int[num_procs] : NULL;
+      int * disp = (rank == 0) ? new int[num_procs] : NULL;
+      int * all_sampled_rows = (rank == 0) ? new int[num_basis_vectors_used] : NULL;
+      if (rank == 0)
+	{
+	  for (int r=0; r<num_procs; ++r)
+	    n[r] = 0;
+
+	  for (int i=0; i<num_basis_vectors_used; ++i)
+	    n[f_sampled_row_owner[i]]++;
+
+	  disp[0] = 0;
+	  for (int r=1; r<num_procs; ++r)
+	    disp[r] = disp[r-1] + n[r-1];
+
+	  CAROM_ASSERT(disp[num_procs-1] + n[num_procs-1] == num_basis_vectors_used);
+
+	  for (int r=0; r<num_procs; ++r)
+	    n[r] = 0;
+
+	  for (int i=0; i<num_basis_vectors_used; ++i)
+	    {
+	      const int owner = f_sampled_row_owner[i];
+	      all_sampled_rows[disp[owner] + n[owner]] = f_sampled_row[i];
+	      n[owner]++;
+	    }
+	}
+
+      int count = 0;
+      MPI_Scatter(n, 1, MPI_INT, &count, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+      int * my_sampled_rows = (count > 0) ? new int[count] : NULL;
+      double * my_sampled_row_data = (count > 0) ? new double[count*num_basis_vectors_used] : NULL;
+
+      MPI_Scatterv(all_sampled_rows, n, disp, MPI_INT, my_sampled_rows, count, MPI_INT, 0, MPI_COMM_WORLD);
+
+      int *row_offset = new int[num_procs];
+      row_offset[rank] = f_basis->numRows();
+
+      CAROM_ASSERT(MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT, row_offset, 1,
+				 MPI_INT, MPI_COMM_WORLD) == MPI_SUCCESS);
+
+      int os = 0;
+      for (int i=0; i<rank; ++i)
+	{
+	  os += row_offset[i];
+	  row_offset[i] = os - row_offset[i];
+	}
+      
+      for (int i=0; i<count; ++i)
+	{
+	  CAROM_ASSERT(my_sampled_rows[i] >= row_offset[rank] && my_sampled_rows[i] < row_offset[rank] + f_basis->numRows());
+	  const int row = my_sampled_rows[i] - row_offset[rank];
+	  os = i*num_basis_vectors_used;
+	  for (int j=0; j<num_basis_vectors_used; ++j)
+	    my_sampled_row_data[os + j] = f_basis->item(row, j);
+	}
+
+      if (rank == 0)
+	{
+	  for (int r=0; r<num_procs; ++r)
+	    {
+	      n[r] *= num_basis_vectors_used;
+	      disp[r] *= num_basis_vectors_used;
+	    }
+	}
+      
+      MPI_Gatherv(my_sampled_row_data, count*num_basis_vectors_used, MPI_DOUBLE, f_basis_sampled.getData(), n, disp, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+      
+      delete [] n;
+      delete [] disp;
+      delete [] my_sampled_rows;
+      delete [] all_sampled_rows;
+      delete [] row_offset;
+    }
+  else
+    {
+      // With the known interpolation (sample) indices, copy over the
+      // rows of the sampled basis
+      for (int i = 0; i < num_basis_vectors_used; i++) {
+	for (int j = 0; j < num_basis_vectors_used; j++) {
+	  f_basis_sampled.item(i, j) = f_basis->item(f_sampled_row[i], j);
+	}
+      }
+    }
+  
 } // end void QDEIM
 
 } // end namespace CAROM

--- a/QDEIM.C
+++ b/QDEIM.C
@@ -29,25 +29,25 @@ QDEIM(const Matrix* f_basis,
       int* f_sampled_row,
       int* f_sampled_rows_per_proc,
       Matrix& f_basis_sampled_inv,
-      const int myid)
+      const int myid,
+      const int num_procs,
+      const int num_samples_req)
 {
   // This algorithm determines the rows of f that should be sampled, the
   // processor that owns each sampled row, and fills f_basis_sampled_inv with the
   // sampled rows of the basis of the RHS.
 
-  // Compute the number of basis vectors used; this number can't
-  // exceed the number of columns of the matrix.
-  const int num_basis_vectors_used = std::min(num_f_basis_vectors_used,
-					      f_basis->numColumns());
-
-  int *f_sampled_row_owner = new int[num_basis_vectors_used];
+  CAROM_VERIFY(num_f_basis_vectors_used == f_basis->numColumns());  // The QR implementation uses the entire matrix.
+  CAROM_VERIFY(f_basis->numColumns() <= num_samples_req && num_samples_req <= f_basis->numRows());
+  
+  int *f_sampled_row_owner = new int[num_samples_req];
 
   // QDEIM computes selection/interpolation indices by taking a
   // column-pivoted QR-decomposition of the transpose of its input
   // matrix.
   f_basis->qrcp_pivots_transpose(f_sampled_row,
 				 f_sampled_row_owner,
-				 num_basis_vectors_used);
+				 num_samples_req);
 
   if (f_basis->distributed())
     {
@@ -55,30 +55,23 @@ QDEIM(const Matrix* f_basis,
 
       // On root, f_sampled_row* contains all global pivots.
       // On non-root processes, they contain the local pivots.
-
-      int rank, num_procs;
-      {
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-	CAROM_ASSERT(rank == myid);
-	MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-      }
       
-      int * n = (rank == 0) ? new int[num_procs] : NULL;
-      int * disp = (rank == 0) ? new int[num_procs] : NULL;
-      int * all_sampled_rows = (rank == 0) ? new int[num_basis_vectors_used] : NULL;
-      if (rank == 0)
+      int * n = (myid == 0) ? new int[num_procs] : NULL;
+      int * disp = (myid == 0) ? new int[num_procs] : NULL;
+      int * all_sampled_rows = (myid == 0) ? new int[num_samples_req] : NULL;
+      if (myid == 0)
 	{
 	  for (int r=0; r<num_procs; ++r)
 	    n[r] = 0;
 
-	  for (int i=0; i<num_basis_vectors_used; ++i)
+	  for (int i=0; i<num_samples_req; ++i)
 	    n[f_sampled_row_owner[i]]++;
 
 	  disp[0] = 0;
 	  for (int r=1; r<num_procs; ++r)
 	    disp[r] = disp[r-1] + n[r-1];
 
-	  CAROM_ASSERT(disp[num_procs-1] + n[num_procs-1] == num_basis_vectors_used);
+	  CAROM_VERIFY(disp[num_procs-1] + n[num_procs-1] == num_samples_req);
 
 	  for (int r=0; r<num_procs; ++r)
 	    {
@@ -86,7 +79,7 @@ QDEIM(const Matrix* f_basis,
 	      n[r] = 0;
 	    }
 	  
-	  for (int i=0; i<num_basis_vectors_used; ++i)
+	  for (int i=0; i<num_samples_req; ++i)
 	    {
 	      const int owner = f_sampled_row_owner[i];
 	      all_sampled_rows[disp[owner] + n[owner]] = f_sampled_row[i];
@@ -102,14 +95,14 @@ QDEIM(const Matrix* f_basis,
       MPI_Scatter(n, 1, MPI_INT, &count, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
       int * my_sampled_rows = (count > 0) ? new int[count] : NULL;
-      double * my_sampled_row_data = (count > 0) ? new double[count*num_basis_vectors_used] : NULL;
+      double * my_sampled_row_data = (count > 0) ? new double[count*num_f_basis_vectors_used] : NULL;
 
       MPI_Scatterv(all_sampled_rows, n, disp, MPI_INT, my_sampled_rows, count, MPI_INT, 0, MPI_COMM_WORLD);
 
       int *row_offset = new int[num_procs];
-      row_offset[rank] = f_basis->numRows();
+      row_offset[myid] = f_basis->numRows();
 
-      CAROM_ASSERT(MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT, row_offset, 1,
+      CAROM_VERIFY(MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT, row_offset, 1,
 				 MPI_INT, MPI_COMM_WORLD) == MPI_SUCCESS);
 
       int os = 0;
@@ -121,27 +114,27 @@ QDEIM(const Matrix* f_basis,
       
       for (int i=0; i<count; ++i)
 	{
-	  CAROM_ASSERT(my_sampled_rows[i] >= row_offset[rank] && my_sampled_rows[i] < row_offset[rank] + f_basis->numRows());
-	  const int row = my_sampled_rows[i] - row_offset[rank];
-	  os = i*num_basis_vectors_used;
-	  for (int j=0; j<num_basis_vectors_used; ++j)
+	  CAROM_VERIFY(my_sampled_rows[i] >= row_offset[myid] && my_sampled_rows[i] < row_offset[myid] + f_basis->numRows());
+	  const int row = my_sampled_rows[i] - row_offset[myid];
+	  os = i*num_f_basis_vectors_used;
+	  for (int j=0; j<num_f_basis_vectors_used; ++j)
 	    my_sampled_row_data[os + j] = f_basis->item(row, j);
 	}
 
-      if (rank == 0)
+      if (myid == 0)
 	{
 	  for (int r=0; r<num_procs; ++r)
 	    {
-	      n[r] *= num_basis_vectors_used;
-	      disp[r] *= num_basis_vectors_used;
+	      n[r] *= num_f_basis_vectors_used;
+	      disp[r] *= num_f_basis_vectors_used;
 	    }
 	}
       
-      MPI_Gatherv(my_sampled_row_data, count*num_basis_vectors_used, MPI_DOUBLE, f_basis_sampled_inv.getData(), n, disp, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+      MPI_Gatherv(my_sampled_row_data, count*num_f_basis_vectors_used, MPI_DOUBLE, f_basis_sampled_inv.getData(), n, disp, MPI_DOUBLE, 0, MPI_COMM_WORLD);
       
       // Subtract row_offset to convert f_sampled_row from global to local indices
-      os = row_offset[rank];
-      for (int i=0; i<num_basis_vectors_used; ++i)
+      os = row_offset[myid];
+      for (int i=0; i<num_f_basis_vectors_used; ++i)
 	{
 	  f_sampled_row[i] -= os;
 	}
@@ -156,22 +149,19 @@ QDEIM(const Matrix* f_basis,
     {
       // With the known interpolation (sample) indices, copy over the
       // rows of the sampled basis
-      for (int i = 0; i < num_basis_vectors_used; i++) {
-	for (int j = 0; j < num_basis_vectors_used; j++) {
+      for (int i = 0; i < num_samples_req; i++) {
+	for (int j = 0; j < num_f_basis_vectors_used; j++) {
 	  f_basis_sampled_inv.item(i, j) = f_basis->item(f_sampled_row[i], j);
 	}
       }
 
-      f_sampled_rows_per_proc[0] = num_basis_vectors_used;
+      f_sampled_rows_per_proc[0] = num_f_basis_vectors_used;
     }
 
   delete [] f_sampled_row_owner;
   
   // Now invert f_basis_sampled_inv, storing its transpose.
-  //f_basis_sampled_inv.transposePseudoinverse();  // TODO?
-  
-  f_basis_sampled_inv.inverse();
-  f_basis_sampled_inv.transpose();
+  f_basis_sampled_inv.transposePseudoinverse();
 } // end void QDEIM
 
 } // end namespace CAROM

--- a/QDEIM.C
+++ b/QDEIM.C
@@ -15,6 +15,19 @@
 #include "mpi.h"
 #include <cmath>
 
+#include <vector>
+#include <set>
+#include <algorithm>
+
+/* Use Autotools-detected Fortran name-mangling scheme */
+#define dgesdd CAROM_FC_GLOBAL(dgesdd, DGESDD)
+
+extern "C" {
+void dgesdd(char*, int*, int*, double*, int*,
+             double*, double*, int*, double*, int*,
+             double*, int*, int*, int*);
+}
+
 namespace CAROM {
 
   /* Implement QDEIM algorithm from Zlatko Drmac, Serkan Gugercin, "A
@@ -39,52 +52,60 @@ QDEIM(const Matrix* f_basis,
 
   CAROM_VERIFY(num_f_basis_vectors_used == f_basis->numColumns());  // The QR implementation uses the entire matrix.
   CAROM_VERIFY(f_basis->numColumns() <= num_samples_req && num_samples_req <= f_basis->numRows());
+
+  // QR will determine (numCol) pivots, which will define the first (numCol) samples.
+  const int numCol = f_basis->numColumns();
+  const int num_samples_req_QR = numCol;
   
-  int *f_sampled_row_owner = new int[num_samples_req];
+  int *f_sampled_row_owner = (myid == 0 && f_basis->distributed()) ? new int[num_samples_req] : NULL;
 
   // QDEIM computes selection/interpolation indices by taking a
   // column-pivoted QR-decomposition of the transpose of its input
   // matrix.
   f_basis->qrcp_pivots_transpose(f_sampled_row,
 				 f_sampled_row_owner,
-				 num_samples_req);
+				 num_samples_req_QR);
 
   if (f_basis->distributed())
     {
       // Gather the sampled rows to root process in f_basis_sampled_inv
 
-      // On root, f_sampled_row* contains all global pivots.
-      // On non-root processes, they contain the local pivots.
+      // On root, f_sampled_row contains all global pivots.
+      // On non-root processes, it contains the local pivots.
       
-      int * n = (myid == 0) ? new int[num_procs] : NULL;
+      int * ns = (myid == 0) ? new int[num_procs] : NULL;
       int * disp = (myid == 0) ? new int[num_procs] : NULL;
       int * all_sampled_rows = (myid == 0) ? new int[num_samples_req] : NULL;
       if (myid == 0)
 	{
 	  for (int r=0; r<num_procs; ++r)
-	    n[r] = 0;
+	    ns[r] = 0;
 
-	  for (int i=0; i<num_samples_req; ++i)
-	    n[f_sampled_row_owner[i]]++;
+	  for (int i=0; i<num_samples_req_QR; ++i)
+	    ns[f_sampled_row_owner[i]]++;
 
 	  disp[0] = 0;
 	  for (int r=1; r<num_procs; ++r)
-	    disp[r] = disp[r-1] + n[r-1];
+	    disp[r] = disp[r-1] + ns[r-1];
 
-	  CAROM_VERIFY(disp[num_procs-1] + n[num_procs-1] == num_samples_req);
+	  CAROM_VERIFY(disp[num_procs-1] + ns[num_procs-1] == num_samples_req_QR);
 
 	  for (int r=0; r<num_procs; ++r)
 	    {
-	      f_sampled_rows_per_proc[r] = n[r];
-	      n[r] = 0;
+	      f_sampled_rows_per_proc[r] = ns[r];
+	      ns[r] = 0;
 	    }
 	  
-	  for (int i=0; i<num_samples_req; ++i)
+	  for (int i=0; i<num_samples_req_QR; ++i)
 	    {
 	      const int owner = f_sampled_row_owner[i];
-	      all_sampled_rows[disp[owner] + n[owner]] = f_sampled_row[i];
-	      n[owner]++;
+	      all_sampled_rows[disp[owner] + ns[owner]] = f_sampled_row[i];
+	      ns[owner]++;
 	    }
+
+	  // Reorder f_sampled_row and f_sampled_row_owner to match the order of f_basis_sampled_inv
+	  for (int i=0; i<num_samples_req_QR; ++i)
+	    f_sampled_row[i] = all_sampled_rows[i];
 	}
 
       MPI_Bcast(f_sampled_rows_per_proc, num_procs, MPI_INT, 0, MPI_COMM_WORLD);
@@ -92,12 +113,12 @@ QDEIM(const Matrix* f_basis,
       // TODO: eliminate n and the following MPI_Scatter
       
       int count = 0;
-      MPI_Scatter(n, 1, MPI_INT, &count, 1, MPI_INT, 0, MPI_COMM_WORLD);
+      MPI_Scatter(ns, 1, MPI_INT, &count, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
       int * my_sampled_rows = (count > 0) ? new int[count] : NULL;
-      double * my_sampled_row_data = (count > 0) ? new double[count*num_f_basis_vectors_used] : NULL;
+      double * my_sampled_row_data = (count > 0) ? new double[count*num_f_basis_vectors_used] : NULL;  // TODO: change to numCol
 
-      MPI_Scatterv(all_sampled_rows, n, disp, MPI_INT, my_sampled_rows, count, MPI_INT, 0, MPI_COMM_WORLD);
+      MPI_Scatterv(all_sampled_rows, ns, disp, MPI_INT, my_sampled_rows, count, MPI_INT, 0, MPI_COMM_WORLD);
 
       int *row_offset = new int[num_procs];
       row_offset[myid] = f_basis->numRows();
@@ -127,13 +148,196 @@ QDEIM(const Matrix* f_basis,
 	{
 	  for (int r=0; r<num_procs; ++r)
 	    {
-	      n[r] *= num_f_basis_vectors_used;
+	      ns[r] *= num_f_basis_vectors_used;
 	      disp[r] *= num_f_basis_vectors_used;
 	    }
 	}
+
+      // TODO: use numCols instead of num_f_basis_vectors_used
+      MPI_Gatherv(my_sampled_row_data, count*num_f_basis_vectors_used, MPI_DOUBLE, f_basis_sampled_inv.getData(), ns, disp, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+      // At this point, only the first (numCol) entries of f_sampled_row and rows of f_basis_sampled_inv are set by QR.
+      // Now set the remaining (num_samples_req - numCol) samples by GappyPOD+E.
+      double *A = (myid == 0) ? new double[num_samples_req * numCol] : NULL;
+
+      const int nf = f_basis->numRows();
+
+      std::vector<int> rcnt(num_procs);
+      std::vector<int> rdsp(num_procs);
+      MPI_Gather(&nf, 1, MPI_INT, rcnt.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+      int nglobal = 0;
+      rdsp[0] = 0;
+      if (myid == 0)
+	{
+	  for (int i=0; i<num_procs; ++i)
+	    nglobal += rcnt[i];
+
+	  for (int i=1; i<num_procs; ++i)
+	    rdsp[i] = rdsp[i-1] + rcnt[i-1];
+	}
+
+      std::set<int> globalSamples;
+      if (myid == 0)
+	{
+	  int count = 0;
+	  for (int i=0; i<num_procs; ++i)
+	    {
+	      for (int j=0; j<f_sampled_rows_per_proc[i]; ++j, ++count)
+		{
+		  //globalSamples.insert(f_sampled_row[count] + row_offset[i]);
+		  globalSamples.insert(f_sampled_row[count]);
+		}
+	    }
+
+	  CAROM_VERIFY(count == numCol);
+	}
       
-      MPI_Gatherv(my_sampled_row_data, count*num_f_basis_vectors_used, MPI_DOUBLE, f_basis_sampled_inv.getData(), n, disp, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+      std::vector<double> rg;
+      if (myid == 0) rg.resize(nglobal);
+
+      std::vector<int> isort(nglobal);
+
+      int n = numCol;
+      Matrix V(n, n, false);
       
+      for (int s = numCol; s < num_samples_req; ++s)  // Determine sample s
+	{
+	  int m = s;
+
+	  double g = 0.0;
+	  if (myid == 0)
+	    {
+	      // Compute SVD of the first s rows of f_basis_sampled_inv locally on root
+	      CAROM_VERIFY(!f_basis_sampled_inv.distributed());
+
+	      //Matrix Ut(n, m, false);global
+
+	      // Use lapack's dgesdd Fortran function to perform the svd. As this is
+	      // Fortran, A and all the computed matrices are in column major order.
+
+	      for (int i=0; i<m; ++i)
+		for (int j=0; j<n; ++j)
+		  {
+		    A[i + (j*m)] = f_basis_sampled_inv.item(i, j);
+		    //Ut.item(j, i) = f_basis_sampled_inv.item(i, j);
+		  }
+
+	      std::vector<double> sigma(n);
+	      char jobz = 'O';
+	      int lda = m;
+	      int ldu = 1;
+	      int ldv = n;
+	      int lwork = (3*n) + std::max(m, (5*n*n) + (4*n));
+	      double* work = new double [lwork];
+	      int iwork[8*n];
+	      int info;
+	      dgesdd(&jobz, &m, &n, A, &lda, sigma.data(), NULL, &ldu, &V.item(0, 0),
+		     &ldv, work, &lwork, iwork, &info);
+
+	      CAROM_VERIFY(info == 0);
+
+	      delete [] work;
+
+	      g = (sigma[n-2] * sigma[n-2]) - (sigma[n-1] * sigma[n-1]);
+
+	      // Note that V stores the right singular vectors row-wise
+
+	      // Set Ub = V' * U'
+	      //Matrix *Ub = V.mult(Ut);  // size n x m
+
+	      // Set Ubt = U * V
+	      V.transpose();
+	    }
+
+	  MPI_Bcast(&g, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+	  // Broadcast the small n-by-n undistributed matrix V which is computed only on root.
+	  MPI_Bcast(V.getData(), n*n, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+	  Matrix *Ubt = f_basis->mult(V);  // distributed
+
+	  CAROM_VERIFY(Ubt->distributed() && Ubt->numRows() == f_basis->numRows() && Ubt->numColumns() == n);
+
+	  std::vector<double> r(nf);
+
+	  for (int i=0; i<nf; ++i)
+	    {
+	      r[i] = g;
+	      for (int j=0; j<n; ++j)
+		r[i] += Ubt->item(i, j) * Ubt->item(i, j);  // column sums of Ub.^2, which are row sums of Ubt.^2
+
+	      r[i] -= sqrt((r[i] * r[i]) - (4.0 * g * Ubt->item(i, n-1) * Ubt->item(i, n-1)));
+	    }
+
+	  MPI_Gatherv(r.data(), nf, MPI_DOUBLE, rg.data(), rcnt.data(), rdsp.data(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+	  int owner = -1;
+	  if (myid == 0)
+	    {
+	      for (int i=0; i<nglobal; ++i)
+		{
+		  isort[i] = i;
+		}
+
+	      //std::sort(isort.begin(), isort.end(), std::greater<double>());  // descending order
+	      std::sort(isort.begin(), isort.end(), [&](const int& a, const int& b) {
+		  return (rg[a] > rg[b]); }
+		);  // descending order
+
+	      // Choose sample s as the first entry in isort not already in f_sampled_row
+	      f_sampled_row[s] = -1;
+	      for (int i=0; i<nglobal; ++i)
+		{
+		  std::set<int>::iterator it = globalSamples.find(isort[i]);
+		  if (it == globalSamples.end()) // not found
+		    {
+		      CAROM_VERIFY(i < s-1 && f_sampled_row[s] == -1);
+		      f_sampled_row[s] = isort[i];
+		      break;
+		    }
+		}
+
+	      CAROM_VERIFY(f_sampled_row[s] >= 0);
+	      for (int i=num_procs-1; i >= 0; --i)
+		{
+		  if (f_sampled_row[s] >= row_offset[i])
+		    {
+		      owner = i;
+		      break;
+		    }
+		}
+
+	      CAROM_VERIFY(owner >= 0);
+	      f_sampled_rows_per_proc[owner]++;
+	      f_sampled_row_owner[s] = owner;
+
+	      for (int i=0; i < num_procs; ++i)
+		ns[i] = -1;
+
+	      ns[owner] = f_sampled_row[s];
+	      globalSamples.insert(f_sampled_row[s]);
+	    }
+
+	  // Send one row of f_basis, corresponding to sample s, to root process for f_basis_sampled_inv
+	  // First, scatter from root to tell the owning process the sample index.
+
+	  int sample = -1;
+	  MPI_Scatter(ns, 1, MPI_INT, &sample, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+	  const int tagSendRecv = 111;
+	  if (sample > -1)
+	    MPI_Send(f_basis->getData() + (sample * numCol), numCol, MPI_DOUBLE, 0, tagSendRecv, MPI_COMM_WORLD);
+
+	  if (myid == 0)
+	    {
+	      MPI_Status status;
+	      MPI_Recv(f_basis_sampled_inv.getData() + (s*numCol), numCol, MPI_DOUBLE, owner, tagSendRecv, MPI_COMM_WORLD, &status);
+	    }
+
+	  delete Ubt;
+	}  // loop s over samples
+
       // Subtract row_offset to convert f_sampled_row from global to local indices
       // Also, reorder f_sampled_row by process
       /*
@@ -143,29 +347,38 @@ QDEIM(const Matrix* f_basis,
 	  f_sampled_row[i] -= os;
 	}
       */
-      
+
       if (myid == 0)
 	{
-	  n[0] = 0;
+	  ns[0] = 0;
 	  disp[0] = 0;
 	  for (int r=1; r<num_procs; ++r)
 	    {
-	      n[r] = 0;
+	      ns[r] = 0;
 	      disp[r] = disp[r-1] + f_sampled_rows_per_proc[r-1];
 	    }
-	  
+
 	  for (int i=0; i<num_samples_req; ++i)
 	    {
 	      const int owner = f_sampled_row_owner[i];
 	      f_sampled_row[i] -= row_offset[owner];
 
-	      all_sampled_rows[disp[owner] + n[owner]] = f_sampled_row[i];
-	      n[owner]++;
+	      all_sampled_rows[disp[owner] + ns[owner]] = f_sampled_row[i];
+
+	      // Swap rows i and (disp[owner] + ns[owner]) of f_basis_sampled_inv
+	      for (int j=0; j<numCol; ++j)
+		{
+		  const double t = f_basis_sampled_inv.item(i, j);
+		  f_basis_sampled_inv.item(i, j) = f_basis_sampled_inv.item(disp[owner] + ns[owner], j);
+		  f_basis_sampled_inv.item(disp[owner] + ns[owner], j) = t;
+		}
+
+	      ns[owner]++;
 	    }
 
 	  for (int r=0; r<num_procs; ++r)
 	    {
-	      CAROM_VERIFY(n[r] == f_sampled_rows_per_proc[r]);
+	      CAROM_VERIFY(ns[r] == f_sampled_rows_per_proc[r]);
 	    }
 
 	  for (int i=0; i<num_samples_req; ++i)
@@ -173,18 +386,19 @@ QDEIM(const Matrix* f_basis,
 	}
 
       MPI_Bcast(f_sampled_row, num_samples_req, MPI_INT, 0, MPI_COMM_WORLD);
-      
-      delete [] n;
+
+      delete [] A;
+      delete [] row_offset;
+      delete [] ns;
       delete [] disp;
       delete [] my_sampled_rows;
       delete [] all_sampled_rows;
-      delete [] row_offset;
     }
   else
     {
       // With the known interpolation (sample) indices, copy over the
       // rows of the sampled basis
-      for (int i = 0; i < num_samples_req; i++) {
+      for (int i = 0; i < num_samples_req_QR; i++) {
 	for (int j = 0; j < num_f_basis_vectors_used; j++) {
 	  f_basis_sampled_inv.item(i, j) = f_basis->item(f_sampled_row[i], j);
 	}
@@ -194,6 +408,11 @@ QDEIM(const Matrix* f_basis,
     }
 
   delete [] f_sampled_row_owner;
+
+  if (!f_basis->distributed())
+    {
+      CAROM_VERIFY(false);  // TODO: implement GappyPOD+E for this case
+    }
   
   // Now invert f_basis_sampled_inv, storing its transpose.
   if (myid == 0)  // Matrix is valid only on root process

--- a/QDEIM.h
+++ b/QDEIM.h
@@ -24,8 +24,9 @@ QDEIM(const Matrix* f_basis,
       int* f_sampled_row,
       int* f_sampled_row_owner,
       Matrix& f_basis_sampled,
-      int myid);
-
+      int myid,
+      const int num_procs,
+      const int num_samples_req);
 }
 
 #endif

--- a/StaticSVD.C
+++ b/StaticSVD.C
@@ -59,7 +59,7 @@ StaticSVD::StaticSVD(
    if (d_total_dim % d_nprow != 0) { d_blocksize += 1; }
 
    initialize_matrix(d_samples.get(), d_total_dim, d_samples_per_time_interval,
-                     d_nprow, d_npcol, d_blocksize, d_blocksize);
+                     d_nprow, d_npcol, d_blocksize, d_blocksize);  // TODO: should nb = 1?
    d_factorizer->A = nullptr;
 }
 

--- a/scalapack_c_wrapper.c
+++ b/scalapack_c_wrapper.c
@@ -38,11 +38,7 @@ void qr_init(struct QRManager* mgr, struct SLPK_Matrix* A)
 {
     mgr->A = A;
     mgr->ipiv = NULL;
-    mgr->tau = NULL;
-    mgr->work = NULL;
     mgr->ipivSize = 0;
-    mgr->tauSize = 0;
-    mgr->lwork = 0;
 }
 
 void factorize_prep(struct SVDManager* mgr)
@@ -69,19 +65,9 @@ void factorize_prep(struct SVDManager* mgr)
 
 void qrfactorize_prep(struct QRManager* mgr)
 {
-  // TODO: clean this up. Remove tau from QRManager?
-  //struct SLPK_Matrix* A = mgr->A;
     if (mgr->ipiv == NULL && mgr->ipivSize > 0) {
         mgr->ipiv = malloc(sizeof(int) * mgr->ipivSize);
     }
-    if (mgr->tau == NULL && mgr->tauSize > 0) {
-        mgr->tau = malloc(sizeof(double) * mgr->tauSize);
-    }
-    /*
-    if (mgr->work == NULL && mgr->lwork > 0) {
-        mgr->work = malloc(sizeof(double) * mgr->lwork);
-    }
-    */
 }
 
 typedef void (* void_func)(void*);

--- a/scalapack_c_wrapper.c
+++ b/scalapack_c_wrapper.c
@@ -69,16 +69,19 @@ void factorize_prep(struct SVDManager* mgr)
 
 void qrfactorize_prep(struct QRManager* mgr)
 {
-    struct SLPK_Matrix* A = mgr->A;
+  // TODO: clean this up. Remove tau from QRManager?
+  //struct SLPK_Matrix* A = mgr->A;
     if (mgr->ipiv == NULL && mgr->ipivSize > 0) {
         mgr->ipiv = malloc(sizeof(int) * mgr->ipivSize);
     }
     if (mgr->tau == NULL && mgr->tauSize > 0) {
         mgr->tau = malloc(sizeof(double) * mgr->tauSize);
     }
+    /*
     if (mgr->work == NULL && mgr->lwork > 0) {
         mgr->work = malloc(sizeof(double) * mgr->lwork);
     }
+    */
 }
 
 typedef void (* void_func)(void*);

--- a/scalapack_c_wrapper.c
+++ b/scalapack_c_wrapper.c
@@ -34,6 +34,17 @@ void svd_init(struct SVDManager* mgr, struct SLPK_Matrix* A)
     mgr->done = 0;
 }
 
+void qr_init(struct QRManager* mgr, struct SLPK_Matrix* A)
+{
+    mgr->A = A;
+    mgr->ipiv = NULL;
+    mgr->tau = NULL;
+    mgr->work = NULL;
+    mgr->ipivSize = 0;
+    mgr->tauSize = 0;
+    mgr->lwork = 0;
+}
+
 void factorize_prep(struct SVDManager* mgr)
 {
     struct SLPK_Matrix* A = mgr->A;
@@ -53,6 +64,20 @@ void factorize_prep(struct SVDManager* mgr)
     
     if (mgr->S == NULL) {
         mgr->S = malloc(sizeof(REAL_TYPE) * SIZE);
+    }
+}
+
+void qrfactorize_prep(struct QRManager* mgr)
+{
+    struct SLPK_Matrix* A = mgr->A;
+    if (mgr->ipiv == NULL && mgr->ipivSize > 0) {
+        mgr->ipiv = malloc(sizeof(int) * mgr->ipivSize);
+    }
+    if (mgr->tau == NULL && mgr->tauSize > 0) {
+        mgr->tau = malloc(sizeof(double) * mgr->tauSize);
+    }
+    if (mgr->work == NULL && mgr->lwork > 0) {
+        mgr->work = malloc(sizeof(double) * mgr->lwork);
     }
 }
 

--- a/scalapack_wrapper.h
+++ b/scalapack_wrapper.h
@@ -281,8 +281,7 @@ struct QRManager
 {
     struct SLPK_Matrix* A;
     int* ipiv;
-  double *tau, *work;  // TODO: remove work?
-  int ipivSize, tauSize, lwork;
+    int ipivSize;
 };
 
 void qr_init(struct QRManager* mgr, struct SLPK_Matrix* A);

--- a/scalapack_wrapper.h
+++ b/scalapack_wrapper.h
@@ -69,7 +69,7 @@ struct SLPK_Matrix
     int pi, pj;
     int mb, nb;
 
-    // Parameters desribing the local storage layout
+    // Parameters describing the local storage layout
     int mm, mn;
     REAL_TYPE* mdata;
 };
@@ -277,6 +277,18 @@ void wrapper_finalize();
  */
 void print_debug_info(struct SLPK_Matrix* A);
 
+struct QRManager
+{
+    struct SLPK_Matrix* A;
+    int* ipiv;
+  int ipivSize, tauSize, lwork;
+  double *tau, *work;  // TODO: remove work?
+};
+
+void qr_init(struct QRManager* mgr, struct SLPK_Matrix* A);
+
+void qrfactorize(struct QRManager*);
+  
 #ifdef __cplusplus
 }
 #endif

--- a/scalapack_wrapper.h
+++ b/scalapack_wrapper.h
@@ -281,8 +281,8 @@ struct QRManager
 {
     struct SLPK_Matrix* A;
     int* ipiv;
-  int ipivSize, tauSize, lwork;
   double *tau, *work;  // TODO: remove work?
+  int ipivSize, tauSize, lwork;
 };
 
 void qr_init(struct QRManager* mgr, struct SLPK_Matrix* A);


### PR DESCRIPTION
QDEIM is implemented, as an alternative to DEIM and GNAT, with oversampling done by GappyPOD+E (see https://arxiv.org/abs/1808.10473). The first samples (numbering up to the basis dimension) for QDEIM are computed using parallel QR with column pivoting for the transposed basis matrix, via `pdgeqpf` in scalapack.

The only validation of this code is its application in Laghos, which has some good results but does not truly validate the QR or QDEIM implementations.