### PR TITLE
Test/gnat tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,6 @@ script:
   - ./test_SVD
   - ./test_Vector
   - ./test_Matrix
+  - ./test_DEIM
+  - ./test_GNAT
   - ./test_IncrementalSVD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ if(GTEST_FOUND)
   set(unit_test_stems
     Vector
     Matrix
+    DEIM
     SVD
     StaticSVD
     IncrementalSVD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if(GTEST_FOUND)
     Vector
     Matrix
     DEIM
+    GNAT
     SVD
     StaticSVD
     IncrementalSVD)

--- a/DEIM.C
+++ b/DEIM.C
@@ -91,6 +91,8 @@ DEIM(const Matrix* f_basis,
    CAROM_VERIFY(0 < num_f_basis_vectors_used && num_f_basis_vectors_used <= f_basis->numColumns());
    int num_basis_vectors =
       std::min(num_f_basis_vectors_used, f_basis->numColumns());
+   CAROM_VERIFY(num_basis_vectors == f_basis_sampled_inv.numRows() && num_basis_vectors == f_basis_sampled_inv.numColumns());
+   CAROM_VERIFY(!f_basis_sampled_inv.distributed());
    int basis_size = f_basis->numRows();
 
    // The small matrix inverted by the algorithm.  We'll allocate the largest

--- a/DEIM.C
+++ b/DEIM.C
@@ -88,6 +88,7 @@ DEIM(const Matrix* f_basis,
    MPI_Op_create((MPI_User_function*)RowInfoMax, true, &RowInfoOp);
 
    // Get the number of basis vectors and the size of each basis vector.
+   CAROM_VERIFY(0 < num_f_basis_vectors_used && num_f_basis_vectors_used <= f_basis->numColumns());
    int num_basis_vectors =
       std::min(num_f_basis_vectors_used, f_basis->numColumns());
    int basis_size = f_basis->numRows();

--- a/GNAT.C
+++ b/GNAT.C
@@ -76,6 +76,7 @@ void GNAT(const Matrix* f_basis,
   MPI_Op_create((MPI_User_function*)RowInfoMax, true, &RowInfoOp);
 
   // Get the number of basis vectors and the size of each basis vector.
+	CAROM_VERIFY(0 < num_f_basis_vectors_used && num_f_basis_vectors_used <= f_basis->numColumns());
   const int num_basis_vectors =
     std::min(num_f_basis_vectors_used, f_basis->numColumns());
   const int basis_size = f_basis->numRows();
@@ -85,7 +86,7 @@ void GNAT(const Matrix* f_basis,
   const int ns_mod_nr = num_samples % num_basis_vectors;
   int ns = 0;
 
-  CAROM_ASSERT(num_samples >= num_basis_vectors && num_samples <= basis_size && num_samples >= 0);
+  CAROM_VERIFY(num_samples >= num_basis_vectors && num_samples <= basis_size && num_samples > 0);
 
   // The small matrix inverted by the algorithm.  We'll allocate the largest
   // matrix we'll need and set its size at each step in the algorithm.

--- a/GNAT.C
+++ b/GNAT.C
@@ -80,7 +80,7 @@ void GNAT(const Matrix* f_basis,
   const int num_basis_vectors =
     std::min(num_f_basis_vectors_used, f_basis->numColumns());
   const int num_samples = num_samples_req > 0 ? num_samples_req : num_basis_vectors;
-  CAROM_VERIFY(num_basis_vectors <= num_samples && num_samples <= f_basis->numRows());
+  CAROM_VERIFY(num_basis_vectors <= num_samples && num_samples <= f_basis->numDistributedRows());
   CAROM_VERIFY(num_samples == f_basis_sampled_inv.numRows() && num_basis_vectors == f_basis_sampled_inv.numColumns());
   CAROM_VERIFY(!f_basis_sampled_inv.distributed());
   const int basis_size = f_basis->numRows();

--- a/GNAT.C
+++ b/GNAT.C
@@ -94,6 +94,7 @@ void GNAT(const Matrix* f_basis,
 
   // Scratch space used throughout the algorithm.
   double* c = new double [num_basis_vectors];
+  double* sampled_row = new double [num_basis_vectors];
 
   std::vector<std::set<int> > proc_sampled_f_row(num_procs);
   std::vector<std::map<int, int> > proc_f_row_to_tmp_fs_row(num_procs);
@@ -129,14 +130,14 @@ void GNAT(const Matrix* f_basis,
       // Now get the first sampled row of the basis of the RHS.
       if (f_bv_max_global.proc == myid) {
 	for (int j = 0; j < num_basis_vectors; ++j) {
-	  c[j] = f_basis->item(f_bv_max_global.row, j);
+	  sampled_row[j] = f_basis->item(f_bv_max_global.row, j);
 	}
       }
-      MPI_Bcast(c, num_basis_vectors, MPI_DOUBLE,
+      MPI_Bcast(sampled_row, num_basis_vectors, MPI_DOUBLE,
 		f_bv_max_global.proc, MPI_COMM_WORLD);
       // Now add the first sampled row of the basis of the RHS to tmp_fs.
       for (int j = 0; j < num_basis_vectors; ++j) {
-	tmp_fs.item(k, j) = c[j];
+	tmp_fs.item(k, j) = sampled_row[j];
       }
       proc_sampled_f_row[f_bv_max_global.proc].insert(f_bv_max_global.row);
       proc_f_row_to_tmp_fs_row[f_bv_max_global.proc][f_bv_max_global.row] = k;
@@ -204,14 +205,14 @@ void GNAT(const Matrix* f_basis,
 	// Now get the next sampled row of the basis of f.
 	if (f_bv_max_global.proc == myid) {
 	  for (int j = 0; j < num_basis_vectors; ++j) {
-	    c[j] = f_basis->item(f_bv_max_global.row, j);
+	    sampled_row[j] = f_basis->item(f_bv_max_global.row, j);
 	  }
 	}
-	MPI_Bcast(c, num_basis_vectors, MPI_DOUBLE,
+	MPI_Bcast(sampled_row, num_basis_vectors, MPI_DOUBLE,
 		  f_bv_max_global.proc, MPI_COMM_WORLD);
 	// Now add the ith sampled row of the basis of the RHS to tmp_fs.
 	for (int j = 0; j < num_basis_vectors; ++j) {
-	  tmp_fs.item(ns+k, j) = c[j];
+	  tmp_fs.item(ns+k, j) = sampled_row[j];
 	}
 	proc_sampled_f_row[f_bv_max_global.proc].insert(f_bv_max_global.row);
 	proc_f_row_to_tmp_fs_row[f_bv_max_global.proc][f_bv_max_global.row] = ns+k;
@@ -252,6 +253,7 @@ void GNAT(const Matrix* f_basis,
   MPI_Op_free(&RowInfoOp);
 
   delete [] c;
+  delete [] sampled_row;
 }
 
 }

--- a/GNAT.C
+++ b/GNAT.C
@@ -76,17 +76,17 @@ void GNAT(const Matrix* f_basis,
   MPI_Op_create((MPI_User_function*)RowInfoMax, true, &RowInfoOp);
 
   // Get the number of basis vectors and the size of each basis vector.
-	CAROM_VERIFY(0 < num_f_basis_vectors_used && num_f_basis_vectors_used <= f_basis->numColumns());
+  CAROM_VERIFY(0 < num_f_basis_vectors_used && num_f_basis_vectors_used <= f_basis->numColumns());
   const int num_basis_vectors =
     std::min(num_f_basis_vectors_used, f_basis->numColumns());
-  const int basis_size = f_basis->numRows();
-
   const int num_samples = num_samples_req > 0 ? num_samples_req : num_basis_vectors;
+  CAROM_VERIFY(num_basis_vectors <= num_samples && num_samples <= f_basis->numRows());
+  CAROM_VERIFY(num_samples == f_basis_sampled_inv.numRows() && num_basis_vectors == f_basis_sampled_inv.numColumns());
+  CAROM_VERIFY(!f_basis_sampled_inv.distributed());
+  const int basis_size = f_basis->numRows();
 
   const int ns_mod_nr = num_samples % num_basis_vectors;
   int ns = 0;
-
-  CAROM_VERIFY(num_samples >= num_basis_vectors && num_samples <= basis_size && num_samples > 0);
 
   // The small matrix inverted by the algorithm.  We'll allocate the largest
   // matrix we'll need and set its size at each step in the algorithm.

--- a/Matrix.C
+++ b/Matrix.C
@@ -59,7 +59,6 @@ Matrix::Matrix(
 {
    CAROM_VERIFY(num_rows > 0);
    CAROM_VERIFY(num_cols > 0);
-   setSize(num_rows, num_cols);
    int mpi_init;
    MPI_Initialized(&mpi_init);
    if (mpi_init) {
@@ -68,6 +67,7 @@ Matrix::Matrix(
    else {
       d_num_procs = 1;
    }
+   setSize(num_rows, num_cols);
 }
 
 Matrix::Matrix(
@@ -84,6 +84,14 @@ Matrix::Matrix(
    CAROM_VERIFY(mat != 0);
    CAROM_VERIFY(num_rows > 0);
    CAROM_VERIFY(num_cols > 0);
+   int mpi_init;
+   MPI_Initialized(&mpi_init);
+   if (mpi_init) {
+      MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+   }
+   else {
+      d_num_procs = 1;
+   }
    if (copy_data) {
       setSize(num_rows, num_cols);
       memcpy(d_mat, mat, d_alloc_size*sizeof(double));
@@ -93,14 +101,9 @@ Matrix::Matrix(
       d_alloc_size = num_rows*num_cols;
       d_num_cols = num_cols;
       d_num_rows = num_rows;
-   }
-   int mpi_init;
-   MPI_Initialized(&mpi_init);
-   if (mpi_init) {
-      MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
-   }
-   else {
-      d_num_procs = 1;
+      if (d_distributed) {
+        calculateNumDistributedRows();
+      }
    }
 }
 
@@ -111,7 +114,6 @@ Matrix::Matrix(
    d_distributed(other.d_distributed),
    d_owns_data(true)
 {
-   setSize(other.d_num_rows, other.d_num_cols);
    int mpi_init;
    MPI_Initialized(&mpi_init);
    if (mpi_init) {
@@ -120,6 +122,7 @@ Matrix::Matrix(
    else {
       d_num_procs = 1;
    }
+   setSize(other.d_num_rows, other.d_num_cols);
    memcpy(d_mat, other.d_mat, d_alloc_size*sizeof(double));
 }
 
@@ -165,12 +168,6 @@ Matrix::operator -= (
 bool
 Matrix::balanced() const
 {
-  // TODO(oxberry1@llnl.gov): Relax the assumption in libROM that
-  // objects use MPI_COMM_WORLD, and that rank 0 is the master rank of
-  // an object.
-  const int master_rank = 0;
-  const MPI_Comm comm = MPI_COMM_WORLD;
-
   // A Matrix is "balanced" (load-balanced for distributed dense matrix
   // computations) if:
   //
@@ -184,15 +181,10 @@ Matrix::balanced() const
   // rows
   if (!distributed()) return true;
 
+  const MPI_Comm comm = MPI_COMM_WORLD;
+
   // Otherwise, get the total number of rows of the matrix.
-  int num_total_rows = d_num_rows;
-  const int reduce_count = 1;
-  CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
-			     &num_total_rows,
-			     reduce_count,
-			     MPI_INT,
-			     MPI_SUM,
-			     comm) == MPI_SUCCESS);
+  int num_total_rows = numDistributedRows();
 
   const int first_rank_with_fewer = num_total_rows % d_num_procs;
   int my_rank;
@@ -205,6 +197,7 @@ Matrix::balanced() const
   const bool has_too_many_rows = (d_num_rows > max_rows_on_rank);
 
   int result = (has_enough_rows && !has_too_many_rows);
+  const int reduce_count = 1;
   CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
 			     &result,
 			     reduce_count,
@@ -749,9 +742,11 @@ Matrix::read(const std::string& base_file_name)
    int rank;
    if (mpi_init) {
       MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+      MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
    }
    else {
       rank = 0;
+      d_num_procs = 1;
    }
 
    char tmp[100];
@@ -774,13 +769,24 @@ Matrix::read(const std::string& base_file_name)
    sprintf(tmp, "data");
    database.getDoubleArray(tmp, d_mat, d_alloc_size);
    d_owns_data = true;
-   if (mpi_init) {
-      MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
-   }
-   else {
-      d_num_procs = 1;
-   }
    database.close();
+}
+
+void
+Matrix::calculateNumDistributedRows() {
+  if (d_distributed && d_num_procs > 1) {
+    int num_total_rows = d_num_rows;
+    CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
+            &num_total_rows,
+            1,
+            MPI_INT,
+            MPI_SUM,
+            MPI_COMM_WORLD) == MPI_SUCCESS);
+    d_num_distributed_rows = num_total_rows;
+  }
+  else {
+    d_num_distributed_rows = d_num_rows;
+  }
 }
 
 void

--- a/Matrix.h
+++ b/Matrix.h
@@ -155,6 +155,9 @@ class Matrix
          }
          d_num_rows = num_rows;
          d_num_cols = num_cols;
+         if (d_distributed) {
+           calculateNumDistributedRows();
+         }
       }
 
       /**
@@ -184,6 +187,20 @@ class Matrix
       {
          return d_num_rows;
       }
+
+      /**
+       * @brief Returns the number of rows of the Matrix across all processors.
+       *
+       * @return The number of rows of the Matrix across all processors.
+       */
+       int
+       numDistributedRows() const
+       {
+          if (!d_distributed) {
+            return d_num_rows;
+          }
+          return d_num_distributed_rows;
+       }
 
       /**
        * @brief Returns the number of columns in the Matrix.
@@ -811,6 +828,14 @@ class Matrix
       // Matrix();
 
       /**
+       * @brief Compute number of rows across all processors
+       *
+       * @pre distributed()
+       */
+      void
+      calculateNumDistributedRows();
+
+      /**
        * @brief Compute the leading numColumns() column pivots from a
        * QR decomposition with column pivots (QRCP) of the transpose
        * of this.
@@ -934,6 +959,11 @@ class Matrix
        * @brief The rows in the Matrix that are on this processor.
        */
       int d_num_rows;
+
+      /**
+       * @brief The rows in the Matrix across all processors.
+       */
+      int d_num_distributed_rows;
 
       /**
        * @brief The number of columns in the Matrix.

--- a/matlab/deim.m
+++ b/matlab/deim.m
@@ -1,10 +1,11 @@
-function [inv_Q] = deim(Q)
-% Input: Q: n by m matrix with orthonormal columns
+function [inv_Q] = deim(Q, m_used)
+% Input:      Q: n by m matrix with orthonormal columns
+%        m_used: number of basis_vectors to use
 
     phi = [];
     [rho, phi(end + 1)] = max(abs(Q(:,1)));
     U = Q(:,1);
-    m = size(Q,2);
+    m = min(m_used, size(Q,2));
     n = size(Q,1);
     P = zeros(n,1);
     P(phi(end)) = 1;

--- a/matlab/deim.m
+++ b/matlab/deim.m
@@ -1,0 +1,21 @@
+m =  5
+n = 25
+A = randn(m, n)
+[Q, R] = qr(A)
+phi = []
+[rho, phi(end + 1)] = max(Q(:,1))
+U = Q(:,1)
+P = zeros(m,1)
+P(phi(end)) = 1
+Q_sampled = Q(phi(end),:)
+for l = 2:m
+    c = inv(transpose(P)*U)*transpose(P)*Q(:,l)
+    r = Q(:,l) - U*c
+    [rho, phi(end + 1)] = max(r)
+    U = [U Q(:,l)]
+    newPcol = zeros(m,1)
+    newPcol(phi(end)) = 1
+    P = [P newPcol]
+    Q_sampled = [Q_sampled;Q(phi(end),:)]
+end
+phi = transpose(phi)

--- a/matlab/deim.m
+++ b/matlab/deim.m
@@ -1,21 +1,26 @@
-m =  5
-n = 25
-A = randn(m, n)
-[Q, R] = qr(A)
-phi = []
-[rho, phi(end + 1)] = max(Q(:,1))
-U = Q(:,1)
-P = zeros(m,1)
-P(phi(end)) = 1
-Q_sampled = Q(phi(end),:)
-for l = 2:m
-    c = inv(transpose(P)*U)*transpose(P)*Q(:,l)
-    r = Q(:,l) - U*c
-    [rho, phi(end + 1)] = max(r)
-    U = [U Q(:,l)]
-    newPcol = zeros(m,1)
-    newPcol(phi(end)) = 1
-    P = [P newPcol]
-    Q_sampled = [Q_sampled;Q(phi(end),:)]
+function [inv_U] = deim(Q)
+% Input: Q: n by m matrix with orthonormal columns
+
+    phi = [];
+    [rho, phi(end + 1)] = max(abs(Q(:,1)));
+    U = Q(:,1);
+    P = zeros(m,1);
+    P(phi(end)) = 1;
+    Q_sampled = Q(phi(end),:);
+    for l = 2:m
+        M = transpose(P)*U;ls
+        
+        inv_M = inv(M);
+        RHS = transpose(P) * Q(:, l);
+        c = inv_M * RHS;
+        r = Q(:,l) - U*c;
+        [rho, phi(end + 1)] = max(abs(r));
+        U = [U Q(:,l)];
+        newPcol = zeros(m,1);
+        newPcol(phi(end)) = 1;
+        P = [P newPcol];
+        Q_sampled = [Q_sampled;Q(phi(end),:)];
+    end
+    phi = transpose(phi);
+    inv_U = inv(U);
 end
-phi = transpose(phi)

--- a/matlab/deim.m
+++ b/matlab/deim.m
@@ -3,7 +3,7 @@ function [inv_Q] = deim(Q, m_used)
 %        m_used: number of basis_vectors to use
 
     phi = [];
-    [rho, phi(end + 1)] = max(abs(Q(:,1)));
+    [~, phi(end + 1)] = max(abs(Q(:,1)));
     U = Q(:,1);
     m = min(m_used, size(Q,2));
     n = size(Q,1);
@@ -17,14 +17,14 @@ function [inv_Q] = deim(Q, m_used)
         RHS = transpose(P) * Q(:, l);
         c = inv_M * RHS;
         r = Q(:,l) - U*c;
-        [rho, phi(end + 1)] = max(abs(r));
+        [~, phi(end + 1)] = max(abs(r));
         U = [U Q(:,l)];
         newPcol = zeros(n,1);
         newPcol(phi(end)) = 1;
         P = [P newPcol];
         Q_sampled = [Q_sampled;Q(phi(end),:)];
     end
-    [phi, phi_sort_order] = sort(phi);
+    [~, phi_sort_order] = sort(phi);
     Q_sampled = Q_sampled(phi_sort_order,:);
     inv_Q = inv(Q_sampled);
 end

--- a/matlab/deim.m
+++ b/matlab/deim.m
@@ -1,14 +1,16 @@
-function [inv_U] = deim(Q)
+function [inv_Q] = deim(Q)
 % Input: Q: n by m matrix with orthonormal columns
 
     phi = [];
     [rho, phi(end + 1)] = max(abs(Q(:,1)));
     U = Q(:,1);
-    P = zeros(m,1);
+    m = size(Q,2);
+    n = size(Q,1);
+    P = zeros(n,1);
     P(phi(end)) = 1;
     Q_sampled = Q(phi(end),:);
     for l = 2:m
-        M = transpose(P)*U;ls
+        M = transpose(P)*U;
         
         inv_M = inv(M);
         RHS = transpose(P) * Q(:, l);
@@ -16,11 +18,12 @@ function [inv_U] = deim(Q)
         r = Q(:,l) - U*c;
         [rho, phi(end + 1)] = max(abs(r));
         U = [U Q(:,l)];
-        newPcol = zeros(m,1);
+        newPcol = zeros(n,1);
         newPcol(phi(end)) = 1;
         P = [P newPcol];
         Q_sampled = [Q_sampled;Q(phi(end),:)];
     end
-    phi = transpose(phi);
-    inv_U = inv(U);
+    [phi, phi_sort_order] = sort(phi);
+    Q_sampled = Q_sampled(phi_sort_order,:);
+    inv_Q = inv(Q_sampled);
 end

--- a/matlab/gnat.m
+++ b/matlab/gnat.m
@@ -1,0 +1,76 @@
+function [inv_Q] = gnat(Q, m_used, nsr)
+% Input:      Q: n by m matrix with orthonormal columns
+%        m_used: number of basis_vectors to use
+%           nsr: number of samples required
+
+    phi = [];
+    used = [];
+    U = Q(:,1);
+    Q_sampled = [];
+    m = min(m_used, size(Q,2));
+    if nsr > 0
+        ns = nsr;
+    else
+        ns = m;
+    end
+    n = size(Q,1);
+    ns_mod_nr = mod(ns,m);
+    if 0 < ns_mod_nr
+        nsi = idivide(int32(ns), int32(m), 'floor') + 1;
+    else
+        nsi = idivide(int32(ns), int32(m), 'floor');
+    end
+    P = [];
+    for i = 1:nsi
+        s_row = -1;
+        s_row_val = Inf;
+        for j = 1:n
+            if ~any(used(:) == j)
+                if s_row == -1 || s_row_val < abs(Q(j,1))
+                    s_row = j;
+                    s_row_val = abs(Q(j,1));
+                end
+            end
+        end
+        used(end + 1) = s_row;
+        phi(end + 1) = s_row;
+        newPcol = zeros(n,1);
+        newPcol(phi(end)) = 1;
+        P = [P newPcol];
+        Q_sampled = [Q_sampled;Q(phi(end),:)];
+    end
+    for l = 2:m
+        M = transpose(P)*U
+        inv_M = pinv(M);
+        RHS = transpose(P) * Q(:, l);
+        c = inv_M * RHS;
+        r = Q(:,l) - U*c;
+        U = [U Q(:,l)];
+        if l < ns_mod_nr
+            nsi = idivide(int32(ns), int32(m), 'floor') + 1;
+        else
+            nsi = idivide(int32(ns), int32(m), 'floor');
+        end
+        for i = 1:nsi
+            s_row = -1;
+            s_row_val = Inf;
+            for j = 1:n
+                if ~any(used(:) == j)
+                    if s_row == -1 || s_row_val < abs(r(j,1))
+                        s_row = j;
+                        s_row_val = abs(r(j,1));
+                    end
+                end
+            end
+            used(end + 1) = s_row;
+            phi(end + 1) = s_row;
+            newPcol = zeros(n,1);
+            newPcol(phi(end)) = 1;
+            P = [P newPcol];
+            Q_sampled = [Q_sampled;Q(phi(end),:)];
+        end
+    end
+    [~, phi_sort_order] = sort(phi);
+    Q_sampled = Q_sampled(phi_sort_order,:);
+    inv_Q = transpose(pinv(Q_sampled));
+end

--- a/matlab/gnat.m
+++ b/matlab/gnat.m
@@ -40,13 +40,13 @@ function [inv_Q] = gnat(Q, m_used, nsr)
         Q_sampled = [Q_sampled;Q(phi(end),:)];
     end
     for l = 2:m
-        M = transpose(P)*U
+        M = transpose(P)*U;
         inv_M = pinv(M);
         RHS = transpose(P) * Q(:, l);
         c = inv_M * RHS;
         r = Q(:,l) - U*c;
         U = [U Q(:,l)];
-        if l < ns_mod_nr
+        if l - 1 < ns_mod_nr
             nsi = idivide(int32(ns), int32(m), 'floor') + 1;
         else
             nsi = idivide(int32(ns), int32(m), 'floor');

--- a/tests/test_DEIM.C
+++ b/tests/test_DEIM.C
@@ -18,6 +18,8 @@
 #include <mpi.h>
 #include "../DEIM.h"
 #include "../Matrix.h"
+#define _USE_MATH_DEFINES
+#include <cmath>
 
 /**
  * Simple smoke test to make sure Google Test is properly linked

--- a/tests/test_DEIM.C
+++ b/tests/test_DEIM.C
@@ -17,8 +17,7 @@
 #include<gtest/gtest.h>
 #include <mpi.h>
 #include "../DEIM.h"
-#define _USE_MATH_DEFINES
-#include <cmath>
+#include "../Matrix.h"
 
 /**
  * Simple smoke test to make sure Google Test is properly linked
@@ -29,28 +28,47 @@ TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
 
 TEST(DEIMSerialTest, Test_DEIM)
 {
-  double* orthonormal_mat = {-0.1735,   -0.2978,   0.4339,   0.8304,   0.0575
+
+  // Orthonormal input matrix to DEIM
+  double* orthonormal_mat = new double[25] {
+   -0.1735,   -0.2978,    0.4339,    0.8304,    0.0575,
    -0.5919,   -0.1608,   -0.7489,    0.2185,   -0.1230,
     0.7291,    0.1574,   -0.4449,    0.4549,   -0.1970,
    -0.2783,    0.7273,    0.1992,    0.1386,   -0.5785,
-   -0.1029,    0.5760,   -0.1147,    0.1910,    0.7798}
-  CAROM::Matrix u(orthonormal_mat, 5, 5, false);
+   -0.1029,    0.5760,   -0.1147,    0.1910,    0.7798};
+
+   // Result of DEIM (f_basis_sampled_inv)
+   double* DEIM_true_ans = new double[25] {
+  -0.173528,  -0.591896,  0.729022,  -0.278257,  -0.102821,
+  -0.29779,   -0.16083,   0.157456,   0.727281 ,  0.575906,
+  0.433945,   -0.748987, -0.444923,   0.19924,   -0.11473,
+  0.830464,   0.218532,   0.454906,   0.138637,   0.191005,
+  0.0574838, -0.123002,  -0.196971,  -0.578576,   0.779759};
+
+  CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, 5, 5, false);
   double* DEIM_res = NULL;
-  int* f_sampled_row;
-  int* f_sampled_rows_per_proc;
-  CAROM::Matrix f_basis_sampled_inv;
-  DEIM(u, 5, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+  int* f_sampled_row = new int[5] {0};
+  int* f_sampled_rows_per_proc = new int[5] {0};
+  CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(5, 5, false);
+  CAROM::DEIM(u, 5, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+
+  // Compare the norm between the DEIM result and the true DEIM answer
+  double l2_norm_diff = 0.0;
   for (int i = 0; i < 5; i++) {
     for (int j = 0; j < 5; j++) {
-      std::cout << f_basis_sampled_inv[i][j] << " ";
+      l2_norm_diff += pow(abs(DEIM_true_ans[i * 5 + j] - f_basis_sampled_inv(i, j)), 2);
     }
   }
-  EXPECT_FALSE(0 == 1);
+  l2_norm_diff = sqrt(l2_norm_diff);
+
+  // Allow for some error due to float rounding
+  EXPECT_TRUE(l2_norm_diff < 1e-5);
 }
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
+  MPI_Init(&argc, &argv);
   return RUN_ALL_TESTS();
 }
 #else // #ifndef CAROM_HAS_GTEST

--- a/tests/test_DEIM.C
+++ b/tests/test_DEIM.C
@@ -58,9 +58,14 @@ TEST(DEIMSerialTest, Test_DEIM)
   CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, num_rows, num_cols, false);
   double* DEIM_res = NULL;
   int* f_sampled_row = new int[num_cols] {0};
+  int* f_sampled_row_true_ans = new int[num_cols] {0, 1, 4, 5, 9};
   int* f_sampled_rows_per_proc = new int[num_cols] {0};
   CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_cols, num_cols, false);
   CAROM::DEIM(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+
+  for (int i = 0; i < num_cols; i++) {
+    EXPECT_EQ(f_sampled_row[i], f_sampled_row_true_ans[i]);
+  }
 
   // Compare the norm between the DEIM result and the true DEIM answer
   double l2_norm_diff = 0.0;
@@ -104,9 +109,14 @@ TEST(DEIMSerialTest, Test_DEIM_decreased_used_basis_vectors)
   CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, num_rows, num_cols, false);
   double* DEIM_res = NULL;
   int* f_sampled_row = new int[num_basis_vectors_used] {0};
+  int* f_sampled_row_true_ans = new int[num_basis_vectors_used] {0, 1, 4};
   int* f_sampled_rows_per_proc = new int[num_basis_vectors_used] {0};
   CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_basis_vectors_used, num_basis_vectors_used, false);
   CAROM::DEIM(u, num_basis_vectors_used, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+
+  for (int i = 0; i < num_basis_vectors_used; i++) {
+    EXPECT_EQ(f_sampled_row[i], f_sampled_row_true_ans[i]);
+  }
 
   // Compare the norm between the DEIM result and the true DEIM answer
   double l2_norm_diff = 0.0;

--- a/tests/test_DEIM.C
+++ b/tests/test_DEIM.C
@@ -1,0 +1,63 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2019, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
+// Description: This source file is a test runner that uses the Google Test
+// Framework to run unit tests on the CAROM::DEIM class.
+
+#include <iostream>
+
+#ifdef CAROM_HAS_GTEST
+#include<gtest/gtest.h>
+#include <mpi.h>
+#include "../DEIM.h"
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+/**
+ * Simple smoke test to make sure Google Test is properly linked
+ */
+TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
+  SUCCEED();
+}
+
+TEST(DEIMSerialTest, Test_DEIM)
+{
+  double* orthonormal_mat = {-0.1735,   -0.2978,   0.4339,   0.8304,   0.0575
+   -0.5919,   -0.1608,   -0.7489,    0.2185,   -0.1230,
+    0.7291,    0.1574,   -0.4449,    0.4549,   -0.1970,
+   -0.2783,    0.7273,    0.1992,    0.1386,   -0.5785,
+   -0.1029,    0.5760,   -0.1147,    0.1910,    0.7798}
+  CAROM::Matrix u(orthonormal_mat, 5, 5, false);
+  double* DEIM_res = NULL;
+  int* f_sampled_row;
+  int* f_sampled_rows_per_proc;
+  CAROM::Matrix f_basis_sampled_inv;
+  DEIM(u, 5, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+  for (int i = 0; i < 5; i++) {
+    for (int j = 0; j < 5; j++) {
+      std::cout << f_basis_sampled_inv[i][j] << " ";
+    }
+  }
+  EXPECT_FALSE(0 == 1);
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+#else // #ifndef CAROM_HAS_GTEST
+int main()
+{
+  std::cout << "libROM was compiled without Google Test support, so unit "
+	    << "tests have been disabled. To enable unit tests, compile "
+	    << "libROM with Google Test support." << std::endl;
+}
+#endif // #endif CAROM_HAS_GTEST

--- a/tests/test_GNAT.C
+++ b/tests/test_GNAT.C
@@ -9,7 +9,7 @@
  *****************************************************************************/
 
 // Description: This source file is a test runner that uses the Google Test
-// Framework to run unit tests on the CAROM::DEIM class.
+// Framework to run unit tests on the CAROM::GNAT class.
 
 #include <iostream>
 
@@ -28,10 +28,10 @@ TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
   SUCCEED();
 }
 
-TEST(DEIMSerialTest, Test_DEIM)
+TEST(GNATSerialTest, Test_GNAT_deim)
 {
 
-  // Orthonormal input matrix to DEIM
+  // Orthonormal input matrix to GNAT
   double* orthonormal_mat = new double[50] {
     -0.1067,   -0.4723,   -0.4552,    0.1104,   -0.2337,
      0.1462,    0.6922,   -0.2716,    0.1663,    0.3569,
@@ -44,8 +44,8 @@ TEST(DEIMSerialTest, Test_DEIM)
      0.4387,   -0.0199,   -0.3338,   -0.1711,   -0.2220,
      0.0101,    0.1807,    0.4488,    0.3219,   -0.6359};
 
-   // Result of DEIM (f_basis_sampled_inv)
-   double* DEIM_true_ans = new double[25] {
+   // Result of GNAT (f_basis_sampled_inv)
+   double* GNAT_true_ans = new double[25] {
     -0.295811, -0.264874,  1.02179,  -1.05194,  -0.554046,
     -0.270643,  1.05349,    0.119162,  0.541832,  0.646459,
     -1.33334,  -0.874864,  -0.276067, -0.27327,   0.124747,
@@ -56,17 +56,17 @@ TEST(DEIMSerialTest, Test_DEIM)
    int num_rows = 10;
 
   CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, num_rows, num_cols, false);
-  double* DEIM_res = NULL;
+  double* GNAT_res = NULL;
   int* f_sampled_row = new int[num_cols] {0};
   int* f_sampled_rows_per_proc = new int[num_cols] {0};
   CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_cols, num_cols, false);
-  CAROM::DEIM(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+  CAROM::GNAT(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
 
-  // Compare the norm between the DEIM result and the true DEIM answer
+  // Compare the norm between the GNAT result and the true GNAT answer
   double l2_norm_diff = 0.0;
   for (int i = 0; i < num_cols; i++) {
     for (int j = 0; j < num_cols; j++) {
-      l2_norm_diff += pow(abs(DEIM_true_ans[i * num_cols + j] - f_basis_sampled_inv(i, j)), 2);
+      l2_norm_diff += pow(abs(GNAT_true_ans[i * num_cols + j] - f_basis_sampled_inv(i, j)), 2);
     }
   }
   l2_norm_diff = sqrt(l2_norm_diff);
@@ -75,10 +75,10 @@ TEST(DEIMSerialTest, Test_DEIM)
   EXPECT_TRUE(l2_norm_diff < 1e-5);
 }
 
-TEST(DEIMSerialTest, Test_DEIM_decreased_used_basis_vectors)
+TEST(GNATSerialTest, Test_GNAT)
 {
 
-  // Orthonormal input matrix to DEIM
+  // Orthonormal input matrix to GNAT
   double* orthonormal_mat = new double[50] {
     -0.1067,   -0.4723,   -0.4552,    0.1104,   -0.2337,
      0.1462,    0.6922,   -0.2716,    0.1663,    0.3569,
@@ -91,28 +91,28 @@ TEST(DEIMSerialTest, Test_DEIM_decreased_used_basis_vectors)
      0.4387,   -0.0199,   -0.3338,   -0.1711,   -0.2220,
      0.0101,    0.1807,    0.4488,    0.3219,   -0.6359};
 
-   // Result of DEIM (f_basis_sampled_inv)
-   double* DEIM_true_ans = new double[9] {
+   // Result of GNAT (f_basis_sampled_inv)
+   double* GNAT_true_ans = new double[9] {
     -0.331632, -0.690455,  2.07025,
     -0.541131,  1.17546,  -0.446068,
     -1.55764,  -1.05777,  -0.022448};
 
   int num_cols = 5;
   int num_rows = 10;
-  int num_basis_vectors_used = 3;
+  int num_samples = 9;
 
   CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, num_rows, num_cols, false);
-  double* DEIM_res = NULL;
-  int* f_sampled_row = new int[num_basis_vectors_used] {0};
-  int* f_sampled_rows_per_proc = new int[num_basis_vectors_used] {0};
-  CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_basis_vectors_used, num_basis_vectors_used, false);
-  CAROM::DEIM(u, num_basis_vectors_used, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+  double* GNAT_res = NULL;
+  int* f_sampled_row = new int[num_samples] {0};
+  int* f_sampled_rows_per_proc = new int[num_samples] {0};
+  CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_samples, num_samples, false);
+  CAROM::GNAT(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1, num_samples);
 
-  // Compare the norm between the DEIM result and the true DEIM answer
+  // Compare the norm between the GNAT result and the true GNAT answer
   double l2_norm_diff = 0.0;
-  for (int i = 0; i < num_basis_vectors_used; i++) {
-    for (int j = 0; j < num_basis_vectors_used; j++) {
-      l2_norm_diff += pow(abs(DEIM_true_ans[i * num_basis_vectors_used + j] - f_basis_sampled_inv(i, j)), 2);
+  for (int i = 0; i < num_samples; i++) {
+    for (int j = 0; j < num_samples; j++) {
+      l2_norm_diff += pow(abs(GNAT_true_ans[i * num_samples + j] - f_basis_sampled_inv(i, j)), 2);
     }
   }
   l2_norm_diff = sqrt(l2_norm_diff);

--- a/tests/test_GNAT.C
+++ b/tests/test_GNAT.C
@@ -58,9 +58,14 @@ TEST(GNATSerialTest, Test_GNAT_deim)
   CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, num_rows, num_cols, false);
   double* GNAT_res = NULL;
   int* f_sampled_row = new int[num_cols] {0};
+  int* f_sampled_row_true_ans = new int[num_cols] {0, 1, 4, 5, 9};
   int* f_sampled_rows_per_proc = new int[num_cols] {0};
   CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_cols, num_cols, false);
   CAROM::GNAT(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1);
+
+  for (int i = 0; i < num_cols; i++) {
+    EXPECT_EQ(f_sampled_row[i], f_sampled_row_true_ans[i]);
+  }
 
   // Compare the norm between the GNAT result and the true GNAT answer
   double l2_norm_diff = 0.0;
@@ -110,9 +115,14 @@ TEST(GNATSerialTest, Test_GNAT_oversampling)
   CAROM::Matrix* u = new CAROM::Matrix(orthonormal_mat, num_rows, num_cols, false);
   double* GNAT_res = NULL;
   int* f_sampled_row = new int[num_samples] {0};
+  int* f_sampled_row_true_ans = new int[num_samples] {0, 1, 2, 4, 5, 6, 7, 8, 9};
   int* f_sampled_rows_per_proc = new int[num_samples] {0};
   CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_samples, num_cols, false);
   CAROM::GNAT(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1, num_samples);
+
+  for (int i = 0; i < num_samples; i++) {
+    EXPECT_EQ(f_sampled_row[i], f_sampled_row_true_ans[i]);
+  }
 
   // Compare the norm between the GNAT result and the true GNAT answer
   double l2_norm_diff = 0.0;

--- a/tests/test_GNAT.C
+++ b/tests/test_GNAT.C
@@ -75,7 +75,7 @@ TEST(GNATSerialTest, Test_GNAT_deim)
   EXPECT_TRUE(l2_norm_diff < 1e-5);
 }
 
-TEST(GNATSerialTest, Test_GNAT)
+TEST(GNATSerialTest, Test_GNAT_oversampling)
 {
 
   // Orthonormal input matrix to GNAT
@@ -92,10 +92,16 @@ TEST(GNATSerialTest, Test_GNAT)
      0.0101,    0.1807,    0.4488,    0.3219,   -0.6359};
 
    // Result of GNAT (f_basis_sampled_inv)
-   double* GNAT_true_ans = new double[9] {
-    -0.331632, -0.690455,  2.07025,
-    -0.541131,  1.17546,  -0.446068,
-    -1.55764,  -1.05777,  -0.022448};
+   double* GNAT_true_ans = new double[45] {
+    -0.111754, -0.472181, -0.454143,  0.110436,  -0.234925,
+     0.169535,  0.691715, -0.276502,  0.166065,   0.362544,
+     0.443111, -0.344589,  0.488125, -0.336035,   0.332789,
+     0.556025,  0.154167, -0.172054, -0.344493,  -0.294606,
+    -0.498551,  0.0149608,-0.191435, -0.576216,   0.00647047,
+    -0.247487,  0.328931,  0.293216, -0.459384,  -0.134887,
+    -0.036157,  0.120386, -0.0906109,-0.228902, -0.382862,
+     0.478391, -0.0208761,-0.342018, -0.171577,  -0.2125,
+    -0.0109879, 0.181169,  0.453212,  0.322187,   -0.640965 };
 
   int num_cols = 5;
   int num_rows = 10;
@@ -105,14 +111,14 @@ TEST(GNATSerialTest, Test_GNAT)
   double* GNAT_res = NULL;
   int* f_sampled_row = new int[num_samples] {0};
   int* f_sampled_rows_per_proc = new int[num_samples] {0};
-  CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_samples, num_samples, false);
+  CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_samples, num_cols, false);
   CAROM::GNAT(u, num_cols, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, 0, 1, num_samples);
 
   // Compare the norm between the GNAT result and the true GNAT answer
   double l2_norm_diff = 0.0;
   for (int i = 0; i < num_samples; i++) {
-    for (int j = 0; j < num_samples; j++) {
-      l2_norm_diff += pow(abs(GNAT_true_ans[i * num_samples + j] - f_basis_sampled_inv(i, j)), 2);
+    for (int j = 0; j < num_cols; j++) {
+      l2_norm_diff += pow(abs(GNAT_true_ans[i * num_cols + j] - f_basis_sampled_inv(i, j)), 2);
     }
   }
   l2_norm_diff = sqrt(l2_norm_diff);


### PR DESCRIPTION
1. Adding unit tests for DEIM and GNAT. QDEIM unit test will be added in another PR, hopefully by tomorrow.
2. Worked with Dylan to fix a bug in GNAT in which oversampling was done incorrectly. Before, a row was chosen using incorrect r values rather than using the row index matching the element in r with the greatest absolute value. This will cause all of the Laghos tests that use GNAT to have different results. The results are generally better, though some have negligible improvements or perform slightly worse, probably due to randomness. For the longer tests, the number of time steps are much shorter than with the current bugged GNAT.
3. Added a function numDistributedRows() that show the number of rows across all processors.

I would appreciate a quick glance at DEIM.C and GNAT.C. The test files and Matlab files do not need to be reviewed.