### PR TITLE
Fix pointwise sampling of L2 fields

### DIFF
--- a/lib/algo/AdaptiveDMD.h
+++ b/lib/algo/AdaptiveDMD.h
@@ -52,7 +52,7 @@ public:
                 std::string interp_method = "LS",
                 double closest_rbf_val = 0.9,
                 Vector* state_offset = NULL);
-    
+
     /**
      * @brief Destroy the AdaptiveDMD object
      */

--- a/lib/mfem/PointwiseSnapshot.cpp
+++ b/lib/mfem/PointwiseSnapshot.cpp
@@ -76,6 +76,7 @@ void PointwiseSnapshot::SetMesh(ParMesh *pmesh)
 
     finder = new FindPointsGSLIB(MPI_COMM_WORLD);
     finder->Setup(*pmesh);
+    finder->SetL2AvgType(FindPointsGSLIB::AvgType::NONE);
 }
 
 void PointwiseSnapshot::GetSnapshot(ParGridFunction const& f, mfem::Vector & s)


### PR DESCRIPTION
The examples in libROM do not seem to require or to be affected by this change. For some applications, the default averaging of points sampled on element boundaries in MFEM apparently has some issue that can result in negative values averaged from positive values. This PR sets the averaging type to `NONE`, avoiding this issue.