### PR TITLE
Generalize DMD scripts

### DIFF
--- a/examples/dmd/heat_conduction_csv.sh
+++ b/examples/dmd/heat_conduction_csv.sh
@@ -6,34 +6,34 @@
 #SBATCH -o sbatch.log
 #SBATCH --open-mode truncate
 
-rm -rf parameters.txt hc_list hc_data run/hc_data
+rm -rf parameters.txt dmd_list dmd_data run/dmd_data
 
-./parametric_heat_conduction -r 0.40 -save -csv -out hc_data/hc_par1 -no-vis > hc_par1.log
-./parametric_heat_conduction -r 0.45 -save -csv -out hc_data/hc_par2 -no-vis > hc_par2.log
-./parametric_heat_conduction -r 0.55 -save -csv -out hc_data/hc_par3 -no-vis > hc_par3.log
-./parametric_heat_conduction -r 0.60 -save -csv -out hc_data/hc_par4 -no-vis > hc_par4.log
-./parametric_heat_conduction -r 0.50 -save -csv -out hc_data/hc_par5 -no-vis > hc_par5.log
+./parametric_heat_conduction -r 0.40 -save -csv -out dmd_data/dmd_par1 -no-vis > hc_par1.log
+./parametric_heat_conduction -r 0.45 -save -csv -out dmd_data/dmd_par2 -no-vis > hc_par2.log
+./parametric_heat_conduction -r 0.55 -save -csv -out dmd_data/dmd_par3 -no-vis > hc_par3.log
+./parametric_heat_conduction -r 0.60 -save -csv -out dmd_data/dmd_par4 -no-vis > hc_par4.log
+./parametric_heat_conduction -r 0.50 -save -csv -out dmd_data/dmd_par5 -no-vis > hc_par5.log
 
-mkdir hc_list
-mv -f run/hc_data .
+mkdir dmd_list
+mv -f run/dmd_data .
 
-awk 'END{print NR}' hc_data/hc_par1/step0/sol.csv > hc_data/dim.csv
+awk 'END{print NR}' dmd_data/dmd_par1/step0/sol.csv > dmd_data/dim.csv
 
-mv hc_data/hc_par1/snap_list.csv hc_list/hc_par1.csv
-mv hc_data/hc_par2/snap_list.csv hc_list/hc_par2.csv
-mv hc_data/hc_par3/snap_list.csv hc_list/hc_par3.csv
-mv hc_data/hc_par4/snap_list.csv hc_list/hc_par4.csv
-mv hc_data/hc_par5/snap_list.csv hc_list/hc_par5.csv
+mv dmd_data/dmd_par1/snap_list.csv dmd_list/dmd_par1.csv
+mv dmd_data/dmd_par2/snap_list.csv dmd_list/dmd_par2.csv
+mv dmd_data/dmd_par3/snap_list.csv dmd_list/dmd_par3.csv
+mv dmd_data/dmd_par4/snap_list.csv dmd_list/dmd_par4.csv
+mv dmd_data/dmd_par5/snap_list.csv dmd_list/dmd_par5.csv
 
-mv hc_data/hc_par1/numsnap hc_list/numsnap1
-mv hc_data/hc_par2/numsnap hc_list/numsnap2
-mv hc_data/hc_par3/numsnap hc_list/numsnap3
-mv hc_data/hc_par4/numsnap hc_list/numsnap4
-mv hc_data/hc_par5/numsnap hc_list/numsnap5
+mv dmd_data/dmd_par1/numsnap dmd_list/numsnap1
+mv dmd_data/dmd_par2/numsnap dmd_list/numsnap2
+mv dmd_data/dmd_par3/numsnap dmd_list/numsnap3
+mv dmd_data/dmd_par4/numsnap dmd_list/numsnap4
+mv dmd_data/dmd_par5/numsnap dmd_list/numsnap5
 
-echo "hc_par1,numsnap1,0.40,0.01,0,0"  > hc_list/hc_train_parametric.csv
-echo "hc_par2,numsnap2,0.45,0.01,0,0" >> hc_list/hc_train_parametric.csv
-echo "hc_par3,numsnap3,0.55,0.01,0,0" >> hc_list/hc_train_parametric.csv
-echo "hc_par4,numsnap4,0.60,0.01,0,0" >> hc_list/hc_train_parametric.csv
-echo "hc_par5,numsnap5,0.50,0.01,0,0"  > hc_list/hc_train_local.csv
-echo "hc_par5,numsnap5,0.50,0.01,0,0"  > hc_list/hc_test.csv
+echo "dmd_par1,numsnap1,0.40,0.01,0,0"  > dmd_list/dmd_train_parametric.csv
+echo "dmd_par2,numsnap2,0.45,0.01,0,0" >> dmd_list/dmd_train_parametric.csv
+echo "dmd_par3,numsnap3,0.55,0.01,0,0" >> dmd_list/dmd_train_parametric.csv
+echo "dmd_par4,numsnap4,0.60,0.01,0,0" >> dmd_list/dmd_train_parametric.csv
+echo "dmd_par5,numsnap5,0.50,0.01,0,0"  > dmd_list/dmd_train_local.csv
+echo "dmd_par5,numsnap5,0.50,0.01,0,0"  > dmd_list/dmd_test.csv

--- a/examples/dmd/heat_conduction_hdf.sh
+++ b/examples/dmd/heat_conduction_hdf.sh
@@ -6,20 +6,20 @@
 #SBATCH -o sbatch.log
 #SBATCH --open-mode truncate
 
-rm -rf parameters.txt hc_list hc_data run/hc_data
+rm -rf parameters.txt dmd_list dmd_data run/dmd_data
 
-./parametric_heat_conduction -r 0.40 -save -hdf -out hc_data/hc_par1 -no-vis > hc_par1.log
-./parametric_heat_conduction -r 0.45 -save -hdf -out hc_data/hc_par2 -no-vis > hc_par2.log
-./parametric_heat_conduction -r 0.55 -save -hdf -out hc_data/hc_par3 -no-vis > hc_par3.log
-./parametric_heat_conduction -r 0.60 -save -hdf -out hc_data/hc_par4 -no-vis > hc_par4.log
-./parametric_heat_conduction -r 0.50 -save -hdf -out hc_data/hc_par5 -no-vis > hc_par5.log
+./parametric_heat_conduction -r 0.40 -save -hdf -out dmd_data/sim0 -no-vis > hc_par0.log
+./parametric_heat_conduction -r 0.45 -save -hdf -out dmd_data/sim1 -no-vis > hc_par1.log
+./parametric_heat_conduction -r 0.55 -save -hdf -out dmd_data/sim2 -no-vis > hc_par2.log
+./parametric_heat_conduction -r 0.60 -save -hdf -out dmd_data/sim3 -no-vis > hc_par3.log
+./parametric_heat_conduction -r 0.50 -save -hdf -out dmd_data/sim4 -no-vis > hc_par4.log
 
-mkdir hc_list
-mv -f run/hc_data .
+mkdir dmd_list
+mv -f run/dmd_data .
 
-echo "hc_par1,0.40,0.01,0,0"  > hc_list/hc_train_parametric.csv
-echo "hc_par2,0.45,0.01,0,0" >> hc_list/hc_train_parametric.csv
-echo "hc_par3,0.55,0.01,0,0" >> hc_list/hc_train_parametric.csv
-echo "hc_par4,0.60,0.01,0,0" >> hc_list/hc_train_parametric.csv
-echo "hc_par5,0.50,0.01,0,0"  > hc_list/hc_train_local.csv
-echo "hc_par5,0.50,0.01,0,0"  > hc_list/hc_test.csv
+echo "sim0,0.40,0.01,0,0"  > dmd_list/dmd_train_parametric.csv
+echo "sim1,0.45,0.01,0,0" >> dmd_list/dmd_train_parametric.csv
+echo "sim2,0.55,0.01,0,0" >> dmd_list/dmd_train_parametric.csv
+echo "sim3,0.60,0.01,0,0" >> dmd_list/dmd_train_parametric.csv
+echo "sim4,0.50,0.01,0,0"  > dmd_list/dmd_train_local.csv
+echo "sim4,0.50,0.01,0,0"  > dmd_list/dmd_test.csv

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -92,12 +92,12 @@ int main(int argc, char *argv[])
     double admd_closest_rbf_val = 0.9;
     double ef = 0.9999;
     int rdim = -1;
-    const char *list_dir = "hc_list";
-    const char *data_dir = "hc_data";
+    const char *list_dir = "dmd_list";
+    const char *data_dir = "dmd_data";
     const char *sim_name = "sim";
     const char *var_name = "sol";
-    const char *train_list = "hc_train_local";
-    const char *test_list = "hc_test";
+    const char *train_list = "dmd_train_local";
+    const char *test_list = "dmd_test";
     const char *temporal_idx_list = "temporal_idx";
     const char *spatial_idx_list = "spatial_idx";
     const char *hdf_name = "dmd.hdf";

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -94,11 +94,13 @@ int main(int argc, char *argv[])
     int rdim = -1;
     const char *list_dir = "hc_list";
     const char *data_dir = "hc_data";
+    const char *sim_name = "sim";
     const char *var_name = "sol";
     const char *train_list = "hc_train_local";
     const char *test_list = "hc_test";
     const char *temporal_idx_list = "temporal_idx";
     const char *spatial_idx_list = "spatial_idx";
+    const char *hdf_name = "dmd.hdf";
     const char *basename = "";
     bool save_csv = false;
     bool csvFormat = true;
@@ -132,6 +134,10 @@ int main(int argc, char *argv[])
                    "Location of training and testing data list.");
     args.AddOption(&data_dir, "-data", "--data-directory",
                    "Location of training and testing data.");
+    args.AddOption(&hdf_name, "-hdffile", "--hdf-file",
+                   "Name of HDF file for training and testing data.");
+    args.AddOption(&sim_name, "-sim", "--sim-name",
+                   "Name of simulation.");
     args.AddOption(&var_name, "-var", "--variable-name",
                    "Name of variable.");
     args.AddOption(&train_list, "-train-set", "--training-set-name",
@@ -206,7 +212,7 @@ int main(int argc, char *argv[])
         db->getIntegerArray(string(data_dir) + "/dim.csv", &nelements, 1);
     else
     {
-        db->open(string(data_dir) + "/hc_par1/dmd.hdf", "r");
+        db->open(string(data_dir) + "/" + sim_name + "0/" + hdf_name, "r");
         nelements = db->getDoubleArraySize("step0sol");
         db->close();
     }
@@ -278,7 +284,7 @@ int main(int argc, char *argv[])
         int snap_bound_size = 0;
         if (!csvFormat)
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
         }
 
         db->getInteger("snap_bound_size", snap_bound_size);
@@ -372,7 +378,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
             db->getInteger("numsnap", numsnap);
         }
 
@@ -593,7 +599,7 @@ int main(int argc, char *argv[])
             db->getInteger(string(list_dir) + "/" + numsnap_str, numsnap);
         else
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
             db->getInteger("numsnap", numsnap);
         }
 

--- a/examples/dmd/parametric_dw_csv.cpp
+++ b/examples/dmd/parametric_dw_csv.cpp
@@ -481,7 +481,7 @@ int main(int argc, char *argv[])
                 }
 
                 dmd[idx_dataset][curr_window]->takeSample(sample, tval);
-                for (int window = curr_window-1; window >= 0; --window) 
+                for (int window = curr_window-1; window >= 0; --window)
                 {
                     if (overlap_count[window] > 0)
                     {
@@ -520,10 +520,14 @@ int main(int argc, char *argv[])
                         if (myid == 0)
                         {
                             cout << "State #" << idx_snap << " - " << data_filename
-                                 << " is the beginning of window " << curr_window+1 << "." << endl;
+                                 << " is the beginning of window " << curr_window+1
+                                 << "." << endl;
                         }
 
-                        overlap_count.push_back(windowOverlapSamples + max(0, rdim+1 - dmd[idx_dataset][curr_window]->getNumSamples()));
+                        int ns = dmd[idx_dataset][curr_window]->getNumSamples();
+                        overlap_count.push_back(windowOverlapSamples +
+                                                max(0, rdim+1 - ns));
+
                         curr_window += 1;
                         dmd[idx_dataset][curr_window]->takeSample(sample, tval);
                     }

--- a/examples/dmd/parametric_tw_csv.cpp
+++ b/examples/dmd/parametric_tw_csv.cpp
@@ -96,12 +96,12 @@ int main(int argc, char *argv[])
     double pdmd_closest_rbf_val = 0.9;
     double ef = 0.9999;
     int rdim = -1;
-    const char *list_dir = "hc_list";
-    const char *data_dir = "hc_data";
+    const char *list_dir = "dmd_list";
+    const char *data_dir = "dmd_data";
     const char *sim_name = "sim";
     const char *var_name = "sol";
-    const char *train_list = "hc_train_parametric";
-    const char *test_list = "hc_test";
+    const char *train_list = "dmd_train_parametric";
+    const char *test_list = "dmd_test";
     const char *temporal_idx_list = "temporal_idx";
     const char *spatial_idx_list = "spatial_idx";
     const char *hdf_name = "dmd.hdf";

--- a/examples/dmd/parametric_tw_csv.cpp
+++ b/examples/dmd/parametric_tw_csv.cpp
@@ -98,11 +98,13 @@ int main(int argc, char *argv[])
     int rdim = -1;
     const char *list_dir = "hc_list";
     const char *data_dir = "hc_data";
+    const char *sim_name = "sim";
     const char *var_name = "sol";
     const char *train_list = "hc_train_parametric";
     const char *test_list = "hc_test";
     const char *temporal_idx_list = "temporal_idx";
     const char *spatial_idx_list = "spatial_idx";
+    const char *hdf_name = "dmd.hdf";
     const char *basename = "";
     bool save_csv = false;
     bool csvFormat = true;
@@ -145,6 +147,10 @@ int main(int argc, char *argv[])
                    "Location of training and testing data list.");
     args.AddOption(&data_dir, "-data", "--data-directory",
                    "Location of training and testing data.");
+    args.AddOption(&hdf_name, "-hdffile", "--hdf-file",
+                   "Name of HDF file for training and testing data.");
+    args.AddOption(&sim_name, "-sim", "--sim-name",
+                   "Name of simulation.");
     args.AddOption(&var_name, "-var", "--variable-name",
                    "Name of variable.");
     args.AddOption(&train_list, "-train-set", "--training-set-name",
@@ -221,7 +227,7 @@ int main(int argc, char *argv[])
         db->getIntegerArray(string(data_dir) + "/dim.csv", &nelements, 1);
     else
     {
-        db->open(string(data_dir) + "/hc_par1/dmd.hdf", "r");
+	db->open(string(data_dir) + "/" + sim_name + "0/" + hdf_name, "r");
         nelements = db->getDoubleArraySize("step0sol");
         db->close();
     }
@@ -287,7 +293,7 @@ int main(int argc, char *argv[])
     }
 
     int dpar = -1;
-    const int ospar = csvFormat ? 2 : 1;
+    const int ospar = csvFormat ? 2 : 1;  // CSV version has numsnap, HDF does not.
 
     for (int idx_dataset = 0; idx_dataset < npar; ++idx_dataset)
     {
@@ -322,7 +328,7 @@ int main(int argc, char *argv[])
 
         if (!csvFormat)
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
         }
 
         int snap_bound_size = 0;
@@ -336,7 +342,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
             db->getInteger("numsnap", numsnap);
         }
 
@@ -478,7 +484,7 @@ int main(int argc, char *argv[])
             }
             else
             {
-                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+                db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
                 db->getInteger("numsnap", numsnap);
             }
 
@@ -653,7 +659,7 @@ int main(int argc, char *argv[])
                 db->getInteger(string(list_dir) + "/" + numsnap_str, numsnap);
             else
             {
-                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+                db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
                 db->getInteger("numsnap", numsnap);
             }
             CAROM_VERIFY(numsnap > 0);
@@ -769,7 +775,7 @@ int main(int argc, char *argv[])
                 db->getInteger(string(list_dir) + "/" + par_ns_list[idx_dataset], numsnap);
             else
             {
-                db->open(string(data_dir) + "/" + par_dir + "/dmd.hdf", "r");
+                db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
                 db->getInteger("numsnap", numsnap);
             }
             CAROM_VERIFY(numsnap > 0);

--- a/examples/dmd/parametric_tw_csv.cpp
+++ b/examples/dmd/parametric_tw_csv.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
         db->getIntegerArray(string(data_dir) + "/dim.csv", &nelements, 1);
     else
     {
-	db->open(string(data_dir) + "/" + sim_name + "0/" + hdf_name, "r");
+        db->open(string(data_dir) + "/" + sim_name + "0/" + hdf_name, "r");
         nelements = db->getDoubleArraySize("step0sol");
         db->close();
     }
@@ -235,8 +235,8 @@ int main(int argc, char *argv[])
     CAROM_VERIFY(nelements > 0);
     if (myid == 0)
     {
-        cout << "Variable " << var_name << " has dimension " << nelements << "." <<
-             endl;
+        cout << "Variable " << var_name << " has dimension " << nelements
+             << "." << endl;
     }
 
     int dim = nelements;
@@ -248,16 +248,16 @@ int main(int argc, char *argv[])
         dim = idx_state.size();
         if (myid == 0)
         {
-            cout << "Restricting on " << dim << " entries out of " << nelements << "." <<
-                 endl;
+            cout << "Restricting on " << dim << " entries out of " << nelements
+                 << "." << endl;
         }
     }
 
     vector<double> indicator_val;
     if (online || numWindows > 0)
     {
-        csv_db.getDoubleVector(string(outputPath) + "/indicator_val.csv", indicator_val,
-                               false);
+        csv_db.getDoubleVector(string(outputPath) + "/indicator_val.csv",
+                               indicator_val, false);
         if (indicator_val.size() > 0)
         {
             if (numWindows > 0)
@@ -270,8 +270,8 @@ int main(int argc, char *argv[])
             }
             if (myid == 0)
             {
-                cout << "Read indicator range partition with " << numWindows << " windows." <<
-                     endl;
+                cout << "Read indicator range partition with " << numWindows
+                     << " windows." << endl;
             }
         }
     }
@@ -351,11 +351,9 @@ int main(int argc, char *argv[])
         vector<int> snap_index_list(numsnap);
         if (csvFormat)
             db->getIntegerArray(string(list_dir) + "/" + par_dir + ".csv",
-                                snap_index_list.data(),
-                                numsnap);
+                                snap_index_list.data(), numsnap);
         else
-            db->getIntegerArray("snap_list", snap_index_list.data(),
-                                numsnap);
+            db->getIntegerArray("snap_list", snap_index_list.data(), numsnap);
 
         vector<int> snap_bound(snap_bound_size);
         if (csvFormat) prefix = string(data_dir) + "/" + par_dir + "/";
@@ -367,8 +365,8 @@ int main(int argc, char *argv[])
             snap_bound[1] -= 1;
             if (myid == 0)
             {
-                cout << "Restricting on snapshot #" << snap_bound[0] << " to #" << snap_bound[1]
-                     << "." << endl;
+                cout << "Restricting on snapshot #" << snap_bound[0] << " to #"
+                     << snap_bound[1] << "." << endl;
             }
         }
         else
@@ -420,10 +418,10 @@ int main(int argc, char *argv[])
         }
         if (myid == 0)
         {
-            cout << "Created new indicator range partition with " << numWindows <<
-                 " windows." << endl;
-            csv_db.putDoubleVector(string(outputPath) + "/indicator_val.csv", indicator_val,
-                                   numWindows);
+            cout << "Created new indicator range partition with " << numWindows
+                 << " windows." << endl;
+            csv_db.putDoubleVector(string(outputPath) + "/indicator_val.csv",
+                                   indicator_val, numWindows);
         }
     }
 
@@ -513,8 +511,8 @@ int main(int argc, char *argv[])
                 CAROM_VERIFY(snap_bound.size() == 2);
                 if (myid == 0)
                 {
-                    cout << "Restricting on snapshot #" << snap_bound[0] << " to #" << snap_bound[1]
-                         << "." << endl;
+                    cout << "Restricting on snapshot #" << snap_bound[0]
+                         << " to #" << snap_bound[1] << "." << endl;
                 }
             }
             else
@@ -548,8 +546,9 @@ int main(int argc, char *argv[])
                     overlap_count -= 1;
                 }
                 // a rough estimate to correct the precision of the indicator range partition
-                double indicator_snap = tval - offset_indicator * tvec[snap_bound[0]] + dt_est /
-                                        100.0;
+                double indicator_snap = tval - offset_indicator * tvec[snap_bound[0]]
+                                        + dt_est / 100.0;
+
                 if (curr_window+1 < numWindows && idx_snap+1 <= snap_bound[1]
                         && indicator_snap > indicator_val[curr_window+1])
                 {
@@ -562,8 +561,8 @@ int main(int argc, char *argv[])
 
             if (myid == 0)
             {
-                cout << "Loaded " << num_train_snap[idx_dataset] << " samples for " << par_dir
-                     << "." << endl;
+                cout << "Loaded " << num_train_snap[idx_dataset]
+                     << " samples for " << par_dir << "." << endl;
             }
 
             for (int window = 0; window < numWindows; ++window)
@@ -580,8 +579,8 @@ int main(int argc, char *argv[])
                 {
                     if (myid == 0)
                     {
-                        cout << "Creating DMD model #" << window << " with energy fraction: " << ef <<
-                             endl;
+                        cout << "Creating DMD model #" << window
+                             << " with energy fraction: " << ef << endl;
                     }
                     dmd[idx_dataset][window]->train(ef);
                 }
@@ -589,8 +588,9 @@ int main(int argc, char *argv[])
                 {
                     if (myid == 0)
                     {
-                        cout << "Projecting initial condition at t = " << indicator_val[window] +
-                             offset_indicator * tvec[snap_bound[0]] << " for DMD model #" << window << endl;
+                        cout << "Projecting initial condition at t = "
+                             << indicator_val[window] + offset_indicator * tvec[snap_bound[0]]
+                             << " for DMD model #" << window << endl;
                     }
                     CAROM::Vector* init_cond = dmd[idx_dataset][window-1]->predict(
                                                    indicator_val[window]);
@@ -601,8 +601,9 @@ int main(int argc, char *argv[])
                                                    window) + "_par" + to_string(idx_dataset));
                 if (myid == 0)
                 {
-                    dmd[idx_dataset][window]->summary(outputPath + "/window" + to_string(
-                                                          window) + "_par" + to_string(idx_dataset));
+                    dmd[idx_dataset][window]->summary(outputPath + "/window"
+                                                      + to_string(window) + "_par"
+                                                      + to_string(idx_dataset));
                 }
             } // escape for-loop over window
 
@@ -694,8 +695,8 @@ int main(int argc, char *argv[])
                 CAROM_VERIFY(snap_bound.size() == 2);
                 if (myid == 0)
                 {
-                    cout << "Restricting on snapshot #" << snap_bound[0] << " to " << snap_bound[1]
-                         << "." << endl;
+                    cout << "Restricting on snapshot #" << snap_bound[0]
+                         << " to " << snap_bound[1] << "." << endl;
                 }
             }
             else
@@ -719,22 +720,23 @@ int main(int argc, char *argv[])
                 std::vector<std::string> dmd_paths;
                 for (int idx_trainset = 0; idx_trainset < par_vectors.size(); ++idx_trainset)
                 {
-                    dmd_paths.push_back(outputPath + "/window" + to_string(window) + "_par" +
-                                        to_string(idx_trainset));
+                    dmd_paths.push_back(outputPath + "/window" + to_string(window)
+                                        + "_par" + to_string(idx_trainset));
                 }
 
                 if (myid == 0)
                 {
                     cout << "Interpolating DMD model #" << window << endl;
                 }
-                CAROM::getParametricDMD(dmd[idx_dataset][window], par_vectors, dmd_paths,
-                                        curr_par,
-                                        string(rbf), string(interp_method), pdmd_closest_rbf_val);
+                CAROM::getParametricDMD(dmd[idx_dataset][window], par_vectors,
+                                        dmd_paths, curr_par, string(rbf),
+                                        string(interp_method), pdmd_closest_rbf_val);
 
                 if (myid == 0)
                 {
-                    cout << "Projecting initial condition at t = " << indicator_val[window] +
-                         offset_indicator * tvec[snap_bound[0]] << " for DMD model #" << window << endl;
+                    cout << "Projecting initial condition at t = "
+                         << indicator_val[window] + offset_indicator * tvec[snap_bound[0]]
+                         << " for DMD model #" << window << endl;
                 }
                 CAROM::Vector* init_cond = nullptr;
                 if (window == 0)
@@ -805,8 +807,8 @@ int main(int argc, char *argv[])
                 CAROM_VERIFY(snap_bound.size() == 2);
                 if (myid == 0)
                 {
-                    cout << "Restricting on snapshot #" << snap_bound[0] << " to " << snap_bound[1]
-                         << "." << endl;
+                    cout << "Restricting on snapshot #" << snap_bound[0]
+                         << " to " << snap_bound[1] << "." << endl;
                 }
             }
             else
@@ -838,16 +840,16 @@ int main(int argc, char *argv[])
                 if (t_final > 0.0) // Actual prediction without true solution for comparison
                 {
                     num_tests += 1;
-                    while (curr_window+1 < numWindows
-                            && t_final - offset_indicator * tvec[snap_bound[0]] > indicator_val[curr_window
-                                    +1])
+                    while (curr_window+1 < numWindows &&
+                            t_final - offset_indicator * tvec[snap_bound[0]] >
+                            indicator_val[curr_window+1])
                     {
                         curr_window += 1;
                     }
                     if (myid == 0)
                     {
-                        cout << "Predicting DMD solution at t = " << t_final << " using DMD model #" <<
-                             curr_window << endl;
+                        cout << "Predicting DMD solution at t = " << t_final
+                             << " using DMD model #" << curr_window << endl;
                     }
 
                     dmd_prediction_timer.Start();
@@ -857,7 +859,8 @@ int main(int argc, char *argv[])
 
                     if (myid == 0)
                     {
-                        csv_db.putDoubleArray(outputPath + "/" + par_dir + "_final_time_prediction.csv",
+                        csv_db.putDoubleArray(outputPath + "/" + par_dir +
+                                              "_final_time_prediction.csv",
                                               result->getData(), dim);
                     }
                     idx_snap = snap_bound[1]+1; // escape for-loop over idx_snap
@@ -865,15 +868,17 @@ int main(int argc, char *argv[])
                 }
                 else // Verify DMD prediction results against dataset
                 {
-                    while (curr_window+1 < numWindows
-                            && tval - offset_indicator * tvec[snap_bound[0]] > indicator_val[curr_window+1])
+                    while (curr_window+1 < numWindows &&
+                            tval - offset_indicator * tvec[snap_bound[0]] >
+                            indicator_val[curr_window+1])
                     {
                         curr_window += 1;
                     }
                     if (myid == 0)
                     {
-                        cout << "Predicting DMD solution #" << idx_snap << " at t = " << tval <<
-                             " using DMD model #" << curr_window << endl;
+                        cout << "Predicting DMD solution #" << idx_snap
+                             << " at t = " << tval << " using DMD model #"
+                             << curr_window << endl;
                     }
 
                     dmd_prediction_timer.Start();
@@ -897,20 +902,20 @@ int main(int argc, char *argv[])
 
                     if (myid == 0)
                     {
-                        cout << "Norm of true solution at t = " << tval << " is " <<
-                             tot_true_solution_norm << endl;
-                        cout << "Absolute error of DMD solution at t = " << tval << " is " <<
-                             tot_diff_norm << endl;
-                        cout << "Relative error of DMD solution at t = " << tval << " is " << rel_error
-                             << endl;
+                        cout << "Norm of true solution at t = " << tval
+                             << " is " << tot_true_solution_norm << endl;
+                        cout << "Absolute error of DMD solution at t = " << tval
+                             << " is " << tot_diff_norm << endl;
+                        cout << "Relative error of DMD solution at t = " << tval
+                             << " is " << rel_error << endl;
                         if (save_csv)
                         {
                             csv_db.putDoubleArray(outputPath + "/" + par_dir + "_" + snap +
                                                   "_prediction.csv", result->getData(), dim);
                             if (dim < nelements)
                             {
-                                csv_db.putDoubleArray(outputPath + "/" + par_dir + "_" + snap + "_state.csv",
-                                                      sample, dim);
+                                csv_db.putDoubleArray(outputPath + "/" + par_dir + "_"
+                                                      + snap + "_state.csv", sample, dim);
                             }
                         }
                     }


### PR DESCRIPTION
This PR generalizes the DMD time-windowing examples, by removing the default names associated with the heat conduction example and allowing for specification of more names. Also, some style improvements are made.