### PR TITLE
BasisGenerator finish output on function call

### DIFF
--- a/lib/linalg/BasisGenerator.h
+++ b/lib/linalg/BasisGenerator.h
@@ -128,6 +128,8 @@ public:
     {
         if (d_basis_writer) {
             d_basis_writer->writeBasis(kind);
+            delete d_basis_writer;
+            d_basis_writer = nullptr;
         }
     }
 
@@ -139,6 +141,8 @@ public:
     {
         if (d_basis_writer) {
             d_basis_writer->writeBasis("snapshot");
+            delete d_basis_writer;
+            d_basis_writer = nullptr;
         }
     }
 

--- a/lib/linalg/BasisGenerator.h
+++ b/lib/linalg/BasisGenerator.h
@@ -131,6 +131,11 @@ public:
             delete d_basis_writer;
             d_basis_writer = nullptr;
         }
+        else
+        {
+            std::cout << "WARNING: file has already been written by endSamples"
+                      << std::endl;
+        }
     }
 
     /**
@@ -139,11 +144,7 @@ public:
     void
     writeSnapshot()
     {
-        if (d_basis_writer) {
-            d_basis_writer->writeBasis("snapshot");
-            delete d_basis_writer;
-            d_basis_writer = nullptr;
-        }
+        endSamples("snapshot");
     }
 
     /**


### PR DESCRIPTION
Before this PR, `BasisGenerator` does not finish writing out basis or snapshot files, when `endSamples` or `writeSnapshot` is called. The files are fully written only when `BasisGenerator` is deleted or goes out of scope, as the writer has to be deleted. This PR deletes the writer when `endSamples` or `writeSnapshot` is called, so that the files are finished. This prevents confusion and bugs, and the only disadvantage is that `endSamples` or `writeSnapshot` cannot be called twice.