### PR TITLE
Const vector print function

### DIFF
--- a/lib/linalg/Vector.cpp
+++ b/lib/linalg/Vector.cpp
@@ -473,7 +473,7 @@ Vector::write(const std::string& base_file_name)
 }
 
 void
-Vector::print(const char * prefix)
+Vector::print(const char * prefix) const
 {
     int my_rank;
     const bool success = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);

--- a/lib/linalg/Vector.h
+++ b/lib/linalg/Vector.h
@@ -715,7 +715,7 @@ public:
      * @param[in] prefix The name of the prefix of the file name.
      *
      */
-    void print(const char * prefix);
+    void print(const char * prefix) const;
 
     /**
      * @brief write Vector into (a) HDF file(s).


### PR DESCRIPTION
This PR adds `const` labels to the print function of `Vector` such that `const Vectors` can be printed as well. 

An alternative to adding `const` labels would be to copy the print function to a `const` version. However, I think this is unnecessary as the print function could be a `const` anyway.

An example where this is beneficial is in the case of printing the  `const`  singular values owned by for instance  `BasisGenerator generator`. Printing these with
```
generator->getSingularValues()->print("sv");
```
will thrown an error. 

The CI/mac test seems to fail. From what I understand this is not due to the added `const` labels.
