### PR TITLE
Run regresssion tests on LGTM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
-on:
-  push:
+on: 
   pull_request:
     branches:
       - master
+  label:
+    types: [created]
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -31,6 +32,7 @@ jobs:
             cmake -DCMAKE_BUILD_TYPE=Optimized -DUSE_MFEM=On ..
             make
       - name: Build baseline libROM
+        if: ${{ github.event.label.name == 'LGTM' || contains(github.event.pull_request.labels.*.name, 'LGTM') }}
         run: |
             cd ${GITHUB_WORKSPACE}/dependencies
             git clone https://github.com/LLNL/libROM.git

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -1,7 +1,7 @@
 runs:
   using: "composite"
   steps:
-    - name: Run tests
+    - name: Run unit tests
       run: |
           cd ${GITHUB_WORKSPACE}/build
           ./tests/test_SVD
@@ -19,6 +19,12 @@ runs:
           mpirun -n 3 --oversubscribe tests/test_DMD
           ./tests/test_GreedyCustomSampler
           mpirun -n 3 --oversubscribe tests/test_GreedyCustomSampler
+
+      shell: bash
+      
+    - name: Run regression tests
+      if: ${{ github.event.label.name == 'LGTM' || contains(github.event.pull_request.labels.*.name, 'LGTM') }}
+      run: |
           cd ${GITHUB_WORKSPACE}
           ./regression_tests/run_regression_tests.sh
          

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ mpicxx myapp.cpp -I/path/to/libROM/lib -Wl,-rpath,/path/to/libROM/build/lib -L/p
 ```
 
 
+# libROM CI
+
+libROM leverages GitHub Actions for CI. The CI currently applies only to commits to pull requests.  Unit tests run for all PR commits. Upon the addition of the `LGTM` label, both the unit tests and regression tests run. While the `LGTM` label is still present, all subsequent commits run both unit tests and regression tests. 
+
 # License
 
 libROM is distributed under the terms of both the MIT license and the


### PR DESCRIPTION
This PR modifies the CI to only run for PR commits, and runs the entire CI pipeline(unit and regression tests) only when the LGTM label is added to the PR. 