### PR TITLE
HDF DMD files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ if (ENABLE_EXAMPLES)
     endforeach() # IN LISTS examples
     file(COPY examples/data DESTINATION ${CMAKE_BINARY_DIR}/examples)
     file(COPY examples/dmd/heat_conduction_csv.sh DESTINATION ${CMAKE_BINARY_DIR}/examples/dmd)
+    file(COPY examples/dmd/heat_conduction_hdf.sh DESTINATION ${CMAKE_BINARY_DIR}/examples/dmd)
   endif()
 
   set(misc_example_names

--- a/examples/dmd/heat_conduction_csv.sh
+++ b/examples/dmd/heat_conduction_csv.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 #SBATCH -N 1
-#SBATCH -t 1:00:00
+#SBATCH -t 0:05:00
 #SBATCH -p pbatch
 #SBATCH -o sbatch.log
 #SBATCH --open-mode truncate
 
 rm -rf parameters.txt hc_list hc_data run/hc_data
 
-./parametric_heat_conduction -r 0.40 -csv -out hc_data/hc_par1 > hc_par1.log
-./parametric_heat_conduction -r 0.45 -csv -out hc_data/hc_par2 > hc_par2.log
-./parametric_heat_conduction -r 0.55 -csv -out hc_data/hc_par3 > hc_par3.log
-./parametric_heat_conduction -r 0.60 -csv -out hc_data/hc_par4 > hc_par4.log
-./parametric_heat_conduction -r 0.50 -csv -out hc_data/hc_par5 > hc_par5.log
+./parametric_heat_conduction -r 0.40 -csv -out hc_data/hc_par1 -no-vis > hc_par1.log
+./parametric_heat_conduction -r 0.45 -csv -out hc_data/hc_par2 -no-vis > hc_par2.log
+./parametric_heat_conduction -r 0.55 -csv -out hc_data/hc_par3 -no-vis > hc_par3.log
+./parametric_heat_conduction -r 0.60 -csv -out hc_data/hc_par4 -no-vis > hc_par4.log
+./parametric_heat_conduction -r 0.50 -csv -out hc_data/hc_par5 -no-vis > hc_par5.log
 
 mkdir hc_list
 mv -f run/hc_data .
@@ -25,9 +25,15 @@ mv hc_data/hc_par3/snap_list.csv hc_list/hc_par3.csv
 mv hc_data/hc_par4/snap_list.csv hc_list/hc_par4.csv
 mv hc_data/hc_par5/snap_list.csv hc_list/hc_par5.csv
 
-echo "hc_par1, 0.40, 0.01, 0, 0"  > hc_list/hc_train_parametric.csv
-echo "hc_par2, 0.45, 0.01, 0, 0" >> hc_list/hc_train_parametric.csv
-echo "hc_par3, 0.55, 0.01, 0, 0" >> hc_list/hc_train_parametric.csv
-echo "hc_par4, 0.60, 0.01, 0, 0" >> hc_list/hc_train_parametric.csv
-echo "hc_par5, 0.50, 0.01, 0, 0"  > hc_list/hc_train_local.csv
-echo "hc_par5, 0.50, 0.01, 0, 0"  > hc_list/hc_test.csv
+mv hc_data/hc_par1/numsnap hc_list/numsnap1
+mv hc_data/hc_par2/numsnap hc_list/numsnap2
+mv hc_data/hc_par3/numsnap hc_list/numsnap3
+mv hc_data/hc_par4/numsnap hc_list/numsnap4
+mv hc_data/hc_par5/numsnap hc_list/numsnap5
+
+echo "hc_par1,numsnap1,0.40,0.01,0,0"  > hc_list/hc_train_parametric.csv
+echo "hc_par2,numsnap2,0.45,0.01,0,0" >> hc_list/hc_train_parametric.csv
+echo "hc_par3,numsnap3,0.55,0.01,0,0" >> hc_list/hc_train_parametric.csv
+echo "hc_par4,numsnap4,0.60,0.01,0,0" >> hc_list/hc_train_parametric.csv
+echo "hc_par5,numsnap5,0.50,0.01,0,0"  > hc_list/hc_train_local.csv
+echo "hc_par5,numsnap5,0.50,0.01,0,0"  > hc_list/hc_test.csv

--- a/examples/dmd/heat_conduction_csv.sh
+++ b/examples/dmd/heat_conduction_csv.sh
@@ -8,11 +8,11 @@
 
 rm -rf parameters.txt hc_list hc_data run/hc_data
 
-./parametric_heat_conduction -r 0.40 -csv -out hc_data/hc_par1 -no-vis > hc_par1.log
-./parametric_heat_conduction -r 0.45 -csv -out hc_data/hc_par2 -no-vis > hc_par2.log
-./parametric_heat_conduction -r 0.55 -csv -out hc_data/hc_par3 -no-vis > hc_par3.log
-./parametric_heat_conduction -r 0.60 -csv -out hc_data/hc_par4 -no-vis > hc_par4.log
-./parametric_heat_conduction -r 0.50 -csv -out hc_data/hc_par5 -no-vis > hc_par5.log
+./parametric_heat_conduction -r 0.40 -save -csv -out hc_data/hc_par1 -no-vis > hc_par1.log
+./parametric_heat_conduction -r 0.45 -save -csv -out hc_data/hc_par2 -no-vis > hc_par2.log
+./parametric_heat_conduction -r 0.55 -save -csv -out hc_data/hc_par3 -no-vis > hc_par3.log
+./parametric_heat_conduction -r 0.60 -save -csv -out hc_data/hc_par4 -no-vis > hc_par4.log
+./parametric_heat_conduction -r 0.50 -save -csv -out hc_data/hc_par5 -no-vis > hc_par5.log
 
 mkdir hc_list
 mv -f run/hc_data .

--- a/examples/dmd/heat_conduction_hdf.sh
+++ b/examples/dmd/heat_conduction_hdf.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#SBATCH -N 1
+#SBATCH -t 0:05:00
+#SBATCH -p pbatch
+#SBATCH -o sbatch.log
+#SBATCH --open-mode truncate
+
+rm -rf parameters.txt hc_list hc_data run/hc_data
+
+./parametric_heat_conduction -r 0.40 -csv -no-csvf -out hc_data/hc_par1 -no-vis > hc_par1.log
+./parametric_heat_conduction -r 0.45 -csv -no-csvf -out hc_data/hc_par2 -no-vis > hc_par2.log
+./parametric_heat_conduction -r 0.55 -csv -no-csvf -out hc_data/hc_par3 -no-vis > hc_par3.log
+./parametric_heat_conduction -r 0.60 -csv -no-csvf -out hc_data/hc_par4 -no-vis > hc_par4.log
+./parametric_heat_conduction -r 0.50 -csv -no-csvf -out hc_data/hc_par5 -no-vis > hc_par5.log
+
+mkdir hc_list
+mv -f run/hc_data .
+
+echo "hc_par1,0.40,0.01,0,0"  > hc_list/hc_train_parametric.csv
+echo "hc_par2,0.45,0.01,0,0" >> hc_list/hc_train_parametric.csv
+echo "hc_par3,0.55,0.01,0,0" >> hc_list/hc_train_parametric.csv
+echo "hc_par4,0.60,0.01,0,0" >> hc_list/hc_train_parametric.csv
+echo "hc_par5,0.50,0.01,0,0"  > hc_list/hc_train_local.csv
+echo "hc_par5,0.50,0.01,0,0"  > hc_list/hc_test.csv

--- a/examples/dmd/heat_conduction_hdf.sh
+++ b/examples/dmd/heat_conduction_hdf.sh
@@ -8,11 +8,11 @@
 
 rm -rf parameters.txt hc_list hc_data run/hc_data
 
-./parametric_heat_conduction -r 0.40 -csv -no-csvf -out hc_data/hc_par1 -no-vis > hc_par1.log
-./parametric_heat_conduction -r 0.45 -csv -no-csvf -out hc_data/hc_par2 -no-vis > hc_par2.log
-./parametric_heat_conduction -r 0.55 -csv -no-csvf -out hc_data/hc_par3 -no-vis > hc_par3.log
-./parametric_heat_conduction -r 0.60 -csv -no-csvf -out hc_data/hc_par4 -no-vis > hc_par4.log
-./parametric_heat_conduction -r 0.50 -csv -no-csvf -out hc_data/hc_par5 -no-vis > hc_par5.log
+./parametric_heat_conduction -r 0.40 -save -hdf -out hc_data/hc_par1 -no-vis > hc_par1.log
+./parametric_heat_conduction -r 0.45 -save -hdf -out hc_data/hc_par2 -no-vis > hc_par2.log
+./parametric_heat_conduction -r 0.55 -save -hdf -out hc_data/hc_par3 -no-vis > hc_par3.log
+./parametric_heat_conduction -r 0.60 -save -hdf -out hc_data/hc_par4 -no-vis > hc_par4.log
+./parametric_heat_conduction -r 0.50 -save -hdf -out hc_data/hc_par5 -no-vis > hc_par5.log
 
 mkdir hc_list
 mv -f run/hc_data .

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -439,8 +439,7 @@ int main(int argc, char *argv[])
                 db->getDoubleArray(data_filename, sample, nelements, idx_state);
             }
             else
-                db->getDoubleArray("step" + to_string(snap_index_list[idx_snap]) + "sol",
-                                   sample, nelements, idx_state);
+                db->getDoubleArray(snap + "sol", sample, nelements, idx_state);
 
             dmd[curr_window]->takeSample(sample, tval);
             if (overlap_count > 0)
@@ -645,17 +644,18 @@ int main(int argc, char *argv[])
         {
             string snap = "step" + to_string(snap_index_list[idx_snap]); // STATE
             double tval = tvec[idx_snap];
-            string data_filename = string(data_dir) + "/" + par_dir + "/" + snap + "/" +
-                                   variable + ".csv"; // path to VAR_NAME.csv
             if (csvFormat)
+            {
+                string data_filename = string(data_dir) + "/" + par_dir + "/" + snap +
+                                       "/" + variable + ".csv"; // path to VAR_NAME.csv
                 db->getDoubleArray(data_filename, sample, nelements, idx_state);
+            }
             else
-                db->getDoubleArray("step" + to_string(snap_index_list[idx_snap]) + "sol",
-                                   sample, nelements, idx_state);
+                db->getDoubleArray(snap + "sol", sample, nelements, idx_state);
 
             if (myid == 0)
             {
-                cout << "State " << data_filename << " read." << endl;
+                cout << "State " << snap << " read." << endl;
             }
 
             if (idx_snap == 0)

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -214,8 +214,8 @@ int main(int argc, char *argv[])
     CAROM_VERIFY(nelements > 0);
     if (myid == 0)
     {
-        cout << "Variable " << var_name << " has dimension " << nelements << "." <<
-             endl;
+        cout << "Variable " << var_name << " has dimension " << nelements
+             << "." << endl;
     }
 
     int dim = nelements;
@@ -300,9 +300,7 @@ int main(int argc, char *argv[])
             if (csvFormat)
                 num_train_snap = csv_db.getLineCount(string(list_dir) + "/" + par_dir + ".csv");
             else
-            {
                 db->getInteger("numsnap", num_train_snap);
-            }
         }
 
         if (!csvFormat)

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -303,8 +303,7 @@ int main(int argc, char *argv[])
                 db->getInteger("numsnap", num_train_snap);
         }
 
-        if (!csvFormat)
-            db->close();
+        db->close();
 
         CAROM_VERIFY(windowOverlapSamples < windowNumSamples);
         numWindows = (windowNumSamples < infty) ? round((double) (num_train_snap-1) /
@@ -365,7 +364,6 @@ int main(int argc, char *argv[])
         string par_dir, numsnap_str;
         getline(par_ss, par_dir, ',');
 
-        vector<int> snap_index_list;
         int numsnap = 0;
         if (csvFormat)
         {
@@ -374,12 +372,12 @@ int main(int argc, char *argv[])
         }
         else
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "wr");
+            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
             db->getInteger("numsnap", numsnap);
         }
 
         CAROM_VERIFY(numsnap > 0);
-        snap_index_list.resize(numsnap);
+        vector<int> snap_index_list(numsnap);
         if (csvFormat)
             db->getIntegerArray(string(list_dir) + "/" + par_dir + ".csv",
                                 snap_index_list.data(),
@@ -568,8 +566,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        if (!csvFormat)
-            db->close();
+        db->close();
     }
 
     vector<string> testing_par_list;
@@ -590,18 +587,18 @@ int main(int argc, char *argv[])
         {
             cout << "Predicting solution for " << par_dir << " using DMD." << endl;
         }
-        vector<int> snap_index_list;
+
         int numsnap = 0;
         if (csvFormat)
             db->getInteger(string(list_dir) + "/" + numsnap_str, numsnap);
         else
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "wr");
+            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
             db->getInteger("numsnap", numsnap);
         }
-        CAROM_VERIFY(numsnap > 0);
-        snap_index_list.resize(numsnap);
 
+        CAROM_VERIFY(numsnap > 0);
+        vector<int> snap_index_list(numsnap);
         if (csvFormat)
             db->getIntegerArray(string(list_dir) + "/" + par_dir + ".csv",
                                 snap_index_list.data(),
@@ -773,8 +770,7 @@ int main(int argc, char *argv[])
         prediction_error.clear();
         num_tests = (t_final > 0.0) ? num_tests + 1 : num_tests + num_snap;
 
-        if (!csvFormat)
-            db->close();
+        db->close();
     }
 
     CAROM_VERIFY(num_tests > 0);

--- a/examples/dmd/parametric_heat_conduction.cpp
+++ b/examples/dmd/parametric_heat_conduction.cpp
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
     bool visit = false;
     int vis_steps = 5;
     bool adios2 = false;
-    bool save_csv = false;
+    bool save_dofs = false;
     bool csvFormat = true;
     const char *basename = "";
 
@@ -231,10 +231,10 @@ int main(int argc, char *argv[])
     args.AddOption(&adios2, "-adios2", "--adios2-streams", "-no-adios2",
                    "--no-adios2-streams",
                    "Save data using adios2 streams.");
-    args.AddOption(&save_csv, "-csv", "--csv", "-no-csv", "--no-csv",
-                   "Enable or disable MFEM result output (files in CSV format).");
-    args.AddOption(&csvFormat, "-csvf", "--csvf", "-no-csvf", "--no-csvf",
-                   "Enable or disable MFEM result output (files in CSV format).");
+    args.AddOption(&save_dofs, "-save", "--save", "-no-save", "--no-save",
+                   "Enable or disable MFEM DOF solution snapshot files).");
+    args.AddOption(&csvFormat, "-csv", "--csv", "-hdf", "--hdf",
+                   "Use CSV or HDF format for files output by -save option.");
     args.AddOption(&basename, "-out", "--outputfile-name",
                    "Name of the sub-folder to dump files within the run directory.");
     args.AddOption(&pointwiseSnapshots, "-pwsnap", "--pw-snap", "-no-pwsnap",
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
     }
 
     string outputPath = ".";
-    if (save_csv)
+    if (save_dofs)
     {
         outputPath = "run";
         if (string(basename) != "") {
@@ -276,9 +276,10 @@ int main(int argc, char *argv[])
         }
     }
 
-    const int check = (int) pointwiseSnapshots + (int) offline + (int) online;
-    MFEM_VERIFY(check == 1 || save_csv,
-                "Only one of offline, online, or pwsnap must be true!");
+    const int check = (int) pointwiseSnapshots + (int) offline + (int) online
+                      + (int) save_dofs;
+    MFEM_VERIFY(check == 1,
+                "Only one of offline, online, save, or pwsnap must be true!");
 
     if (offline)
     {
@@ -551,7 +552,7 @@ int main(int argc, char *argv[])
         init = new CAROM::Vector(u.GetData(), u.Size(), true);
     }
 
-    if (save_csv && myid == 0)
+    if (save_dofs && myid == 0)
     {
         if (csvFormat)
         {
@@ -597,7 +598,7 @@ int main(int argc, char *argv[])
             dmd_training_timer.Stop();
         }
 
-        if (save_csv && myid == 0)
+        if (save_dofs && myid == 0)
         {
             if (csvFormat)
             {
@@ -663,7 +664,7 @@ int main(int argc, char *argv[])
         oper.SetParameters(u);
     }
 
-    if (save_csv && myid == 0)
+    if (save_dofs && myid == 0)
     {
         if (csvFormat)
         {

--- a/examples/dmd/parametric_tw_csv.cpp
+++ b/examples/dmd/parametric_tw_csv.cpp
@@ -10,18 +10,19 @@
 
 // Compile with: make parametric_tw_csv
 //
-// Generate CSV database on heat conduction with: heat_conduction_csv.sh
+// Generate CSV or HDF database on heat conduction with either
+// heat_conduction_csv.sh or heat_conduction_hdf.sh (HDF is more efficient).
 //
 // =================================================================================
 //
-// Parametric serial DMD command:
+// Parametric serial DMD command (for HDF version, append -hdf):
 //   mpirun -np 8 parametric_tw_csv -o parametric_csv_serial -rdim 16 -dtc 0.01 -offline
 //   mpirun -np 8 parametric_tw_csv -o parametric_csv_serial -rdim 16 -dtc 0.01 -online
 //
 // Final-time prediction error (Last line in run/parametric_csv_serial/hc_par5_prediction_error.csv):
 //   0.0012598331433506
 //
-// Parametric time windowing DMD command:
+// Parametric time windowing DMD command (for HDF version, append -hdf):
 //   mpirun -np 8 parametric_tw_csv -o parametric_csv_tw -rdim 16 -nwinsamp 25 -dtc 0.01 -offline
 //   mpirun -np 8 parametric_tw_csv -o parametric_csv_tw -rdim 16 -nwinsamp 25 -dtc 0.01 -online
 //
@@ -286,6 +287,7 @@ int main(int argc, char *argv[])
     }
 
     int dpar = -1;
+    const int ospar = csvFormat ? 2 : 1;
 
     for (int idx_dataset = 0; idx_dataset < npar; ++idx_dataset)
     {
@@ -297,7 +299,7 @@ int main(int argc, char *argv[])
             par_info.push_back(par_entry);
         }
 
-        dpar = par_info.size() - 2;
+        dpar = par_info.size() - ospar;
         CAROM::Vector* curr_par = new CAROM::Vector(dpar, false);
 
         if (idx_dataset == 0)
@@ -310,7 +312,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            CAROM_VERIFY(dpar == par_info.size() - 2);
+            CAROM_VERIFY(dpar == par_info.size() - ospar);
         }
 
         string par_dir = par_info[0];
@@ -334,7 +336,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "wr");
+            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
             db->getInteger("numsnap", numsnap);
         }
 
@@ -372,7 +374,7 @@ int main(int argc, char *argv[])
 
         for (int par_order = 0; par_order < dpar; ++par_order)
         {
-            curr_par->item(par_order) = stod(par_info[par_order+2]);
+            curr_par->item(par_order) = stod(par_info[par_order+ospar]);
         }
         par_vectors.push_back(curr_par);
 
@@ -637,7 +639,7 @@ int main(int argc, char *argv[])
                 par_info.push_back(par_entry);
             }
 
-            CAROM_VERIFY(dpar == par_info.size() - 2);
+            CAROM_VERIFY(dpar == par_info.size() - ospar);
 
             string par_dir = par_info[0];
             string numsnap_str = par_info[1];
@@ -653,7 +655,7 @@ int main(int argc, char *argv[])
                 db->getInteger(string(list_dir) + "/" + numsnap_str, numsnap);
             else
             {
-                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "wr");
+                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
                 db->getInteger("numsnap", numsnap);
             }
             CAROM_VERIFY(numsnap > 0);
@@ -669,7 +671,7 @@ int main(int argc, char *argv[])
 
             for (int par_order = 0; par_order < dpar; ++par_order)
             {
-                curr_par->item(par_order) = stod(par_info[par_order+2]);
+                curr_par->item(par_order) = stod(par_info[par_order+ospar]);
             }
 
             vector<double> tvec(numsnap);
@@ -770,7 +772,7 @@ int main(int argc, char *argv[])
                 db->getInteger(string(list_dir) + "/" + par_ns_list[idx_dataset], numsnap);
             else
             {
-                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "wr");
+                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
                 db->getInteger("numsnap", numsnap);
             }
             CAROM_VERIFY(numsnap > 0);

--- a/examples/dmd/parametric_tw_csv.cpp
+++ b/examples/dmd/parametric_tw_csv.cpp
@@ -23,11 +23,11 @@
 //   0.0012598331433506
 //
 // Parametric time windowing DMD command (for HDF version, append -hdf):
-//   mpirun -np 8 parametric_tw_csv -o parametric_csv_tw -rdim 16 -nwinsamp 25 -dtc 0.01 -offline
-//   mpirun -np 8 parametric_tw_csv -o parametric_csv_tw -rdim 16 -nwinsamp 25 -dtc 0.01 -online
+//   mpirun -np 8 parametric_tw_csv -o parametric_csv_tw -nwinsamp 25 -dtc 0.01 -offline
+//   mpirun -np 8 parametric_tw_csv -o parametric_csv_tw -nwinsamp 25 -dtc 0.01 -online
 //
 // Final-time prediction error (Last line in run/parametric_csv_tw/hc_par5_prediction_error.csv):
-//   0.0007348122935743
+//   0.0006507358659606
 //
 // =================================================================================
 //
@@ -396,8 +396,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        if (!csvFormat)
-            db->close();
+        db->close();
     }
 
     CAROM_VERIFY(windowOverlapSamples < windowNumSamples);
@@ -601,8 +600,7 @@ int main(int argc, char *argv[])
                 }
             } // escape for-loop over window
 
-            if (!csvFormat)
-                db->close();
+            db->close();
         } // escape for-loop over idx_dataset
         dmd_training_timer.Stop();
     } // escape if-statement of offline
@@ -749,8 +747,7 @@ int main(int argc, char *argv[])
                 delete init_cond;
             } // escape for-loop over window
 
-            if (!csvFormat)
-                db->close();
+            db->close();
         } // escape for-loop over idx_dataset
         dmd_preprocess_timer.Stop();
     } // escape if-statement of online
@@ -925,8 +922,7 @@ int main(int argc, char *argv[])
             prediction_error.clear();
             num_tests = (t_final > 0.0) ? num_tests + 1 : num_tests + num_snap;
 
-            if (!csvFormat)
-                db->close();
+            db->close();
         }
 
         CAROM_VERIFY(num_tests > 0);

--- a/lib/utils/CSVDatabase.cpp
+++ b/lib/utils/CSVDatabase.cpp
@@ -107,7 +107,7 @@ CSVDatabase::putDoubleVector(
 void
 CSVDatabase::putComplexVector(
     const std::string& file_name,
-    const std::vector<std::complex<double>> data,
+    const std::vector<std::complex<double>>& data,
     int nelements,
     int precision)
 {
@@ -127,7 +127,7 @@ CSVDatabase::putComplexVector(
 void
 CSVDatabase::putStringVector(
     const std::string& file_name,
-    const std::vector<std::string> data,
+    const std::vector<std::string>& data,
     int nelements)
 {
     CAROM_VERIFY(!file_name.empty());
@@ -211,7 +211,7 @@ CSVDatabase::getDoubleArray(
     const std::string& file_name,
     double* data,
     int nelements,
-    std::vector<int> idx)
+    const std::vector<int>& idx)
 {
     CAROM_VERIFY(!file_name.empty());
 #ifndef DEBUG_CHECK_ASSERTIONS

--- a/lib/utils/CSVDatabase.cpp
+++ b/lib/utils/CSVDatabase.cpp
@@ -87,7 +87,7 @@ CSVDatabase::putDoubleArray(
 void
 CSVDatabase::putDoubleVector(
     const std::string& file_name,
-    const std::vector<double> data,
+    const std::vector<double>& data,
     int nelements,
     int precision)
 {
@@ -154,6 +154,8 @@ CSVDatabase::getIntegerArray(
 #endif
 
     std::ifstream d_fs(file_name.c_str());
+    if (d_fs.fail())
+        return;
     CAROM_VERIFY(!d_fs.fail());
     int data_entry = 0;
     for (int i = 0; i < nelements; ++i)

--- a/lib/utils/CSVDatabase.h
+++ b/lib/utils/CSVDatabase.h
@@ -208,7 +208,9 @@ public:
 
     virtual int getDoubleArraySize(const std::string& key)
     {
-        return -1;
+        std::vector<double> tmp;
+        getDoubleVector(key, tmp);
+        return tmp.size();
     }
 
     /**

--- a/lib/utils/CSVDatabase.h
+++ b/lib/utils/CSVDatabase.h
@@ -149,7 +149,7 @@ public:
     void
     putComplexVector(
         const std::string& file_name,
-        const std::vector<std::complex<double>> data,
+        const std::vector<std::complex<double>>& data,
         int nelements,
         int precision = 6);
 
@@ -169,7 +169,7 @@ public:
     void
     putStringVector(
         const std::string& file_name,
-        const std::vector<std::string> data,
+        const std::vector<std::string>& data,
         int nelements);
 
     /**
@@ -249,7 +249,7 @@ public:
         const std::string& file_name,
         double* data,
         int nelements,
-        std::vector<int> idx);
+        const std::vector<int>& idx);
 
     /**
      * @brief Reads an array of doubles associated with the supplied filename.

--- a/lib/utils/CSVDatabase.h
+++ b/lib/utils/CSVDatabase.h
@@ -16,7 +16,6 @@
 #include "Database.h"
 #include <string>
 #include <fstream>
-#include <vector>
 #include <complex>
 
 namespace CAROM {
@@ -129,7 +128,7 @@ public:
     void
     putDoubleVector(
         const std::string& file_name,
-        const std::vector<double> data,
+        const std::vector<double>& data,
         int nelements,
         int precision = 6);
 
@@ -206,6 +205,11 @@ public:
         const std::string& file_name,
         std::vector<int> &data,
         bool append = false);
+
+    virtual int getDoubleArraySize(const std::string& key)
+    {
+        return -1;
+    }
 
     /**
      * @brief Reads an array of doubles associated with the supplied filename.

--- a/lib/utils/Database.h
+++ b/lib/utils/Database.h
@@ -212,7 +212,7 @@ public:
         const std::string& file_name,
         double* data,
         int nelements,
-        std::vector<int> idx) = 0;
+        const std::vector<int>& idx) = 0;
 
     /**
      * @brief Reads an array of doubles associated with the supplied key

--- a/lib/utils/Database.h
+++ b/lib/utils/Database.h
@@ -14,6 +14,7 @@
 #define included_Database_h
 
 #include <string>
+#include <vector>
 
 namespace CAROM {
 
@@ -133,6 +134,14 @@ public:
         const double* const data,
         int nelements) = 0;
 
+    virtual
+    void
+    putDoubleVector(
+        const std::string& file_name,
+        const std::vector<double>& data,
+        int nelements,
+        int precision = 6) = 0;
+
     /**
      * @brief Reads an integer associated with the supplied key from the
      *        currently open database file.
@@ -179,6 +188,8 @@ public:
         getDoubleArray(key, &data, 1);
     }
 
+    virtual int getDoubleArraySize(const std::string& key) = 0;
+
     /**
      * @brief Reads an array of doubles associated with the supplied key
      *        from the currently open database file.
@@ -194,6 +205,14 @@ public:
         const std::string& key,
         double* data,
         int nelements) = 0;
+
+    virtual
+    void
+    getDoubleArray(
+        const std::string& file_name,
+        double* data,
+        int nelements,
+        std::vector<int> idx) = 0;
 
     /**
      * @brief Reads an array of doubles associated with the supplied key

--- a/lib/utils/HDFDatabase.cpp
+++ b/lib/utils/HDFDatabase.cpp
@@ -336,7 +336,7 @@ HDFDatabase::getDoubleArray(
     const std::string& key,
     double* data,
     int nelements,
-    std::vector<int> idx)
+    const std::vector<int>& idx)
 {
     if (idx.size() == 0)
     {

--- a/lib/utils/HDFDatabase.h
+++ b/lib/utils/HDFDatabase.h
@@ -111,6 +111,14 @@ public:
         const double* const data,
         int nelements);
 
+    virtual
+    void
+    putDoubleVector(
+        const std::string& file_name,
+        const std::vector<double>& data,
+        int nelements,
+        int precision = 6);
+
     /**
      * @brief Reads an array of integers associated with the supplied key
      * from the currently open HDF5 database file.
@@ -130,6 +138,8 @@ public:
         int* data,
         int nelements);
 
+    virtual int getDoubleArraySize(const std::string& key);
+
     /**
      * @brief Reads an array of doubles associated with the supplied key
      * from the currently open HDF5 database file.
@@ -148,6 +158,14 @@ public:
         const std::string& key,
         double* data,
         int nelements);
+
+    virtual
+    void
+    getDoubleArray(
+        const std::string& file_name,
+        double* data,
+        int nelements,
+        std::vector<int> idx);
 
     /**
      * @brief Reads an array of doubles associated with the supplied key

--- a/lib/utils/HDFDatabase.h
+++ b/lib/utils/HDFDatabase.h
@@ -165,7 +165,7 @@ public:
         const std::string& file_name,
         double* data,
         int nelements,
-        std::vector<int> idx);
+        const std::vector<int>& idx);
 
     /**
      * @brief Reads an array of doubles associated with the supplied key


### PR DESCRIPTION
This PR implements the option to generate binary HDF files for the solutions of the `dmd/parametric_heat_conduction.cpp` example. Previously, CSV files were the only option. CSV is still used for some small amounts of data describing the simulations, but HDF can be used for solution data. The advantage of the HDF option is that the data is stored in full precision more efficiently than CSV, and there is only 1 HDF file per simulation as opposed to one CSV file per timestep. For example, `heat_conduction_hdf.sh` runs several times faster than `heat_conduction_csv.sh` for generating training data. The `Database` classes are enhanced to support the new features.