### PR TITLE
minor change for prom examples in libROM

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ These data and examples are built using MFEM and derived from their examples
 
 - DG Advection (Global ROM)
 - DG Advection (Local ROM with matrix interpolation)
+- Linear Elasticity
 - Mixed Linear Diffusion (Global ROM)
 - Poisson (Global ROM)
 - Poisson (Local ROM using the greedy algorithm)

--- a/examples/dmd/de_parametric_heat_conduction_greedy.cpp
+++ b/examples/dmd/de_parametric_heat_conduction_greedy.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: Greedy Parametric_Heat_Conduction with Differential Evolution (adapted from ex16p.cpp)
 //
 // Compile with: make de_parametric_heat_conduction_greedy

--- a/examples/dmd/dg_advection.cpp
+++ b/examples/dmd/dg_advection.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: DG Advection (adapted from ex9p.cpp)
 //
 // Compile with: make dg_advection

--- a/examples/dmd/dg_euler.cpp
+++ b/examples/dmd/dg_euler.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                         libROM MFEM Example: DG Euler Equations (adapted from ex18p.cpp)
 //
 // Compile with: make dg_euler

--- a/examples/dmd/dg_euler.hpp
+++ b/examples/dmd/dg_euler.hpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                  libROM MFEM Example: DG Euler Equations (adapted from ex18p.cpp)
 
 #include "mfem.hpp"

--- a/examples/dmd/heat_conduction.cpp
+++ b/examples/dmd/heat_conduction.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: Heat_Conduction (adapted from ex16p.cpp)
 //
 // Compile with: make heat_conduction

--- a/examples/dmd/nonlinear_elasticity.cpp
+++ b/examples/dmd/nonlinear_elasticity.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: Nonlinear elasticity (adapted from ex10p.cpp)
 //
 // Compile with: make nonlinear_elasticity

--- a/examples/dmd/parametric_heat_conduction.cpp
+++ b/examples/dmd/parametric_heat_conduction.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: Parametric_Heat_Conduction (adapted from ex16p.cpp)
 //
 // Compile with: make parametric_heat_conduction

--- a/examples/prom/dg_advection_global_rom.cpp
+++ b/examples/prom/dg_advection_global_rom.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: DG Advection (adapted from ex9p.cpp)
 //
 // Compile with: make dg_advection_global_rom

--- a/examples/prom/dg_advection_local_rom_matrix_interp.cpp
+++ b/examples/prom/dg_advection_local_rom_matrix_interp.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //                       libROM MFEM Example: DG Advection (adapted from ex9p.cpp)
 //
 // Compile with: make dg_advection_local_rom_matrix_interp

--- a/examples/prom/linear_elasticity_global_rom.cpp
+++ b/examples/prom/linear_elasticity_global_rom.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //               libROM MFEM Example: parametric ROM for linear elasticity problem (adapted from ex2p.cpp)
 //
 // Compile with: ./scripts/compile.sh -m

--- a/examples/prom/linear_elasticity_global_rom.cpp
+++ b/examples/prom/linear_elasticity_global_rom.cpp
@@ -17,17 +17,17 @@
 //               operator, solves the reduced order system, and lifts the
 //               solution to the full order space.
 //
-// Offline phase: ./linear_elasticity_global_rom -offline -id 0 -f 0.01
-//                ./linear_elasticity_global_rom -offline -id 1 -f 0.015
-//                ./linear_elasticity_global_rom -offline -id 2 -f 0.02
+// Offline phase: ./linear_elasticity_global_rom -offline -id 0 -nu 0.2
+//                ./linear_elasticity_global_rom -offline -id 1 -nu 0.4
 //
 //
-// Merge phase:   ./linear_elasticity_global_rom -merge -ns 3
+// Merge phase:   ./linear_elasticity_global_rom -merge -ns 2
 //
-// Online phase:  ./linear_elasticity_global_rom -online -id 3 -f 0.012
-// 
 // NB: to evaluate relative error, call this before the online phase:
-//                ./linear_elasticity_global_rom -offline -id 4 -f 0.012
+//                ./linear_elasticity_global_rom -offline -id 2 -nu 0.3
+//
+// Online phase:  ./linear_elasticity_global_rom -online -id 3 -nu 0.3
+// 
 
 #include "mfem.hpp"
 #include <fstream>

--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //               libROM MFEM Example: parametric ROM for nonlinear diffusion problem
 //
 // Compile with: ./scripts/compile.sh -m

--- a/examples/prom/poisson_global_rom.cpp
+++ b/examples/prom/poisson_global_rom.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //               libROM MFEM Example: parametric ROM for Poisson problem (adapted from ex1p.cpp)
 //
 // Compile with: ./scripts/compile.sh -m

--- a/examples/prom/poisson_local_rom_greedy.cpp
+++ b/examples/prom/poisson_local_rom_greedy.cpp
@@ -520,7 +520,7 @@ int main(int argc, char *argv[])
         DataCollection *dc = NULL;
         if (visit)
         {
-            if(offline) dc = new VisItDataCollection("Example1", &pmesh);
+            if(offline || fom) dc = new VisItDataCollection("Example1", &pmesh);
             else if(online) dc = new VisItDataCollection("Example1_rom", &pmesh);
             dc->SetPrecision(precision);
             dc->RegisterField("solution", &x);

--- a/examples/prom/poisson_local_rom_greedy.cpp
+++ b/examples/prom/poisson_local_rom_greedy.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2022, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
 //               libROM MFEM Example: parametric ROM for Poisson problem (adapted from ex1p.cpp)
 //
 // Compile with: ./scripts/compile.sh -m


### PR DESCRIPTION
Two minor changes are made for this PR:

1. enable visit output for -fom flag in poisson_local_rom_greedy.cpp
2. Change the parameterization for linear_elasticity_global_rom.cpp to be "nu" because "external force" parameter is linear and linear parameterization for linear problem is easier to solve than the nonlinear parameterization. 
