### PR TITLE
Updates on MFEM DMD examples

### DIFF
--- a/examples/dmd/dg_advection.cpp
+++ b/examples/dmd/dg_advection.cpp
@@ -19,22 +19,6 @@
 //   Relative error of DMD solution (u) at t_final: 4 is 0.00019053762
 //
 // =================================================================================
-// For DMD:
-//   mpirun -np 8 dg_advection
-//   mpirun -np 8 dg_advection -p 3 -rp 1 -dt 0.005 -tf 4 -visit
-//
-// Sample runs:
-//    mpirun -np 4 dg_advection -p 0 -dt 0.005
-//    mpirun -np 4 dg_advection -p 1 -dt 0.005 -tf 9
-//    mpirun -np 4 dg_advection -p 1 -rp 1 -dt 0.002 -tf 9
-//    mpirun -np 4 dg_advection -p 1 -rp 1 -dt 0.02 -s 13 -tf 9
-//    mpirun -np 4 dg_advection -p 1 -rp 1 -dt 0.004 -tf 9
-//    mpirun -np 4 dg_advection -p 1 -rp 1 -dt 0.005 -tf 9
-//    mpirun -np 4 dg_advection -p 3 -rp 2 -dt 0.0025 -tf 9 -vs 20
-//    mpirun -np 4 dg_advection -p 0 -o 2 -rp 1 -dt 0.01 -tf 8
-//    mpirun -np 4 dg_advection -p 0 -rs 2 -dt 0.005 -tf 2
-//    mpirun -np 4 dg_advection -p 0 -rs 1 -o 2 -tf 2
-//    mpirun -np 3 dg_advection -p 1 -rs 1 -rp 0 -dt 0.005 -tf 0.5
 //
 // Description:  This example code solves the time-dependent advection equation
 //               du/dt + v.grad(u) = 0, where v is a given fluid velocity, and

--- a/examples/dmd/dg_advection.cpp
+++ b/examples/dmd/dg_advection.cpp
@@ -571,11 +571,11 @@ int main(int argc, char *argv[])
             sout << "parallel " << num_procs << " " << myid << "\n";
             sout.precision(precision);
             sout << "solution\n" << *pmesh << *u;
-            sout << "pause\n";
+            //sout << "pause\n";
             sout << flush;
-            if (mpi.Root())
-                cout << "GLVis visualization paused."
-                     << " Press space (in the GLVis window) to resume it.\n";
+            //if (mpi.Root())
+            //    cout << "GLVis visualization paused."
+            //         << " Press space (in the GLVis window) to resume it.\n";
         }
     }
 

--- a/examples/dmd/dg_advection.cpp
+++ b/examples/dmd/dg_advection.cpp
@@ -2,13 +2,29 @@
 //
 // Compile with: make dg_advection
 //
+// =================================================================================
+//
+// Sample runs and results for DMD:
+//
+// Command 1:
+//   mpirun -np 8 dg_advection -p 0 -dt 0.01 -tf 2 -visit
+//
+// Output 1:
+//   Relative error of DMD solution (u) at t_final: 2 is 0.00031683336
+//
+// Command 2:
+//   mpirun -np 8 dg_advection -p 3 -rp 1 -dt 0.005 -tf 4 -visit
+//
+// Output 2:
+//   Relative error of DMD solution (u) at t_final: 4 is 0.00019053762
+//
+// =================================================================================
 // For DMD:
 //   mpirun -np 8 dg_advection
 //   mpirun -np 8 dg_advection -p 3 -rp 1 -dt 0.005 -tf 4 -visit
 //
 // Sample runs:
 //    mpirun -np 4 dg_advection -p 0 -dt 0.005
-//    mpirun -np 4 dg_advection -p 0 -dt 0.01
 //    mpirun -np 4 dg_advection -p 1 -dt 0.005 -tf 9
 //    mpirun -np 4 dg_advection -p 1 -rp 1 -dt 0.002 -tf 9
 //    mpirun -np 4 dg_advection -p 1 -rp 1 -dt 0.02 -s 13 -tf 9

--- a/examples/dmd/dg_advection.cpp
+++ b/examples/dmd/dg_advection.cpp
@@ -571,11 +571,7 @@ int main(int argc, char *argv[])
             sout << "parallel " << num_procs << " " << myid << "\n";
             sout.precision(precision);
             sout << "solution\n" << *pmesh << *u;
-            //sout << "pause\n";
             sout << flush;
-            //if (mpi.Root())
-            //    cout << "GLVis visualization paused."
-            //         << " Press space (in the GLVis window) to resume it.\n";
         }
     }
 

--- a/examples/dmd/dg_euler.cpp
+++ b/examples/dmd/dg_euler.cpp
@@ -287,13 +287,13 @@ int main(int argc, char *argv[])
             sout << "parallel " << mpi.WorldSize() << " " << mpi.WorldRank() << "\n";
             sout.precision(precision);
             sout << "solution\n" << pmesh << mom;
-            sout << "pause\n";
+            //sout << "pause\n";
             sout << flush;
-            if (mpi.Root())
-            {
-                cout << "GLVis visualization paused."
-                     << " Press space (in the GLVis window) to resume it.\n";
-            }
+            //if (mpi.Root())
+            //{
+            //    cout << "GLVis visualization paused."
+            //         << " Press space (in the GLVis window) to resume it.\n";
+            //}
         }
     }
 

--- a/examples/dmd/dg_euler.cpp
+++ b/examples/dmd/dg_euler.cpp
@@ -2,17 +2,38 @@
 //
 // Compile with: make dg_euler
 //
-// For AdaptiveDMD:
-//   mpirun -n 8 dg_euler
-//   mpirun -n 8 dg_euler -p 2 -rs 2 -rp 1 -o 1 -s 3 -visit
+// =================================================================================
 //
-// Sample runs:
+// Sample runs and results for adaptive DMD:
 //
-//       mpirun -np 4 dg_euler -p 1 -rs 2 -rp 1 -o 1 -s 3
-//       mpirun -np 4 dg_euler -p 1 -rs 1 -rp 1 -o 3 -s 4
-//       mpirun -np 4 dg_euler -p 1 -rs 1 -rp 1 -o 5 -s 6
-//       mpirun -np 4 dg_euler -p 2 -rs 1 -rp 1 -o 1 -s 3
-//       mpirun -np 4 dg_euler -p 2 -rs 1 -rp 1 -o 3 -s 3
+// Command 1:
+//   mpirun -np 8 dg_euler -p 1 -rs 1 -rp 1 -o 5 -s 6 -tf 0.1 -visit
+//
+// Output 1:
+//   Relative error of AdaptiveDMD density (dens) at t_final: 0.1 is 0.00015279217
+//   Relative error of AdaptiveDMD x-momentum (x_mom) at t_final: 0.1 is 2.9074268e-05
+//   Relative error of AdaptiveDMD y-momentum (y_mom) at t_final: 0.1 is 8.9542312e-05
+//   Relative error of AdaptiveDMD energy (e) at t_final: 0.1 is 6.8687185e-05
+//
+// Command 2:
+//   mpirun -np 8 dg_euler -p 2 -rs 2 -rp 1 -o 1 -s 3 -tf 0.1 -visit
+//
+// Output 2:
+//   Relative error of AdaptiveDMD density (dens) at t_final: 0.1 is 2.1881846e-06
+//   Relative error of AdaptiveDMD x-momentum (x_mom) at t_final: 0.1 is 4.3873307e-05
+//   Relative error of AdaptiveDMD y-momentum (y_mom) at t_final: 0.1 is 0.0026632618
+//   Relative error of AdaptiveDMD energy (e) at t_final: 0.1 is 2.3054118e-06
+//
+// Command 3:
+//   mpirun -np 8 dg_euler -p 2 -rs 2 -rp 1 -o 1 -s 3 -visit
+//
+// Output 3:
+//   Relative error of AdaptiveDMD density (dens) at t_final: 2 is 1.9677493e-05
+//   Relative error of AdaptiveDMD x-momentum (x_mom) at t_final: 2 is 0.00011781827
+//   Relative error of AdaptiveDMD y-momentum (y_mom) at t_final: 2 is 0.00017120499
+//   Relative error of AdaptiveDMD energy (e) at t_final: 2 is 1.9836223e-05
+//
+// =================================================================================
 //
 // Description:  This example code solves the compressible Euler system of
 //               equations, a model nonlinear hyperbolic PDE, with a

--- a/examples/dmd/dg_euler.cpp
+++ b/examples/dmd/dg_euler.cpp
@@ -308,13 +308,7 @@ int main(int argc, char *argv[])
             sout << "parallel " << mpi.WorldSize() << " " << mpi.WorldRank() << "\n";
             sout.precision(precision);
             sout << "solution\n" << pmesh << mom;
-            //sout << "pause\n";
             sout << flush;
-            //if (mpi.Root())
-            //{
-            //    cout << "GLVis visualization paused."
-            //         << " Press space (in the GLVis window) to resume it.\n";
-            //}
         }
     }
 

--- a/examples/dmd/heat_conduction.cpp
+++ b/examples/dmd/heat_conduction.cpp
@@ -343,13 +343,7 @@ int main(int argc, char *argv[])
         {
             sout.precision(precision);
             sout << "solution\n" << *pmesh << u_gf;
-            //sout << "pause\n";
             sout << flush;
-            //if (myid == 0)
-            //{
-            //    cout << "GLVis visualization paused."
-            //         << " Press space (in the GLVis window) to resume it.\n";
-            //}
         }
     }
 

--- a/examples/dmd/heat_conduction.cpp
+++ b/examples/dmd/heat_conduction.cpp
@@ -326,13 +326,13 @@ int main(int argc, char *argv[])
         {
             sout.precision(precision);
             sout << "solution\n" << *pmesh << u_gf;
-            sout << "pause\n";
+            //sout << "pause\n";
             sout << flush;
-            if (myid == 0)
-            {
-                cout << "GLVis visualization paused."
-                     << " Press space (in the GLVis window) to resume it.\n";
-            }
+            //if (myid == 0)
+            //{
+            //    cout << "GLVis visualization paused."
+            //         << " Press space (in the GLVis window) to resume it.\n";
+            //}
         }
     }
 

--- a/examples/dmd/heat_conduction.cpp
+++ b/examples/dmd/heat_conduction.cpp
@@ -2,6 +2,23 @@
 //
 // Compile with: make heat_conduction
 //
+// =================================================================================
+//
+// Sample runs and results for DMD:
+//
+// Command 1:
+//   mpirun -np 8 heat_conduction -s 1 -a 0.0 -k 1.0 -visit
+//
+// Output 1:
+//   Relative error of DMD temperature (u) at t_final: 0.5 is 0.00049906934
+//
+// Command 2:
+//   mpirun -np 8 heat_conduction -s 3 -a 0.5 -k 0.5 -o 4 -tf 0.7 -vs 1 -visit
+//
+// Output 2:
+//   Relative error of DMD temperature (u) at t_final: 0.7 is 0.00082289823
+//
+// =================================================================================
 // For DMD:
 //   mpirun -np 8 heat_conduction
 //   mpirun -np 8 heat_conduction -s 3 -a 0.5 -k 0.5 -o 4 -tf 0.7 -vs 1 -visit

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -668,12 +668,16 @@ int main(int argc, char *argv[])
 
         if (i == ts.size() - 1 || (i % vis_steps) == 0)
         {
+            GridFunction *nodes = &x_gf;
+            int owns_nodes = 0;
+            pmesh->SwapNodes(nodes, owns_nodes);
             if (visit)
             {
                 dmd_dc->SetCycle(i);
                 dmd_dc->SetTime(ts[i]);
                 dmd_dc->Save();
             }
+            pmesh->SwapNodes(nodes, owns_nodes);
         }
 
         delete result_x;

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -13,14 +13,14 @@
 //   Relative error of DMD position (x) at t_final: 5 is 6.95681e-05
 //   Relative error of DMD velocity (v) at t_final: 5 is 0.00139776
 //
-// Command 2:
+// Command 2: (Serial DMD does not work well)
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -visit
 //
 // Output 2:
 //   Relative error of DMD position (x) at t_final: 20 is 0.000571937
 //   Relative error of DMD velocity (v) at t_final: 20 is 6.16546
 //
-// Command 3:
+// Command 3: (Serial DMD does not work well)
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50 -visit
 //
 // Output 3:
@@ -38,14 +38,14 @@
 //   Relative error of DMD position (x) at t_final: 5 is 2.37444e-06
 //   Relative error of DMD velocity (v) at t_final: 5 is 3.40045e-05
 //
-// Command 2:
+// Command 2: (Time windowing DMD works significantly better than seiral DMD)
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
 //
 // Output 2:
 //   Relative error of DMD position (x) at t_final: 20 is 4.11479e-06
 //   Relative error of DMD velocity (v) at t_final: 20 is 9.43364e-05
 //
-// Command 3:
+// Command 3: (Time windowing DMD works significantly better than seiral DMD)
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50 -nwinsamp 10 -visit
 //
 // Output 3:

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -38,14 +38,14 @@
 //   Relative error of DMD position (x) at t_final: 5 is 2.37444e-06
 //   Relative error of DMD velocity (v) at t_final: 5 is 3.40045e-05
 //
-// Command 2: (Time windowing DMD works significantly better than seiral DMD)
+// Command 2: (Time windowing DMD works significantly better than serial DMD)
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
 //
 // Output 2:
 //   Relative error of DMD position (x) at t_final: 20 is 4.11479e-06
 //   Relative error of DMD velocity (v) at t_final: 20 is 9.43364e-05
 //
-// Command 3: (Time windowing DMD works significantly better than seiral DMD)
+// Command 3: (Time windowing DMD works significantly better than serial DMD)
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50 -nwinsamp 10 -visit
 //
 // Output 3:

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -432,6 +432,11 @@ int main(int argc, char *argv[])
             vis_w.precision(8);
             visualize(vis_w, pmesh, &x_gf, &w_gf, "Elastic energy density", true);
         }
+        //if (my_id == 0)
+        //{
+            //cout << "GLVis visualization paused."
+            //     << " Press space (in the GLVis window) to resume it.\n";
+        //}
     }
 
     // Create data collection for solution output: either VisItDataCollection for
@@ -756,8 +761,6 @@ void visualize(ostream &out, ParMesh *mesh, ParGridFunction *deformed_nodes,
         out << "keys cm\n";         // show colorbar and mesh
         out << "autoscale value\n"; // update value-range; keep mesh-extents fixed
         //out << "pause\n";
-        //cout << "GLVis visualization paused."
-        //     << " Press space (in the GLVis window) to resume it.\n";
     }
     out << flush;
 }

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -7,16 +7,23 @@
 // Sample runs and results for serial DMD:
 //
 // Command 1:
-//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -visit
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.01 -tf 5 -visit
 //
 // Output 1:
+//   Relative error of DMD position (x) at t_final: 5 is 6.95681e-05
+//   Relative error of DMD velocity (v) at t_final: 5 is 0.00139776
+//
+// Command 2:
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -visit
+//
+// Output 2:
 //   Relative error of DMD position (x) at t_final: 20 is 0.000571937
 //   Relative error of DMD velocity (v) at t_final: 20 is 6.16546
 //
-// Command 2:
-//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50.0 -visit
+// Command 3:
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50 -visit
 //
-// Output 2:
+// Output 3:
 //   Relative error of DMD position (x) at t_final: 50 is 7.98169
 //   Relative error of DMD velocity (v) at t_final: 50 is 0.0276505
 //
@@ -25,35 +32,25 @@
 // Sample runs and results for time windowing DMD:
 //
 // Command 1:
-//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.01 -tf 5 -nwinsamp 10 -visit
 //
 // Output 1:
+//   Relative error of DMD position (x) at t_final: 5 is 2.37444e-06
+//   Relative error of DMD velocity (v) at t_final: 5 is 3.40045e-05
+//
+// Command 2:
+//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
+//
+// Output 2:
 //   Relative error of DMD position (x) at t_final: 20 is 4.11479e-06
 //   Relative error of DMD velocity (v) at t_final: 20 is 9.43364e-05
 //
-// Command 2:
-//   ./nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50.0 -nwinsamp 10 -visit
-//
-// Output 2:
-//   Relative error of DMD position (x) at t_final: 50 is 1.57678e-05
-//   Relative error of DMD velocity (v) at t_final: 50 is 2.2577e-05
-//
-// =================================================================================
-//
-// For DMD:
-//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.01 -tf 5 -visit
-//   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.02 -tf 20 -nwinsamp 10 -visit
+// Command 3:
 //   mpirun -np 8 nonlinear_elasticity -s 2 -rs 1 -dt 0.05 -tf 50 -nwinsamp 10 -visit
 //
-// Sample runs:
-//    mpirun -np 4 nonlinear_elasticity -s 3 -rs 2 -dt 3
-//    mpirun -np 4 nonlinear_elasticity -s 3 -rs 2 -dt 3
-//    mpirun -np 4 nonlinear_elasticity -s 2 -rs 1 -dt 3
-//    mpirun -np 4 nonlinear_elasticity -m -s 2 -rs 1 -dt 3
-//    mpirun -np 4 nonlinear_elasticity -m -s 2 -rs 1 -dt 3
-//    mpirun -np 4 nonlinear_elasticity -m -s 14 -rs 2 -dt 0.03 -vs 20
-//    mpirun -np 4 nonlinear_elasticity -m -s 14 -rs 1 -dt 0.05 -vs 20
-//    mpirun -np 4 nonlinear_elasticity -m -s 3 -rs 2 -dt 3
+// Output 3:
+//   Relative error of DMD position (x) at t_final: 50 is 1.57678e-05
+//   Relative error of DMD velocity (v) at t_final: 50 is 2.2577e-05
 //
 // =================================================================================
 //

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -432,11 +432,6 @@ int main(int argc, char *argv[])
             vis_w.precision(8);
             visualize(vis_w, pmesh, &x_gf, &w_gf, "Elastic energy density", true);
         }
-        //if (my_id == 0)
-        //{
-            //cout << "GLVis visualization paused."
-            //     << " Press space (in the GLVis window) to resume it.\n";
-        //}
     }
 
     // Create data collection for solution output: either VisItDataCollection for
@@ -764,7 +759,6 @@ void visualize(ostream &out, ParMesh *mesh, ParGridFunction *deformed_nodes,
         }
         out << "keys cm\n";         // show colorbar and mesh
         out << "autoscale value\n"; // update value-range; keep mesh-extents fixed
-        //out << "pause\n";
     }
     out << flush;
 }

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -758,7 +758,9 @@ void visualize(ostream &out, ParMesh *mesh, ParGridFunction *deformed_nodes,
         }
         out << "keys cm\n";         // show colorbar and mesh
         out << "autoscale value\n"; // update value-range; keep mesh-extents fixed
-        out << "pause\n";
+        //out << "pause\n";
+        //cout << "GLVis visualization paused."
+        //     << " Press space (in the GLVis window) to resume it.\n";
     }
     out << flush;
 }

--- a/examples/dmd/parametric_heat_conduction.cpp
+++ b/examples/dmd/parametric_heat_conduction.cpp
@@ -390,13 +390,7 @@ int main(int argc, char *argv[])
         {
             sout.precision(precision);
             sout << "solution\n" << *pmesh << u_gf;
-            //sout << "pause\n";
             sout << flush;
-            //if (myid == 0)
-            //{
-            //    cout << "GLVis visualization paused."
-            //         << " Press space (in the GLVis window) to resume it.\n";
-            //}
         }
     }
 

--- a/examples/dmd/parametric_heat_conduction.cpp
+++ b/examples/dmd/parametric_heat_conduction.cpp
@@ -2,6 +2,8 @@
 //
 // Compile with: make parametric_heat_conduction
 //
+// =================================================================================
+//
 // In these examples, the radius of the interface between different initial temperatures, the
 // alpha coefficient, and two center location variables are modified.
 //
@@ -12,7 +14,7 @@
 //   mpirun -np 8 parametric_heat_conduction -r 0.55 -visit -offline -rdim 16
 //   mpirun -np 8 parametric_heat_conduction -r 0.6 -visit -offline -rdim 16
 //   mpirun -np 8 parametric_heat_conduction -r 0.5 -visit -online -predict
-
+//
 // For Parametric DMD (ex. 2) (radius & cx & cy, extrapolation):
 //   rm -rf parameters.txt
 //   mpirun -np 8 parametric_heat_conduction -r 0.1 -visit -offline -rdim 16
@@ -33,7 +35,7 @@
 //   mpirun -np 8 parametric_heat_conduction -a 0.25 -visit -offline -rdim 16
 //   mpirun -np 8 parametric_heat_conduction -a 0.3 -visit -offline -rdim 16
 //   mpirun -np 8 parametric_heat_conduction -a 0.2 -visit -online -predict
-
+//
 // For Parametric DMD (ex. 4) (alpha, interpolation):
 //   rm -rf parameters.txt
 //   mpirun -np 8 parametric_heat_conduction -s 3 -a 0.5 -k 0.5 -o 4 -tf 0.7 -vs 1 -visit -offline -rdim 20
@@ -42,15 +44,7 @@
 //   mpirun -np 8 parametric_heat_conduction -s 3 -a 0.7 -k 0.5 -o 4 -tf 0.7 -vs 1 -visit -offline -rdim 20
 //   mpirun -np 8 parametric_heat_conduction -s 3 -a 0.6 -k 0.5 -o 4 -tf 0.7 -vs 1 -visit -online -predict
 //
-// Sample runs:  mpirun -np 4 parametric_heat_conduction
-//               mpirun -np 4 parametric_heat_conduction -tf 2
-//               mpirun -np 4 parametric_heat_conduction -s 1 -a 0.0 -k 1.0
-//               mpirun -np 4 parametric_heat_conduction -s 2 -a 1.0 -k 0.0
-//               mpirun -np 8 parametric_heat_conduction -s 3 -a 0.5 -k 0.5 -o 4
-//               mpirun -np 4 parametric_heat_conduction -s 14 -dt 1.0e-4 -tf 4.0e-2 -vs 40
-//               mpirun -np 8 parametric_heat_conduction -tf 10 -dt 0.1
-//               mpirun -np 4 parametric_heat_conduction -o 4 -rs 0 -rp 0
-//               mpirun -np 4 parametric_heat_conduction -o 2 -rs 0 -rp 0
+// =================================================================================
 //
 // Description:  This example solves a time dependent nonlinear heat equation
 //               problem of the form du/dt = C(u), with a non-linear diffusion

--- a/examples/dmd/parametric_heat_conduction.cpp
+++ b/examples/dmd/parametric_heat_conduction.cpp
@@ -396,13 +396,13 @@ int main(int argc, char *argv[])
         {
             sout.precision(precision);
             sout << "solution\n" << *pmesh << u_gf;
-            sout << "pause\n";
+            //sout << "pause\n";
             sout << flush;
-            if (myid == 0)
-            {
-                cout << "GLVis visualization paused."
-                     << " Press space (in the GLVis window) to resume it.\n";
-            }
+            //if (myid == 0)
+            //{
+            //    cout << "GLVis visualization paused."
+            //         << " Press space (in the GLVis window) to resume it.\n";
+            //}
         }
     }
 


### PR DESCRIPTION
- Add representation command lines and results in DMD examples. Each file now includes the results on [libROM webpage](https://www.librom.net/examples.html) and 1-2 more examples
- Remove command lines copied from MFEM. 
- Fix a visit visualization issue in nonlinear elasticity DMD, where the deformed mesh should be used. 
- Remove the pauses in glvis visualization. Otherwise users are required to press space in all the glvis windows after initialization to resume the run.

