### PR TITLE
Add regression test for mixed nonlinear diffusion EQP

### DIFF
--- a/regression_tests/tests/prom/mixed_nonlinear_diffusion.sh
+++ b/regression_tests/tests/prom/mixed_nonlinear_diffusion.sh
@@ -4,6 +4,7 @@ CMDS=(
     "./mixed_nonlinear_diffusion -offline -tf 0.01"
     "./mixed_nonlinear_diffusion -merge -ns 1 -tf 0.01"
     "./mixed_nonlinear_diffusion -online -tf 0.01"
+    "./mixed_nonlinear_diffusion -online -tf 0.01 -rrdim 2 -rwdim 2 -nldim 3 -ns 1 -eqp -maxnnls 4"
 )
 TYPE="PROM"
 OFFSET=5

--- a/regression_tests/tests/prom/mixed_nonlinear_diffusion.sh
+++ b/regression_tests/tests/prom/mixed_nonlinear_diffusion.sh
@@ -4,6 +4,7 @@ CMDS=(
     "./mixed_nonlinear_diffusion -offline -tf 0.01"
     "./mixed_nonlinear_diffusion -merge -ns 1 -tf 0.01"
     "./mixed_nonlinear_diffusion -online -tf 0.01"
+    "./mixed_nonlinear_diffusion -online -tf 0.01 -sopt"
     "./mixed_nonlinear_diffusion -online -tf 0.01 -rrdim 2 -rwdim 2 -nldim 3 -ns 1 -eqp -maxnnls 4"
 )
 TYPE="PROM"


### PR DESCRIPTION
A snapshot of the final output for the EQP command:

Newton iteration  8 : ||r|| = 3.18996e-08, ||r||/||r_0|| = 8.99834e-05
step 10, t = 0.01 == 0, dt 0.001
rom time 0.01
Comparing current run to solution at: nldiff-fom-values-final0.000000 with offline parameter index 0
Relative l2 error of ROM solution 4.239776745386202e-06
L2 norm of exact error: 0.005018583888292249, FEM solution norm 0.0626066279205276, relative norm 0.0801605845097232
Elapsed time for time integration loop 0.008127402000000001
Elapsed time for entire simulation 0.139631309