### PR TITLE
DMD load methods bugfixes

### DIFF
--- a/lib/algo/DMD.cpp
+++ b/lib/algo/DMD.cpp
@@ -798,6 +798,9 @@ DMD::load(std::string base_file_name)
         d_state_offset->read(full_file_name);
     }
 
+    d_init_projected = true;
+    d_trained = true;
+
     MPI_Barrier(MPI_COMM_WORLD);
 }
 

--- a/lib/algo/NonuniformDMD.cpp
+++ b/lib/algo/NonuniformDMD.cpp
@@ -134,8 +134,11 @@ NonuniformDMD::load(std::string base_file_name)
     CAROM_ASSERT(!base_file_name.empty());
 
     std::string full_file_name = base_file_name + "_derivative_offset";
-    d_derivative_offset = new Vector();
-    d_derivative_offset->read(full_file_name);
+    if (Utilities::file_exist(full_file_name + ".000000"))
+    {
+        d_derivative_offset = new Vector();
+        d_derivative_offset->read(full_file_name);
+    }
 
     DMD::load(base_file_name);
 }


### PR DESCRIPTION
This PR addresses two small bugs in the `load()` methods of `NonuniformDMD` and `DMD`.

- `DMD::load()` loads a trained ROM, but subsequently calling `DMD::predict()` fails at [line 611](https://github.com/LLNL/libROM/blob/master/lib/algo/DMD.cpp#L611) because `d_trained` and `d_init_projected` are false.  This bugfix sets these variables to true when calling `DMD::load()`.
- `NonuniformDMD::load()` will always attempt to load the optional variable `d_derivative_offset`.  This bugfix ensures the optional file exists before attempting to load.