### PR TITLE
Parallel example bug fixes

### DIFF
--- a/examples/prom/dg_advection_global_rom.cpp
+++ b/examples/prom/dg_advection_global_rom.cpp
@@ -678,7 +678,7 @@ int main(int argc, char *argv[])
     CAROM::Vector *b_hat_carom, *u_init_hat_carom;
     Vector *b_hat, *u_init_hat;
 
-    Vector u_init(*U->GlobalVector());
+    Vector u_init(*U);
     Vector *u_in;
 
     // 10. Set BasisGenerator if offline
@@ -686,7 +686,7 @@ int main(int argc, char *argv[])
     {
         options = new CAROM::Options(U->Size(), max_num_snapshots, 1, update_right_SV);
         generator = new CAROM::BasisGenerator(*options, isIncremental, basisFileName);
-        Vector u_curr(*U->GlobalVector());
+        Vector u_curr(*U);
         Vector u_centered(U->Size());
         subtract(u_curr, u_init, u_centered);
         bool addSample = generator->takeSample(u_centered.GetData(), t, dt);
@@ -766,7 +766,7 @@ int main(int argc, char *argv[])
         K_hat->Set(1, K_hat_carom->getData());
         K_hat->Transpose();
 
-        Vector b_vec = *B->GlobalVector();
+        Vector b_vec = *B;
         CAROM::Vector b_carom(b_vec.GetData(), b_vec.Size(), true);
         b_hat_carom = spatialbasis->transposeMult(&b_carom);
         b_hat = new Vector(b_hat_carom->getData(), b_hat_carom->dim());
@@ -820,7 +820,7 @@ int main(int argc, char *argv[])
         // 18. take and write snapshot for ROM
         if (offline)
         {
-            Vector u_curr(*U->GlobalVector());
+            Vector u_curr(*U);
             Vector u_centered(U->Size());
             subtract(u_curr, u_init, u_centered);
             bool addSample = generator->takeSample(u_centered.GetData(), t, dt);

--- a/examples/prom/dg_advection_global_rom.cpp
+++ b/examples/prom/dg_advection_global_rom.cpp
@@ -55,6 +55,9 @@
 //               with VisIt (visit.llnl.gov) and ParaView (paraview.org), as
 //               well as the optional saving with ADIOS2 (adios2.readthedocs.io)
 //               are also illustrated.
+//
+// This example runs in parallel with MPI, by using the same number of MPI ranks
+// in all phases (offline, merge, fom, online).
 
 #include "mfem.hpp"
 #include "linalg/Vector.h"

--- a/examples/prom/dg_advection_local_rom_matrix_interp.cpp
+++ b/examples/prom/dg_advection_local_rom_matrix_interp.cpp
@@ -698,7 +698,7 @@ int main(int argc, char *argv[])
     CAROM::Vector *b_hat_carom, *u_init_hat_carom;
     Vector *b_hat, *u_init_hat;
 
-    Vector u_init(*U->GlobalVector());
+    Vector u_init(*U);
     Vector *u_in;
 
     // 10. Set BasisGenerator if offline
@@ -706,7 +706,7 @@ int main(int argc, char *argv[])
     {
         options = new CAROM::Options(U->Size(), max_num_snapshots, 1, update_right_SV);
         generator = new CAROM::BasisGenerator(*options, isIncremental, basisName);
-        Vector u_curr(*U->GlobalVector());
+        Vector u_curr(*U);
         Vector u_centered(U->Size());
         subtract(u_curr, u_init, u_centered);
         bool addSample = generator->takeSample(u_centered.GetData(), t, dt);
@@ -764,7 +764,7 @@ int main(int argc, char *argv[])
             K_hat->Set(1, K_hat_carom->getData());
             K_hat->Transpose();
 
-            Vector b_vec = *B->GlobalVector();
+            Vector b_vec = *B;
             CAROM::Vector b_carom(b_vec.GetData(), b_vec.Size(), true);
             b_hat_carom = spatialbasis->transposeMult(&b_carom);
             if (interp_prep) b_hat_carom->write("b_hat_" + std::to_string(f_factor));
@@ -927,7 +927,7 @@ int main(int argc, char *argv[])
         // 18. take and write snapshot for ROM
         if (offline)
         {
-            Vector u_curr(*U->GlobalVector());
+            Vector u_curr(*U);
             Vector u_centered(U->Size());
             subtract(u_curr, u_init, u_centered);
             bool addSample = generator->takeSample(u_centered.GetData(), t, dt);

--- a/examples/prom/linear_elasticity_global_rom.cpp
+++ b/examples/prom/linear_elasticity_global_rom.cpp
@@ -385,9 +385,9 @@ int main(int argc, char* argv[])
                numRowRB, numColumnRB);
 
         // 21. form inverse ROM operator
-        CAROM::Matrix reducedA(numColumnRB, numColumnRB, false);
-        ComputeCtAB(A, *spatialbasis, *spatialbasis, reducedA);
-        reducedA.inverse();
+        CAROM::Matrix invReducedA(numColumnRB, numColumnRB, false);
+        ComputeCtAB(A, *spatialbasis, *spatialbasis, invReducedA);
+        invReducedA.inverse();
 
         CAROM::Vector B_carom(B.GetData(), B.Size(), true, false);
         CAROM::Vector X_carom(X.GetData(), X.Size(), true, false);
@@ -398,12 +398,13 @@ int main(int argc, char* argv[])
 
         // 22. solve ROM
         solveTimer.Start();
-        reducedA.mult(*reducedRHS, reducedSol);
+        invReducedA.mult(*reducedRHS, reducedSol);
         solveTimer.Stop();
 
         // 23. reconstruct FOM state
         spatialbasis->mult(reducedSol, X_carom);
         delete spatialbasis;
+        delete reducedRHS;
     }
 
     // 24. Recover the parallel grid function corresponding to X. This is the
@@ -428,8 +429,9 @@ int main(int argc, char* argv[])
     ostringstream mesh_name, sol_name, mesh_name_fom, sol_name_fom;
     if (fom || offline)
     {
-        mesh_name << "mesh_f"<< ext_force <<"_fom." << setfill('0') << setw(6) << myid;
-        sol_name << "sol_f"<< ext_force <<"_fom." << setfill('0') << setw(6) << myid;
+        mesh_name << "mesh_f" << ext_force << "_fom." << setfill('0')
+                  << setw(6) << myid;
+        sol_name << "sol_f" << ext_force << "_fom." << setfill('0') << setw(6) << myid;
     }
     if (online)
     {
@@ -486,7 +488,6 @@ int main(int argc, char* argv[])
             cout << "Relative error of ROM for E = " << E << " and nu = " << nu <<
                  " is: " << tot_diff_norm_x / tot_x_fom_norm << endl;
         }
-
     }
 
     // 28. Save data in the VisIt format.

--- a/examples/prom/linear_elasticity_global_rom.cpp
+++ b/examples/prom/linear_elasticity_global_rom.cpp
@@ -37,6 +37,8 @@
 //
 // Online phase:  ./linear_elasticity_global_rom -online -id 3 -nu 0.3
 //
+// This example runs in parallel with MPI, by using the same number of MPI ranks
+// in all phases (offline, merge, online).
 
 #include "mfem.hpp"
 #include <fstream>

--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -78,6 +78,9 @@
 //
 //               Pointwise snapshots for DMD input
 //               mpirun -n 1 ./mixed_nonlinear_diffusion -pwsnap -pwx 101 -pwy 101
+//
+// This example runs in parallel with MPI, by using the same number of MPI ranks
+// in all phases (offline, merge, online).
 
 #include "mfem.hpp"
 #include <fstream>

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -81,6 +81,9 @@
 //      Elapsed time for time integration loop 1.01136
 //      Relative error of ROM position (x) at t_final: 5 is 0.0130818
 //      Relative error of ROM velocity (v) at t_final: 5 is 0.979978
+//
+// This example runs in parallel with MPI, by using the same number of MPI ranks
+// in all phases (offline, merge, online).
 
 #include "mfem.hpp"
 #include "linalg/Vector.h"

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -30,25 +30,25 @@
 // and nonlinear term basis, with velocity initial condition:
 //
 // Offline phase:
-//      ./nonlinear_elasticity_global_rom --offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 0.90 -id 0
+//      ./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 0.90 -id 0
 //
-//      ./nonlinear_elasticity_global_rom --offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.10 -id 1
+//      ./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.10 -id 1
 //
 // Merge phase:
-//      ./nonlinear_elasticity_global_rom --merge -ns 2 -dt 0.01 -tf 5.0
+//      ./nonlinear_elasticity_global_rom -merge -ns 2 -dt 0.01 -tf 5.0
 //
 // Create FOM comparison data:
-//      ./nonlinear_elasticity_global_rom --offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.00 -id 2
+//      ./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.00 -id 2
 //
 // Online phase with full sampling:
-//      ./nonlinear_elasticity_global_rom --online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rvdim 40 -rxdim 10 -hdim 71 -nsr 1170 -sc 1.00
+//      ./nonlinear_elasticity_global_rom -online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rvdim 40 -rxdim 10 -hdim 71 -nsr 1170 -sc 1.00
 // Output message:
 //      Elapsed time for time integration loop 1.80759
 //      Relative error of ROM position (x) at t_final: 5 is 0.000231698
 //      Relative error of ROM velocity (v) at t_final: 5 is 0.466941
 //
 // Online phase with strong hyper-reduction:
-//      ./nonlinear_elasticity_global_rom --online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rvdim 40 -rxdim 10 -hdim 71 -nsr 100 -sc 1.00
+//      ./nonlinear_elasticity_global_rom -online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rvdim 40 -rxdim 10 -hdim 71 -nsr 100 -sc 1.00
 // Output message:
 //      Elapsed time for time integration loop 1.08048
 //      Relative error of ROM position (x) at t_final: 5 is 0.00209877
@@ -59,24 +59,24 @@
 // Sample runs and results for parametric ROM using only displacement basis
 // and nonlinear term basis:
 // Offline phase:
-//      ./nonlinear_elasticity_global_rom --offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 0.90 -xbo -def-ic -id 0
-//      ./nonlinear_elasticity_global_rom --offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.10 -xbo -def-ic -id 1
+//      ./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 0.90 -xbo -def-ic -id 0
+//      ./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.10 -xbo -def-ic -id 1
 //
 // Merge phase:
-//      ./nonlinear_elasticity_global_rom --merge -ns 2 -dt 0.01 -tf 5.0 -xbo
+//      ./nonlinear_elasticity_global_rom -merge -ns 2 -dt 0.01 -tf 5.0 -xbo
 //
 // Create FOM comparison data:
-//      ./nonlinear_elasticity_global_rom --offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.00 -xbo -def-ic -id 2
+//      ./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.00 -xbo -def-ic -id 2
 //
 // Online phase with full sampling:
-//      ./nonlinear_elasticity_global_rom --online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rxdim 57 -hdim 183 -nsr 1170 -sc 1.00 -xbo -def-ic
+//      ./nonlinear_elasticity_global_rom -online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rxdim 57 -hdim 183 -nsr 1170 -sc 1.00 -xbo -def-ic
 // Output message:
 //      Elapsed time for time integration loop 18.9874
 //      Relative error of ROM position (x) at t_final: 5 is 7.08272e-05
 //      Relative error of ROM velocity (v) at t_final: 5 is 0.00387647
 //
 // Online phase with strong hyper reduction:
-//      ./nonlinear_elasticity_global_rom --online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rxdim 2 -hdim 4 -nsr 10 -sc 1.00 -xbo -def-ic
+//      ./nonlinear_elasticity_global_rom -online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -rxdim 2 -hdim 4 -nsr 10 -sc 1.00 -xbo -def-ic
 // Output message:
 //      Elapsed time for time integration loop 1.01136
 //      Relative error of ROM position (x) at t_final: 5 is 0.0130818

--- a/examples/prom/poisson_global_rom.cpp
+++ b/examples/prom/poisson_global_rom.cpp
@@ -37,6 +37,9 @@
 //                poisson_global_rom -fom -f 1.15
 //
 // Online phase:  poisson_global_rom -online -f 1.15
+//
+// This example runs in parallel with MPI, by using the same number of MPI ranks
+// in all phases (offline, merge, fom, online).
 
 #include "mfem.hpp"
 #include <fstream>

--- a/lib/linalg/Options.h
+++ b/lib/linalg/Options.h
@@ -46,7 +46,7 @@ public:
             bool update_right_SV_ = false,
             bool write_snapshots_ = false
            ): dim(dim_),
-        max_basis_dimension(dim_),
+        max_basis_dimension(samples_per_time_interval_),
         samples_per_time_interval(samples_per_time_interval_),
         max_time_intervals(max_time_intervals_),
         update_right_SV(update_right_SV_),


### PR DESCRIPTION
- [x] Fixed a bug in the `Options` class, by correctly setting `max_basis_dimension`. Before this fix, `max_basis_dimension` was set to the FOM dimension. In parallel, it was possible for the FOM dimension to be smaller than the number of snapshots, resulting in a failure in scalapack.
- [x] Fixed multiple examples so that they run in parallel, including
dg_advection_global_rom, linear_elasticity_global_rom, poisson_global_rom, poisson_local_rom_greedy.
- [x] Examples nonlinear_elasticity_global_rom, mixed_nonlinear_diffusion seem to have been fixed in parallel by PR 145, aside from issues resulting from the `Options` class bug.
- [x] Added relative error calculation in poisson_global_rom.
- [x] Laghos/rom regression tests pass (except for three randomized tests that fail even for the master branch).

Note that dg_advection_local_rom_matrix_interp has serial usage of frequencies.txt. For now, it only works in serial (this PR does not parallelize it).