### PR TITLE
Add init samples to S_OPT for Laghos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ non-intrusive black-box approaches.
 
 ## Features to be added
 
-- S-OPT: stable sampling algorithm for hyper-reduction
 - EQP: quadrature-based hyper-reduction sampling algorithm
 - Python interface
 

--- a/lib/hyperreduction/GNAT.h
+++ b/lib/hyperreduction/GNAT.h
@@ -42,6 +42,7 @@ class Matrix;
  * @param[in] myid The rank of this process.
  * @param[in] num_procs The total number of processes.
  * @param[in] num_samples_req The minimum number of samples required.
+ * @param[in] init_samples Samples to initialize the GNAT algorithm.
  */
 void
 GNAT(const Matrix* f_basis,

--- a/lib/hyperreduction/S_OPT.C
+++ b/lib/hyperreduction/S_OPT.C
@@ -141,8 +141,13 @@ S_OPT(const Matrix* f_basis,
     int init_sample_offset = 0;
     for (int i = 0; i < total_num_init_samples; i++)
     {
-        f_bv_max_local.row_val = 1.0;
-        f_bv_max_local.row = (*init_samples)[init_sample_offset];
+        f_bv_max_local.row_val = -1.0;
+        f_bv_max_local.proc = myid;
+        if (init_sample_offset < num_init_samples)
+        {
+            f_bv_max_local.row_val = 1.0;
+            f_bv_max_local.row = (*init_samples)[init_sample_offset];
+        }
         MPI_Allreduce(&f_bv_max_local, &f_bv_max_global, 1,
                       MaxRowType, RowInfoOp, MPI_COMM_WORLD);
         // Now get the first sampled row of the basis of the rhs->
@@ -436,6 +441,7 @@ S_OPT(const Matrix* f_basis,
             }
 
             f_bv_max_local.row_val = -1.0;
+            f_bv_max_local.proc = myid;
             for (int j = 0; j < num_rows; ++j) {
                 if (proc_f_row_to_tmp_fs_row[f_bv_max_local.proc].find(j) ==
                         proc_f_row_to_tmp_fs_row[f_bv_max_local.proc].end())

--- a/lib/hyperreduction/S_OPT.C
+++ b/lib/hyperreduction/S_OPT.C
@@ -191,7 +191,7 @@ S_OPT(const Matrix* f_basis,
         proc_f_row_to_tmp_fs_row[f_bv_max_global.proc][f_bv_max_global.row] = 0;
         num_samples_obtained++;
     }
-    if (num_samples > 1 || total_num_init_samples > 0)
+    if (num_samples_obtained < num_samples)
     {
         Vector* A = new Vector(num_rows, f_basis->distributed());
         Vector* noM = new Vector(num_rows, f_basis->distributed());

--- a/lib/hyperreduction/S_OPT.C
+++ b/lib/hyperreduction/S_OPT.C
@@ -18,6 +18,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <climits>
 
 #include "S_OPT.h"
 
@@ -141,7 +142,7 @@ S_OPT(const Matrix* f_basis,
     int init_sample_offset = 0;
     for (int i = 0; i < total_num_init_samples; i++)
     {
-        f_bv_max_local.row_val = -1.0;
+        f_bv_max_local.row_val = -INT_MAX;
         f_bv_max_local.proc = myid;
         if (init_sample_offset < num_init_samples)
         {
@@ -167,9 +168,10 @@ S_OPT(const Matrix* f_basis,
         proc_f_row_to_tmp_fs_row[f_bv_max_global.proc][f_bv_max_global.row] = num_samples_obtained;
         num_samples_obtained++;
     }
+
     if (num_samples_obtained == 0)
     {
-        f_bv_max_local.row_val = -1.0;
+        f_bv_max_local.row_val = -INT_MAX;
         f_bv_max_local.proc = myid;
         for (int i = 0; i < num_rows; ++i) {
             double f_bv_val = fabs(Vo->item(i, 0));
@@ -196,6 +198,7 @@ S_OPT(const Matrix* f_basis,
         proc_f_row_to_tmp_fs_row[f_bv_max_global.proc][f_bv_max_global.row] = 0;
         num_samples_obtained++;
     }
+
     if (num_samples_obtained < num_samples)
     {
         Vector* A = new Vector(num_rows, f_basis->distributed());
@@ -210,7 +213,12 @@ S_OPT(const Matrix* f_basis,
         Vector ls_res_first_row(num_basis_vectors - 1, false);
         Vector nV(num_basis_vectors, false);
 
-        for (int i = 2 + total_num_init_samples; i <= num_samples; i++)
+        int start_idx = 2;
+        if (total_num_init_samples > 1)
+        {
+            start_idx += (total_num_init_samples - 1);
+        }
+        for (int i = start_idx; i <= num_samples; i++)
         {
             if (i <= num_basis_vectors)
             {
@@ -440,7 +448,7 @@ S_OPT(const Matrix* f_basis,
                 delete ls_res;
             }
 
-            f_bv_max_local.row_val = -1.0;
+            f_bv_max_local.row_val = -INT_MAX;
             f_bv_max_local.proc = myid;
             for (int j = 0; j < num_rows; ++j) {
                 if (proc_f_row_to_tmp_fs_row[f_bv_max_local.proc].find(j) ==

--- a/lib/hyperreduction/S_OPT.C
+++ b/lib/hyperreduction/S_OPT.C
@@ -18,7 +18,7 @@
 #include <vector>
 #include <map>
 #include <set>
-#include <climits>
+#include <cfloat>
 
 #include "S_OPT.h"
 
@@ -41,7 +41,7 @@ S_OPT(const Matrix* f_basis,
     CAROM_VERIFY(num_procs == f_sampled_rows_per_proc.size());
     // This algorithm determines the rows of f that should be sampled, the
     // processor that owns each sampled row, and fills f_basis_sampled_inv with
-    // the inverse of the sampled rows of the basis of the RHS.
+    // the inverse of the sampled rows of the basis.
 
     // Create an MPI_Datatype for the RowInfo struct.
     MPI_Datatype MaxRowType, oldtypes[2];
@@ -142,7 +142,7 @@ S_OPT(const Matrix* f_basis,
     int init_sample_offset = 0;
     for (int i = 0; i < total_num_init_samples; i++)
     {
-        f_bv_max_local.row_val = -INT_MAX;
+        f_bv_max_local.row_val = -DBL_MAX;
         f_bv_max_local.proc = myid;
         if (init_sample_offset < num_init_samples)
         {
@@ -151,7 +151,7 @@ S_OPT(const Matrix* f_basis,
         }
         MPI_Allreduce(&f_bv_max_local, &f_bv_max_global, 1,
                       MaxRowType, RowInfoOp, MPI_COMM_WORLD);
-        // Now get the first sampled row of the basis of the rhs->
+        // Now get the first sampled row of the basis
         if (f_bv_max_global.proc == myid) {
             for (int j = 0; j < num_basis_vectors; ++j) {
                 c[j] = Vo->item(f_bv_max_global.row, j);
@@ -160,7 +160,7 @@ S_OPT(const Matrix* f_basis,
         }
         MPI_Bcast(c.data(), num_basis_vectors, MPI_DOUBLE,
                   f_bv_max_global.proc, MPI_COMM_WORLD);
-        // Now add the first sampled row of the basis of the RHS to tmp_fs.
+        // Now add the first sampled row of the basis to tmp_fs.
         for (int j = 0; j < num_basis_vectors; ++j) {
             V1.item(num_samples_obtained, j) = c[j];
         }
@@ -171,7 +171,7 @@ S_OPT(const Matrix* f_basis,
 
     if (num_samples_obtained == 0)
     {
-        f_bv_max_local.row_val = -INT_MAX;
+        f_bv_max_local.row_val = -DBL_MAX;
         f_bv_max_local.proc = myid;
         for (int i = 0; i < num_rows; ++i) {
             double f_bv_val = fabs(Vo->item(i, 0));
@@ -182,7 +182,7 @@ S_OPT(const Matrix* f_basis,
         }
         MPI_Allreduce(&f_bv_max_local, &f_bv_max_global, 1,
                       MaxRowType, RowInfoOp, MPI_COMM_WORLD);
-        // Now get the first sampled row of the basis of the rhs->
+        // Now get the first sampled row of the basis
         if (f_bv_max_global.proc == myid) {
             for (int j = 0; j < num_basis_vectors; ++j) {
                 c[j] = Vo->item(f_bv_max_global.row, j);
@@ -190,7 +190,7 @@ S_OPT(const Matrix* f_basis,
         }
         MPI_Bcast(c.data(), num_basis_vectors, MPI_DOUBLE,
                   f_bv_max_global.proc, MPI_COMM_WORLD);
-        // Now add the first sampled row of the basis of the RHS to tmp_fs.
+        // Now add the first sampled row of the basis to tmp_fs.
         for (int j = 0; j < num_basis_vectors; ++j) {
             V1.item(0, j) = c[j];
         }
@@ -448,7 +448,7 @@ S_OPT(const Matrix* f_basis,
                 delete ls_res;
             }
 
-            f_bv_max_local.row_val = -INT_MAX;
+            f_bv_max_local.row_val = -DBL_MAX;
             f_bv_max_local.proc = myid;
             for (int j = 0; j < num_rows; ++j) {
                 if (proc_f_row_to_tmp_fs_row[f_bv_max_local.proc].find(j) ==
@@ -463,7 +463,7 @@ S_OPT(const Matrix* f_basis,
             }
             MPI_Allreduce(&f_bv_max_local, &f_bv_max_global, 1,
                           MaxRowType, RowInfoOp, MPI_COMM_WORLD);
-            // Now get the first sampled row of the basis of the rhs->
+            // Now get the first sampled row of the basis
             if (f_bv_max_global.proc == myid) {
                 for (int j = 0; j < num_basis_vectors; ++j) {
                     c[j] = Vo->item(f_bv_max_global.row, j);
@@ -471,7 +471,7 @@ S_OPT(const Matrix* f_basis,
             }
             MPI_Bcast(c.data(), num_basis_vectors, MPI_DOUBLE,
                       f_bv_max_global.proc, MPI_COMM_WORLD);
-            // Now add the first sampled row of the basis of the RHS to tmp_fs.
+            // Now add the first sampled row of the basis to tmp_fs.
             for (int j = 0; j < num_basis_vectors; ++j) {
                 V1.item(num_samples_obtained, j) = c[j];
             }

--- a/lib/hyperreduction/S_OPT.h
+++ b/lib/hyperreduction/S_OPT.h
@@ -40,6 +40,7 @@ class Matrix;
  * @param[in] myid The rank of this process.
  * @param[in] num_procs The total number of processes.
  * @param[in] num_samples_req The minimum number of samples required.
+ * @param[in] init_samples Samples to initialize the S_OPT algorithm.
  * @param[in] qr_factorize Whether to factorize the incoming matrix. If true and
  *                         if the incoming matrix is a basis, the unnecessary
  *                         computation of a QR factorization will be performed.
@@ -53,6 +54,7 @@ S_OPT(const Matrix* f_basis,
       const int myid,
       const int num_procs,
       const int num_samples_req = -1,
+      std::vector<int> *init_samples=NULL,
       bool qr_factorize = false);
 
 }

--- a/lib/librom.h
+++ b/lib/librom.h
@@ -23,7 +23,9 @@
 #include "algo/manifold_interp/MatrixInterpolator.h"
 #include "algo/manifold_interp/VectorInterpolator.h"
 #include "hyperreduction/DEIM.h"
+#include "hyperreduction/GNAT.h"
 #include "hyperreduction/QDEIM.h"
+#include "hyperreduction/S_OPT.h"
 #include "hyperreduction/STSampling.h"
 #ifdef USEMFEM
 #include "mfem/SampleMesh.hpp"

--- a/tests/test_S_OPT.C
+++ b/tests/test_S_OPT.C
@@ -327,9 +327,9 @@ TEST(S_OPTSerialTest, Test_S_OPT_init_vector)
     std::vector<int> f_sampled_row(num_samples, 0);
     std::vector<int> f_sampled_row_true_ans{0, 44, 46, 49, 90};
     std::vector<int> f_sampled_rows_per_proc(d_num_procs, 0);
-
-    // Just the first element (90)
     std::vector<int> init_samples;
+
+    // Use just the first true sampled element as an initial sample (90)
     if (row_offset[d_rank] <= 90 && row_offset[d_rank + 1] > 90)
     {
         init_samples.push_back(90 - row_offset[d_rank]);
@@ -364,7 +364,7 @@ TEST(S_OPTSerialTest, Test_S_OPT_init_vector)
     // Allow for some error due to float rounding
     EXPECT_TRUE(l2_norm_diff < 1e-4);
 
-    // Try the first element and second element (90, 0)
+    // Add the second true sampled element as an initial sample (0)
     if (d_rank == 0)
     {
         init_samples.push_back(0);

--- a/tests/test_S_OPT.C
+++ b/tests/test_S_OPT.C
@@ -327,8 +327,9 @@ TEST(S_OPTSerialTest, Test_S_OPT_QR)
     std::vector<int> f_sampled_row(num_samples, 0);
     std::vector<int> f_sampled_row_true_ans{0, 44, 46, 49, 90};
     std::vector<int> f_sampled_rows_per_proc(d_num_procs, 0);
+    std::vector<int> init_samples;
     CAROM::Matrix f_basis_sampled_inv = CAROM::Matrix(num_samples, num_basis_vectors, false);
-    CAROM::S_OPT(u, num_basis_vectors, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, d_rank, d_num_procs, num_samples, true);
+    CAROM::S_OPT(u, num_basis_vectors, f_sampled_row, f_sampled_rows_per_proc, f_basis_sampled_inv, d_rank, d_num_procs, num_samples, &init_samples, true);
 
     int curr_index = 0;
     for (int i = 1; i < f_sampled_rows_per_proc.size(); i++)


### PR DESCRIPTION
It wasn't entirely clear to me what the GNAT version of this was doing, so I tried to re-implement it here.

Here, I assume each process has its own unique init_samples vector using the local row indices (i.e., the indices for each init_samples vector start from zero on each processor) and that num_samples <= init_samples.

1. Sample all init_samples from each processor in a random order.
2. Continue on with the normal S_OPT algorithm assuming we still have some samples left over to sample, skipping the special case for the very first sample.