### PR TITLE
Remove force update for macOS 

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -74,7 +74,6 @@ if [ "$(uname)" == "Darwin" ]; then
   if [[ $? != 0 ]] ; then
       xcode-select --install
   fi
-  softwareupdate --all --install --force
   brew list open-mpi > /dev/null || brew install open-mpi
   brew list openblas > /dev/null || brew install openblas
   brew list lapack > /dev/null || brew install lapack


### PR DESCRIPTION
Small change to remove the forced update line for macOS. 

I recently did a clean install of librom and used `./scripts/compile.sh` (from the README), and my mac was forced to upgrade to Big Sur which took ~30 minutes I hadn't planned for. So, unless a software update is needed for some reason, I don't think this line is needed.