### PR TITLE
Implement time windowing DMD for MFEM example 10

### DIFF
--- a/examples/dmd/generic_csv.cpp
+++ b/examples/dmd/generic_csv.cpp
@@ -483,5 +483,10 @@ int main(int argc, char *argv[])
     }
 
     delete[] sample;
+    for (int window = 0; window < numWindows; ++window)
+    {
+        delete dmd[window];
+    }
+
     return 0;
 }

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -4,6 +4,8 @@
 //
 // For DMD:
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.01 -tf 5 -visit
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50 -nwinsamp 10 -visit
 //
 // Sample runs:
 //    mpirun -np 4 nonlinear_elasticity -s 3 -rs 2 -dt 3
@@ -437,11 +439,9 @@ int main(int argc, char *argv[])
     int curr_window = 0;
     vector<CAROM::DMD*> dmd_x;
     vector<CAROM::DMD*> dmd_v;
-    vector<double> tw;
 
     dmd_x.push_back(new CAROM::DMD(x_gf.GetTrueVector().Size(), dt));
     dmd_v.push_back(new CAROM::DMD(v_gf.GetTrueVector().Size(), dt));
-    tw.push_back(t);
 
     dmd_x[curr_window]->takeSample(x_gf.GetTrueVector(), t);
     dmd_v[curr_window]->takeSample(v_gf.GetTrueVector(), t);
@@ -473,7 +473,6 @@ int main(int argc, char *argv[])
             curr_window++;
             dmd_x.push_back(new CAROM::DMD(x_gf.GetTrueVector().Size(), dt));
             dmd_v.push_back(new CAROM::DMD(v_gf.GetTrueVector().Size(), dt));
-            tw.push_back(t);
 
             dmd_x[curr_window]->takeSample(x_gf.GetTrueVector(), t);
             dmd_v[curr_window]->takeSample(v_gf.GetTrueVector(), t);

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -2,6 +2,44 @@
 //
 // Compile with: make nonlinear_elasticity
 //
+// =================================================================================
+//
+// Sample runs and results for serial DMD:
+//
+// Command 1:
+//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -visit
+//
+// Output 1:
+//   Relative error of DMD position (x) at t_final: 20 is 0.000571937
+//   Relative error of DMD velocity (v) at t_final: 20 is 6.16546
+//
+// Command 2:
+//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50.0 -visit
+//
+// Output 2:
+//   Relative error of DMD position (x) at t_final: 50 is 7.98169
+//   Relative error of DMD velocity (v) at t_final: 50 is 0.0276505
+//
+// =================================================================================
+//
+// Sample runs and results for time windowing DMD:
+//
+// Command 1:
+//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
+//
+// Output 1:
+//   Relative error of DMD position (x) at t_final: 20 is 4.11479e-06
+//   Relative error of DMD velocity (v) at t_final: 20 is 9.43364e-05
+//
+// Command 2:
+//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50.0 -nwinsamp 10 -visit
+//
+// Output 2:
+//   Relative error of DMD position (x) at t_final: 50 is 1.57678e-05
+//   Relative error of DMD velocity (v) at t_final: 50 is 2.2577e-05
+//
+// =================================================================================
+//
 // For DMD:
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.01 -tf 5 -visit
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
@@ -16,6 +54,8 @@
 //    mpirun -np 4 nonlinear_elasticity -m -s 14 -rs 2 -dt 0.03 -vs 20
 //    mpirun -np 4 nonlinear_elasticity -m -s 14 -rs 1 -dt 0.05 -vs 20
 //    mpirun -np 4 nonlinear_elasticity -m -s 3 -rs 2 -dt 3
+//
+// =================================================================================
 //
 // Description:  This examples solves a time dependent nonlinear elasticity
 //               problem of the form dv/dt = H(x) + S v, dx/dt = v, where H is a

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -640,6 +640,8 @@ int main(int argc, char *argv[])
 
         if (i % windowNumSamples == 0 && i < ts.size()-1)
         {
+            delete dmd_x[curr_window];
+            delete dmd_v[curr_window];
             curr_window++;
         }
     }

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -681,6 +681,8 @@ int main(int argc, char *argv[])
     delete result_v;
     delete dc;
     delete dmd_dc;
+    delete dmd_x[curr_window];
+    delete dmd_v[curr_window];
 
     MPI_Finalize();
 


### PR DESCRIPTION
This PR adds the option of time windowing DMD for MFEM example 10 nonlinear elasticity. Without specifying the option `-nwinsamp` it will run the serial DMD and produce identical results to master branch.

============================================================

Serial DMD results (takes a while to do the prediction)

Command 1:
`./nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20`

Output 1: 
Relative error of DMD position (x) at t_final: 20 is 0.000571937
Relative error of DMD velocity (v) at t_final: 20 is 6.16546

Command 2:
`./nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50.0`

Output 2: 
Relative error of DMD position (x) at t_final: 50 is 7.98169
Relative error of DMD velocity (v) at t_final: 50 is 0.0276505

============================================================

Time windowing DMD results (with 10 samples per window)

Command 1:
`./nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10`

Output 1: 
Relative error of DMD position (x) at t_final: 20 is 4.11479e-06
Relative error of DMD velocity (v) at t_final: 20 is 9.43364e-05

Command 2:
`./nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50.0 -nwinsamp 10`

Output 2: 
Relative error of DMD position (x) at t_final: 50 is 1.57678e-05
Relative error of DMD velocity (v) at t_final: 50 is 2.2577e-05