### PR TITLE
Print out error message if trivial solution is taken.

### DIFF
--- a/lib/linalg/BasisGenerator.cpp
+++ b/lib/linalg/BasisGenerator.cpp
@@ -132,7 +132,7 @@ BasisGenerator::takeSample(
     // Check that u_in is not non-zero.
     Vector u_vec(u_in, getDim(), true);
     if (u_vec.norm() == 0.0) {
-        printf("BasisGenerator::takeSample - trivial samples are not allowed!\n");
+        printf("WARNING: BasisGenerator::takeSample skipped trivial sample at time %.4E\n", time);
         return false;
     }
 

--- a/lib/linalg/BasisGenerator.cpp
+++ b/lib/linalg/BasisGenerator.cpp
@@ -132,6 +132,7 @@ BasisGenerator::takeSample(
     // Check that u_in is not non-zero.
     Vector u_vec(u_in, getDim(), true);
     if (u_vec.norm() == 0.0) {
+        printf("BasisGenerator::takeSample - trivial samples are not allowed!\n");
         return false;
     }
 


### PR DESCRIPTION
Resolve the issue #194 .

`BasisGenerator` does not allow trivial samples, returning failure without any error message. Added a short error message to make it clear.