### PR TITLE
Fix issue in doxygen

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/sphinx/conf.py


### PR DESCRIPTION
It seems the issue is not in libROM, but a new release of [urllib3](https://github.com/urllib3/urllib3/releases/tag/2.0.0) is not compatible with the readthedocs docker image used to build the documentation. 

Following [this page](https://docs.readthedocs.io/en/stable/config-file/v2.html), it may be fixed by specifying the most recent image.

Update: the build #20414929 is successful.