### PR TITLE
Get rows and columns from BasisReader

### DIFF
--- a/lib/linalg/BasisReader.C
+++ b/lib/linalg/BasisReader.C
@@ -343,8 +343,8 @@ BasisReader::getSingularValues(
     return truncated_singular_values;
 }
 
-Matrix*
-BasisReader::getSnapshotMatrix(
+int
+BasisReader::getDim( 
     double time)
 {
     CAROM_ASSERT(0 < numTimeIntervals());
@@ -362,10 +362,50 @@ BasisReader::getSnapshotMatrix(
     int num_rows;
     sprintf(tmp, "snapshot_matrix_num_rows_%06d", i);
     d_database->getInteger(tmp, num_rows);
+    return num_rows;
+}
+
+int 
+BasisReader::getNSamples(
+    double time)
+{
+    CAROM_ASSERT(0 < numTimeIntervals());
+    CAROM_ASSERT(0 <= time);
+    int num_time_intervals = numTimeIntervals();
+    int i;
+    for (i = 0; i < num_time_intervals-1; ++i) {
+        if (d_time_interval_start_times[i] <= time &&
+                time < d_time_interval_start_times[i+1]) {
+            break;
+        }
+    }
+    d_last_basis_idx = i;
+    char tmp[100];
     int num_cols;
     sprintf(tmp, "snapshot_matrix_num_cols_%06d", i);
     d_database->getInteger(tmp, num_cols);
+    return num_cols;
+}
 
+Matrix*
+BasisReader::getSnapshotMatrix(
+    double time)
+{
+    CAROM_ASSERT(0 < numTimeIntervals());
+    CAROM_ASSERT(0 <= time);
+    int num_time_intervals = numTimeIntervals();
+    int i;
+    for (i = 0; i < num_time_intervals-1; ++i) {
+        if (d_time_interval_start_times[i] <= time &&
+                time < d_time_interval_start_times[i+1]) {
+            break;
+        }
+    }
+    d_last_basis_idx = i;
+    int num_rows = getDim(time);
+    int num_cols = getNSamples(time);
+
+    char tmp[100];
     Matrix* snapshots = new Matrix(num_rows, num_cols, false);
     sprintf(tmp, "snapshot_matrix_%06d", i);
     d_database->getDoubleArray(tmp,

--- a/lib/linalg/BasisReader.C
+++ b/lib/linalg/BasisReader.C
@@ -366,7 +366,7 @@ BasisReader::getDim(
 }
 
 int 
-BasisReader::getNSamples(
+BasisReader::getNumSamples(
     double time)
 {
     CAROM_ASSERT(0 < numTimeIntervals());
@@ -403,7 +403,7 @@ BasisReader::getSnapshotMatrix(
     }
     d_last_basis_idx = i;
     int num_rows = getDim(time);
-    int num_cols = getNSamples(time);
+    int num_cols = getNumSamples(time);
 
     char tmp[100];
     Matrix* snapshots = new Matrix(num_rows, num_cols, false);

--- a/lib/linalg/BasisReader.h
+++ b/lib/linalg/BasisReader.h
@@ -293,7 +293,7 @@ public:
      * @return The number of samples in file.
      */
     int
-    getNSamples(
+    getNumSamples(
         double time);
 
     /**

--- a/lib/linalg/BasisReader.h
+++ b/lib/linalg/BasisReader.h
@@ -278,6 +278,26 @@ public:
 
     /**
      *
+     * @brief Returns the dimension of the system on this processor.
+     *
+     * @return The dimension of the system on this processor.
+     */
+    int
+    getDim(
+        double time);
+
+    /**
+     *
+     * @brief Returns the number of samples (columns) in file.
+     *
+     * @return The number of samples in file.
+     */
+    int
+    getNSamples(
+        double time);
+
+    /**
+     *
      * @brief Returns the snapshot matrix for the requested time.
      *
      * @pre 0 < numTimeIntervals()


### PR DESCRIPTION
Add the capability to read only the dimension of the snapshot matrix, as suggested by @dylan-copeland in #98 .

Currently I've added that capability for just the snapshot matrix. I feel like this might be an opportunity to generalize the two added functions (`getDim` and `getNSamples`) for the basis and temporal matrices as well. Is there any need for that?