### PR TITLE
Addition of apt update to Linux CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+            sudo apt update
             sudo apt-get install libmpich-dev libblas-dev liblapack-dev libscalapack-mpi-dev libhdf5-serial-dev
       - name: Check out libROM
         uses: actions/checkout@v2


### PR DESCRIPTION
Our Linux CI workflow began failing this afternoon for no apparent reason(there have been no changes to the Linux-specific section of the relevant workflow file). An addition of `apt update` before fetching the necessary packages for the Ubuntu GitHub Actions runner refreshes the list of available packages and results in successful Linux CI runs. 