### PR TITLE
Added toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ FCMangle.h
 # Do not track executables
 build
 
-# Do not track docs/latex
+# Do not track docs/latex and docs/html
 docs/latex
+docs/html

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ To compile and link an existing code with libROM, follow these steps:
  -lROM
 ```
 
+For example,
+```sh
+mpicxx myapp.cpp -I/path/to/libROM/lib -Wl,-rpath,/path/to/libROM/build/lib -L/path/to/libROM/build/lib -lROM -o myapp.out
+```
+
+
 # License
 
 libROM is distributed under the terms of both the MIT license and the

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ To install libROM with MFEM using spack.
  spack install librom +mfem
 ```
 
+# Compiling and linking with libROM
+
+To compile and link an existing code with libROM, follow these steps:
+
+- Add libROM/lib to the include path
+```sh
+ -I/path/to/libROM/lib
+```
+- Add the following to the linker flags (LDFLAGS)
+```sh
+ -Wl,-rpath,/path/to/libROM/build/lib -L/path/to/libROM/build/lib
+```
+- Add the following library
+```sh
+ -lROM
+```
+
 # License
 
 libROM is distributed under the terms of both the MIT license and the

--- a/cmake/toolchains/default-toss_3_x86_64_ib-librom-dev.cmake
+++ b/cmake/toolchains/default-toss_3_x86_64_ib-librom-dev.cmake
@@ -1,0 +1,31 @@
+# Toolchain for Lawrence Livermore National Laboratory TOSS3 machines
+# (e.g., Quartz), using the compilers and HDF5 library as available
+# in the environment (i.e., through "module load").
+#
+# Note that:
+#   which mpicc
+#   which mpicxx
+#   which mpif90
+#   which h5diff
+# should point to MPI compilers and the HDF5 library built with
+# the same C/FORTRAN compilers.
+
+# Use MPI compiler wrappers because it simplifies detection of MPI
+set(CMAKE_C_COMPILER mpicc)
+set(CMAKE_CXX_COMPILER mpicxx)
+set(CMAKE_Fortran_COMPILER mpif90)
+set(BLA_VENDOR Intel10_64lp)
+
+execute_process(
+  COMMAND "echo $(which h5diff) | sed -e s/'/bin/h5diff'//"
+  OUTPUT_VARIABLE hdf5_serial_path
+)
+set(HDF5_ROOT ${hdf5_serial_path})
+
+set(BLAS_ROOT /usr/tce/packages/mkl/mkl-2019.0/mkl)
+set(LAPACK_ROOT /usr/tce/packages/mkl/mkl-2019.0/mkl)
+set(CMAKE_LIBRARY_ARCHITECTURE intel64)
+
+set(MKL_MESSAGE_PASSING MPICH2)
+set(MKL_THREADING Sequential)
+set(MKL_ROOT /usr/tce/packages/mkl/mkl-2019.0/mkl)

--- a/cmake/toolchains/gnu4-toss_3_x86_64_ib-librom-dev.cmake
+++ b/cmake/toolchains/gnu4-toss_3_x86_64_ib-librom-dev.cmake
@@ -1,0 +1,22 @@
+# Toolchain for Lawrence Livermore National Laboratory TOSS3 machines
+# (e.g., Quartz), assuming the following dependencies:
+#
+# - MVAPICH2/2.3 with Intel 19.0.4 compilers
+# - Intel MKL
+# - HDF5 1.8.18
+
+# Use MPI compiler wrappers because it simplifies detection of MPI
+set(CMAKE_C_COMPILER mpicc)
+set(CMAKE_CXX_COMPILER mpicxx)
+set(CMAKE_Fortran_COMPILER mpif90)
+set(BLA_VENDOR Intel10_64lp)
+set(HDF5_ROOT /usr/tce/packages/hdf5/hdf5-serial-1.8.17-gcc4.9.3)
+#string(APPEND CMAKE_CXX_FLAGS_INIT " -gxx-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++")
+
+set(BLAS_ROOT /usr/tce/packages/mkl/mkl-2019.0/mkl)
+set(LAPACK_ROOT /usr/tce/packages/mkl/mkl-2019.0/mkl)
+set(CMAKE_LIBRARY_ARCHITECTURE intel64)
+
+set(MKL_MESSAGE_PASSING MPICH2)
+set(MKL_THREADING Sequential)
+set(MKL_ROOT /usr/tce/packages/mkl/mkl-2019.0/mkl)

--- a/cmake/toolchains/gnu4-toss_3_x86_64_ib-librom-dev.cmake
+++ b/cmake/toolchains/gnu4-toss_3_x86_64_ib-librom-dev.cmake
@@ -1,14 +1,14 @@
 # Toolchain for Lawrence Livermore National Laboratory TOSS3 machines
 # (e.g., Quartz), assuming the following dependencies:
 #
-# - MVAPICH2/2.3 with Intel 19.0.4 compilers
+# - MVAPICH2/2.2 with GNU 4.9.3 compilers
 # - Intel MKL
-# - HDF5 1.8.18
+# - HDF5 1.8.17
 
 # Use MPI compiler wrappers because it simplifies detection of MPI
-set(CMAKE_C_COMPILER mpicc)
-set(CMAKE_CXX_COMPILER mpicxx)
-set(CMAKE_Fortran_COMPILER mpif90)
+set(CMAKE_C_COMPILER /usr/tce/packages/mvapich2/mvapich2-2.2-gcc-4.9.3/bin/mpicc)
+set(CMAKE_CXX_COMPILER /usr/tce/packages/mvapich2/mvapich2-2.2-gcc-4.9.3/bin/mpicxx)
+set(CMAKE_Fortran_COMPILER /usr/tce/packages/mvapich2/mvapich2-2.2-gcc-4.9.3/bin/mpif90)
 set(BLA_VENDOR Intel10_64lp)
 set(HDF5_ROOT /usr/tce/packages/hdf5/hdf5-serial-1.8.17-gcc4.9.3)
 #string(APPEND CMAKE_CXX_FLAGS_INIT " -gxx-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++")

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -88,7 +88,7 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   if [[ $ARDRA == "true" ]]; then
       TOOLCHAIN_FILE=${REPO_PREFIX}/cmake/toolchains/ic18-toss_3_x86_64_ib-ardra.cmake
   elif [[ -z ${TOOLCHAIN_FILE} ]]; then
-      TOOLCHAIN_FILE=${REPO_PREFIX}/cmake/toolchains/ic19-toss_3_x86_64_ib-librom-dev.cmake
+      TOOLCHAIN_FILE=${REPO_PREFIX}/cmake/toolchains/default-toss_3_x86_64_ib-librom-dev.cmake
   fi
   cmake ${REPO_PREFIX} \
         -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \


### PR DESCRIPTION
I have added the toolchain file required to compile on Quartz with GNU compilers, assuming they are currently loaded in the environment (i.e., the command "mpicc -v" or "mpicxx -v" should indicate a GNU compiler).

Also updated .gitignore to ignore docs/html