### PR TITLE
Restore the snapshot filename format in CSV databases

### DIFF
--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -16,15 +16,15 @@
 // =================================================================================
 //
 // Local serial DMD command for CSV or HDF:
-//   mpirun -np 8 local_tw_csv -o hc_local_serial -rdim 16 -dtc 0.01 -csv
-//   mpirun -np 8 local_tw_csv -o hc_local_serial -rdim 16 -dtc 0.01 -hdf
+//   mpirun -np 8 local_tw_csv -o hc_local_serial -rdim 16 -dtc 0.01 -csv -snap-pfx step
+//   mpirun -np 8 local_tw_csv -o hc_local_serial -rdim 16 -dtc 0.01 -hdf -snap-pfx step
 //
 // Final-time prediction error (last line in run/hc_local_serial/dmd_par5_prediction_error.csv):
 //   0.0004063242226265
 //
 // Local time windowing DMD command for CSV or HDF:
-//   mpirun -np 8 local_tw_csv -o hc_local_tw -rdim 16 -nwinsamp 25 -dtc 0.01 -csv
-//   mpirun -np 8 local_tw_csv -o hc_local_tw -nwinsamp 25 -dtc 0.01 -hdf
+//   mpirun -np 8 local_tw_csv -o hc_local_tw -rdim 16 -nwinsamp 25 -dtc 0.01 -csv -snap-pfx step
+//   mpirun -np 8 local_tw_csv -o hc_local_tw -nwinsamp 25 -dtc 0.01 -hdf -snap-pfx step
 //
 // Final-time prediction error (last line in run/hc_local_tw/dmd_par5_prediction_error.csv):
 //   0.0002458808673544
@@ -101,6 +101,7 @@ int main(int argc, char *argv[])
     const char *temporal_idx_list = "temporal_idx";
     const char *spatial_idx_list = "spatial_idx";
     const char *hdf_name = "dmd.hdf";
+    const char *snap_pfx = "";
     const char *basename = "";
     bool save_csv = false;
     bool csvFormat = true;
@@ -148,6 +149,8 @@ int main(int argc, char *argv[])
                    "Name of the file indicating bound of temporal indices.");
     args.AddOption(&spatial_idx_list, "-x-idx", "--spatial-index",
                    "Name of the file indicating spatial indices.");
+    args.AddOption(&snap_pfx, "-snap-pfx", "--snapshot-prefix",
+                   "Prefix of snapshots.");
     args.AddOption(&basename, "-o", "--outputfile-name",
                    "Name of the sub-folder to dump files within the run directory.");
     args.AddOption(&save_csv, "-save", "--save", "-no-save", "--no-save",
@@ -270,49 +273,62 @@ int main(int argc, char *argv[])
     }
 
     int npar = 0;
-    int num_train_snap;
+    int num_train_snap_orig, num_train_snap;
+    string training_par_dir;
     vector<string> training_par_list;
+    vector<int> training_snap_bound;
     if (train)
     {
-        csv_db.getStringVector(string(list_dir) + "/" + train_list + ".csv",
+        csv_db.getStringVector(string(list_dir) + "/" + string(train_list) + ".csv",
                                training_par_list, false);
         npar = training_par_list.size();
         CAROM_VERIFY(npar == 1);
 
         stringstream par_ss(training_par_list[0]); // training DATASET
-        string par_dir;
-        getline(par_ss, par_dir, ',');
+        getline(par_ss, training_par_dir, ',');
 
-        int snap_bound_size = 0;
-        if (!csvFormat)
+        if (csvFormat)
         {
-            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
-        }
-
-        db->getInteger("snap_bound_size", snap_bound_size);
-
-        vector<int> snap_bound(snap_bound_size);
-        if (csvFormat) prefix = string(data_dir) + "/" + par_dir + "/";
-        db->getIntegerArray(prefix + temporal_idx_list + suffix,
-                            snap_bound.data(), snap_bound_size);
-
-        if (snap_bound.size() > 0)
-        {
-            snap_bound[0] -= 1;
-            snap_bound[1] -= 1;
-            CAROM_VERIFY(snap_bound.size() == 2);
-            num_train_snap = snap_bound[1] - snap_bound[0] + 1;
+            num_train_snap_orig = csv_db.getLineCount(string(list_dir) + "/" + training_par_dir + ".csv");
         }
         else
         {
-            if (csvFormat)
+            db->getInteger("numsnap", num_train_snap_orig);
+        }
+        CAROM_VERIFY(num_train_snap_orig > 0);
+
+        int snap_bound_size = 0;
+        if (csvFormat)
+        {
+            prefix = string(data_dir) + "/" + training_par_dir + "/";
+            snap_bound_size = csv_db.getLineCount(prefix + temporal_idx_list + suffix);
+        }
+        else
+        {
+            db->open(string(data_dir) + "/" + training_par_dir + "/" + hdf_name, "r");
+            db->getInteger("snap_bound_size", snap_bound_size);
+        }
+
+        if (snap_bound_size > 0)
+        {
+            CAROM_VERIFY(snap_bound_size == 2);
+            training_snap_bound.resize(2);
+            db->getIntegerArray(prefix + temporal_idx_list + suffix,
+                                training_snap_bound.data(), snap_bound_size);
+            training_snap_bound[0] -= 1;
+            training_snap_bound[1] -= 1;
+            num_train_snap = training_snap_bound[1] - training_snap_bound[0] + 1;
+            if (myid == 0)
             {
-                num_train_snap = csv_db.getLineCount(string(list_dir) + "/" + par_dir + ".csv");
+                cout << "Restricting on snapshot #" << training_snap_bound[0] << " to "
+                     << training_snap_bound[1] << "." << endl;
             }
-            else
-            {
-                db->getInteger("numsnap", num_train_snap);
-            }
+        }
+        else
+        {
+            training_snap_bound.push_back(0);
+            training_snap_bound.push_back(num_train_snap_orig - 1);
+            num_train_snap = num_train_snap_orig;
         }
 
         db->close();
@@ -376,29 +392,17 @@ int main(int argc, char *argv[])
         string par_dir;
         getline(par_ss, par_dir, ',');
 
-        int numsnap = 0;
+        vector<string> snap_list(num_train_snap_orig);
+        vector<int> snap_index_list(num_train_snap_orig);
         if (csvFormat)
         {
-            numsnap = csv_db.getLineCount(string(list_dir) + "/" + par_dir + ".csv");
-        }
-        else
-        {
-            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
-            db->getInteger("numsnap", numsnap);
-        }
-
-        CAROM_VERIFY(numsnap > 0);
-        vector<int> snap_index_list(numsnap);
-        if (csvFormat)
-        {
-            db->getIntegerArray(string(list_dir) + "/" + par_dir + ".csv",
-                                snap_index_list.data(),
-                                numsnap);
+            csv_db.getStringVector(string(list_dir) + "/" + par_dir + ".csv", snap_list,
+                               false);
         }
         else
         {
             db->getIntegerArray("snap_list", snap_index_list.data(),
-                                numsnap);
+                                num_train_snap_orig);
         }
 
         if (myid == 0)
@@ -406,53 +410,34 @@ int main(int argc, char *argv[])
             cout << "Loading samples for " << par_dir << " to train DMD." << endl;
         }
 
-        vector<double> tvec(numsnap);
+        vector<double> tvec(num_train_snap_orig);
         if (csvFormat) prefix = string(data_dir) + "/" + par_dir + "/";
-        db->getDoubleArray(prefix + "tval" + suffix, tvec.data(), numsnap);
-
-        int snap_bound_size = 0;
-        db->getInteger("snap_bound_size", snap_bound_size);
-        vector<int> snap_bound(snap_bound_size);
-        db->getIntegerArray(prefix + temporal_idx_list + suffix,
-                            snap_bound.data(), snap_bound_size);
-
-        if (snap_bound.size() > 0)
-        {
-            snap_bound[0] -= 1;
-            snap_bound[1] -= 1;
-            CAROM_VERIFY(snap_bound.size() == 2);
-            if (myid == 0)
-            {
-                cout << "Restricting on snapshot #" << snap_bound[0] << " to "
-                     << snap_bound[1] << "." << endl;
-            }
-        }
-        else
-        {
-            snap_bound.push_back(0);
-            snap_bound.push_back(snap_index_list.size()-1);
-        }
+        db->getDoubleArray(prefix + "tval" + suffix, tvec.data(), num_train_snap_orig);
 
         int curr_window = 0;
         int overlap_count = 0;
-        for (int idx_snap = snap_bound[0]; idx_snap <= snap_bound[1]; ++idx_snap)
+        for (int idx_snap = training_snap_bound[0]; idx_snap <= training_snap_bound[1]; ++idx_snap)
         {
-            string snap = "step" + to_string(snap_index_list[idx_snap]); // STATE
+            string snap = snap_pfx;
             double tval = tvec[idx_snap];
 
-            if (idx_snap == snap_bound[0])
+            if (idx_snap == training_snap_bound[0])
             {
                 indicator_val.push_back(tval);
             }
 
             if (csvFormat)
             {
+                snap += snap_list[idx_snap]; // STATE
                 string data_filename = string(data_dir) + "/" + par_dir + "/" + snap + "/" +
                                        variable + ".csv"; // path to VAR_NAME.csv
                 db->getDoubleArray(data_filename, sample, nelements, idx_state);
             }
             else
+            {
+                snap += to_string(snap_index_list[idx_snap]); // STATE
                 db->getDoubleArray(snap + "sol", sample, nelements, idx_state);
+            }
 
             dmd[curr_window]->takeSample(sample, tval);
             if (overlap_count > 0)
@@ -460,12 +445,12 @@ int main(int argc, char *argv[])
                 dmd[curr_window-1]->takeSample(sample, tval);
                 overlap_count -= 1;
             }
-            if (curr_window+1 < numWindows && idx_snap+1 <= snap_bound[1])
+            if (curr_window+1 < numWindows && idx_snap+1 <= training_snap_bound[1])
             {
                 bool new_window = false;
                 if (windowNumSamples < infty)
                 {
-                    new_window = (idx_snap >= snap_bound[0] + (curr_window+1)*windowNumSamples);
+                    new_window = (idx_snap >= training_snap_bound[0] + (curr_window+1)*windowNumSamples);
                 }
                 else
                 {
@@ -604,47 +589,60 @@ int main(int argc, char *argv[])
             cout << "Predicting solution for " << par_dir << " using DMD." << endl;
         }
 
-        int numsnap = 0;
+        int num_snap_orig = 0;
         if (csvFormat)
         {
-            numsnap = csv_db.getLineCount(string(list_dir) + "/" + par_dir + ".csv");
+            num_snap_orig = csv_db.getLineCount(string(list_dir) + "/" + par_dir + ".csv");
         }
         else
         {
             db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
-            db->getInteger("numsnap", numsnap);
+            db->getInteger("numsnap", num_snap_orig);
         }
 
-        CAROM_VERIFY(numsnap > 0);
-        vector<int> snap_index_list(numsnap);
+        CAROM_VERIFY(num_snap_orig > 0);
+        vector<string> snap_list(num_snap_orig);
+        vector<int> snap_index_list(num_snap_orig);
         if (csvFormat)
         {
-            db->getIntegerArray(string(list_dir) + "/" + par_dir + ".csv",
-                                snap_index_list.data(),
-                                numsnap);
+            csv_db.getStringVector(string(list_dir) + "/" + par_dir + ".csv", snap_list,
+                               false);
         }
         else
         {
             db->getIntegerArray("snap_list", snap_index_list.data(),
-                                numsnap);
+                                num_snap_orig);
         }
 
         if (csvFormat) prefix = string(data_dir) + "/" + par_dir + "/";
 
-        vector<double> tvec(numsnap);
-        db->getDoubleArray(prefix + "tval" + suffix, tvec.data(), numsnap);
+        vector<double> tvec(num_snap_orig);
+        db->getDoubleArray(prefix + "tval" + suffix, tvec.data(), num_snap_orig);
 
         int snap_bound_size = 0;
-        db->getInteger("snap_bound_size", snap_bound_size);
+        if (csvFormat)
+        {
+            prefix = string(data_dir) + "/" + par_dir + "/";
+            snap_bound_size = csv_db.getLineCount(prefix + temporal_idx_list + suffix);
+        }
+        else
+        {
+            db->open(string(data_dir) + "/" + par_dir + "/" + hdf_name, "r");
+            db->getInteger("snap_bound_size", snap_bound_size);
+        }
+
         vector<int> snap_bound(snap_bound_size);
         db->getIntegerArray(prefix + temporal_idx_list + suffix,
                             snap_bound.data(), snap_bound_size);
 
-        if (snap_bound.size() > 0)
+        if (snap_bound_size > 0)
         {
+            CAROM_VERIFY(snap_bound_size == 2);
+            snap_bound.resize(2);
+            db->getIntegerArray(prefix + temporal_idx_list + suffix,
+                                snap_bound.data(), snap_bound_size);
             snap_bound[0] -= 1;
             snap_bound[1] -= 1;
-            CAROM_VERIFY(snap_bound.size() == 2);
             if (myid == 0)
             {
                 cout << "Restricting on snapshot #" << snap_bound[0] << " to "
@@ -654,23 +652,27 @@ int main(int argc, char *argv[])
         else
         {
             snap_bound.push_back(0);
-            snap_bound.push_back(snap_index_list.size()-1);
+            snap_bound.push_back(num_snap_orig - 1);
         }
 
         int num_snap = snap_bound[1] - snap_bound[0] + 1;
         int curr_window = 0;
         for (int idx_snap = snap_bound[0]; idx_snap <= snap_bound[1]; ++idx_snap)
         {
-            string snap = "step" + to_string(snap_index_list[idx_snap]); // STATE
+            string snap = snap_pfx;
             double tval = tvec[idx_snap];
             if (csvFormat)
             {
+                snap += snap_list[idx_snap]; // STATE
                 string data_filename = string(data_dir) + "/" + par_dir + "/" + snap +
                                        "/" + variable + ".csv"; // path to VAR_NAME.csv
                 db->getDoubleArray(data_filename, sample, nelements, idx_state);
             }
             else
+            {
+                snap += to_string(snap_index_list[idx_snap]); // STATE
                 db->getDoubleArray(snap + "sol", sample, nelements, idx_state);
+            }
 
             if (myid == 0)
             {


### PR DESCRIPTION
Several fixes are made to make the DMD capabilities work for general datasets. 

- Fix the temporal trimming (by getting the correct `snap_bound_size` from the file)
- Fix the snapshot filename restriction in CSV file. In general, the snapshot files may be named by a combination of prefix and suffix, `{snap_pfx}{snap_sfx}`, where `snap_pfx` is set as an option (default empty) and `snap_sfx` is read from the snapshot list. For example, in the heat conduction example, the option `-snap-pfx step` is added, and the first line of the list file is `0`. With the data format suffix `.csv`, the first snapshot filename is `step0.csv`. @dylan-copeland This changes will need you to add the corresponding option in your tests.
- Simplify the training phase of the `local_tw_csv` script.