### PR TITLE
add destructors and virtual destructor to DMD base and derived classes

### DIFF
--- a/lib/algo/AdaptiveDMD.cpp
+++ b/lib/algo/AdaptiveDMD.cpp
@@ -34,6 +34,14 @@ AdaptiveDMD::AdaptiveDMD(int dim, double desired_dt, std::string rbf,
     d_closest_rbf_val = closest_rbf_val;
 }
 
+AdaptiveDMD::~AdaptiveDMD()
+{
+    for (auto interp_snapshot : d_interp_snapshots)
+    {
+        delete interp_snapshot;
+    }
+}
+
 void AdaptiveDMD::train(double energy_fraction, const Matrix* W0,
                         double linearity_tol)
 {

--- a/lib/algo/AdaptiveDMD.h
+++ b/lib/algo/AdaptiveDMD.h
@@ -52,6 +52,11 @@ public:
                 std::string interp_method = "LS",
                 double closest_rbf_val = 0.9,
                 Vector* state_offset = NULL);
+    
+    /**
+     * @brief Destroy the AdaptiveDMD object
+     */
+    ~AdaptiveDMD();
 
     /**
      * @param[in] energy_fraction The energy fraction to keep after doing SVD.

--- a/lib/algo/DMD.cpp
+++ b/lib/algo/DMD.cpp
@@ -135,42 +135,15 @@ DMD::~DMD()
     {
         delete sampled_time;
     }
-    if (d_state_offset != nullptr)
-    {
-        delete d_state_offset;
-    }
-    if (d_basis != nullptr)
-    {
-        delete d_basis;
-    }
-    if (d_A_tilde != nullptr)
-    {
-        delete d_A_tilde;
-    }
-    if (d_phi_real != nullptr)
-    {
-        delete d_phi_real;
-    }
-    if (d_phi_imaginary != nullptr)
-    {
-        delete d_phi_imaginary;
-    }
-    if (d_phi_real_squared_inverse != nullptr)
-    {
-        delete d_phi_real_squared_inverse;
-    }
-    if (d_phi_imaginary_squared_inverse != nullptr)
-    {
-        delete d_phi_imaginary_squared_inverse;
-    }
-    if (d_projected_init_real != nullptr)
-    {
-        delete d_projected_init_real;
-    }
-    if (d_projected_init_imaginary != nullptr)
-    {
-        delete d_projected_init_imaginary;
-    }
+    delete d_state_offset;
+    delete d_basis;
+    delete d_A_tilde;
+    delete d_phi_real;
+    delete d_phi_imaginary;
+    delete d_phi_real_squared_inverse;
+    delete d_phi_imaginary_squared_inverse;
+    delete d_projected_init_real;
+    delete d_projected_init_imaginary;
 }
 
 void DMD::setOffset(Vector* offset_vector, int order)

--- a/lib/algo/DMD.cpp
+++ b/lib/algo/DMD.cpp
@@ -125,6 +125,54 @@ DMD::DMD(std::vector<std::complex<double>> eigs, Matrix* phi_real,
     setOffset(state_offset, 0);
 }
 
+DMD::~DMD()
+{
+    for (auto snapshot : d_snapshots)
+    {
+        delete snapshot;
+    }
+    for (auto sampled_time : d_sampled_times)
+    {
+        delete sampled_time;
+    }
+    if (d_state_offset != nullptr)
+    {
+        delete d_state_offset;
+    }
+    if (d_basis != nullptr)
+    {
+        delete d_basis;
+    }
+    if (d_A_tilde != nullptr)
+    {
+        delete d_A_tilde;
+    }
+    if (d_phi_real != nullptr)
+    {
+        delete d_phi_real;
+    }
+    if (d_phi_imaginary != nullptr)
+    {
+        delete d_phi_imaginary;
+    }
+    if (d_phi_real_squared_inverse != nullptr)
+    {
+        delete d_phi_real_squared_inverse;
+    }
+    if (d_phi_imaginary_squared_inverse != nullptr)
+    {
+        delete d_phi_imaginary_squared_inverse;
+    }
+    if (d_projected_init_real != nullptr)
+    {
+        delete d_projected_init_real;
+    }
+    if (d_projected_init_imaginary != nullptr)
+    {
+        delete d_projected_init_imaginary;
+    }
+}
+
 void DMD::setOffset(Vector* offset_vector, int order)
 {
     if (order == 0)

--- a/lib/algo/DMD.cpp
+++ b/lib/algo/DMD.cpp
@@ -377,6 +377,7 @@ DMD::constructDMD(const Matrix* f_snapshots,
         gather_transposed_block(&d_basis_right->item(0, 0), d_factorizer->U, 1, 1,
                                 f_snapshots_in->numColumns(), d_k, d_rank);
     }
+    delete[] row_offset;
 
     // Get inverse of singular values by multiplying by reciprocal.
     for (int i = 0; i < d_k; ++i)
@@ -473,13 +474,13 @@ DMD::constructDMD(const Matrix* f_snapshots,
         d_k = d_basis_new->numColumns();
         if (d_rank == 0) std::cout << "After adding W0, now using " << d_k <<
                                        " basis vectors." << std::endl;
+        delete d_basis_new;
     }
 
     // Calculate A_tilde = U_transpose * f_snapshots_out * V * inv(S)
     Matrix* d_basis_mult_f_snapshots_out = d_basis->transposeMult(f_snapshots_out);
     Matrix* d_basis_mult_f_snapshots_out_mult_d_basis_right =
         d_basis_mult_f_snapshots_out->mult(d_basis_right);
-    d_A_tilde = d_basis_mult_f_snapshots_out_mult_d_basis_right->mult(d_S_inv);
     if (Q == NULL)
     {
         d_A_tilde = d_basis_mult_f_snapshots_out_mult_d_basis_right->mult(d_S_inv);

--- a/lib/algo/DMD.h
+++ b/lib/algo/DMD.h
@@ -66,6 +66,11 @@ public:
     DMD(std::string base_file_name);
 
     /**
+     * @brief Destroy the DMD object
+     */
+    virtual ~DMD();
+
+    /**
      * @brief Set the offset of a certain order.
      */
     virtual void setOffset(Vector* offset_vector, int order);

--- a/lib/algo/NonuniformDMD.cpp
+++ b/lib/algo/NonuniformDMD.cpp
@@ -48,6 +48,14 @@ NonuniformDMD::NonuniformDMD(std::vector<std::complex<double>> eigs,
     setOffset(derivative_offset, 1);
 }
 
+NonuniformDMD::~NonuniformDMD()
+{
+    if (d_derivative_offset != nullptr)
+    {
+        delete d_derivative_offset;
+    }
+}
+
 void NonuniformDMD::setOffset(Vector* offset_vector, int order)
 {
     if (order == 0)

--- a/lib/algo/NonuniformDMD.cpp
+++ b/lib/algo/NonuniformDMD.cpp
@@ -50,10 +50,7 @@ NonuniformDMD::NonuniformDMD(std::vector<std::complex<double>> eigs,
 
 NonuniformDMD::~NonuniformDMD()
 {
-    if (d_derivative_offset != nullptr)
-    {
-        delete d_derivative_offset;
-    }
+    delete d_derivative_offset;
 }
 
 void NonuniformDMD::setOffset(Vector* offset_vector, int order)

--- a/lib/algo/NonuniformDMD.h
+++ b/lib/algo/NonuniformDMD.h
@@ -56,6 +56,11 @@ public:
     NonuniformDMD(std::string base_file_name);
 
     /**
+     * @brief Destroy the NonuniformDMD object
+     */
+    ~NonuniformDMD();
+
+    /**
      * @brief Set the offset of a certain order.
      */
     void setOffset(Vector* offset_vector, int order) override;


### PR DESCRIPTION
This PR adds destructors to `delete` allocated memory in `CAROM::DMD`, `CAROM::NonuniformDMD`, and `CAROM::AdaptiveDMD`.