### PR TITLE
StaticSVD supports for transposed SVD + minor fixes on SVD classes

### DIFF
--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -7,6 +7,7 @@ runs:
           ./tests/test_SVD
           ./tests/test_Vector
           ./tests/test_Matrix
+          mpirun -n 3 ./tests/test_Matrix
           ./tests/test_DEIM
           ./tests/test_GNAT
           ./tests/test_QDEIM

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -19,6 +19,8 @@ runs:
           mpirun -n 3 --oversubscribe tests/test_GreedyCustomSampler
           ./tests/test_RandomizedSVD
           mpirun -n 3 --oversubscribe tests/test_RandomizedSVD
+          ./tests/test_StaticSVD
+          mpirun -n 3 --oversubscribe tests/test_StaticSVD
       shell: bash
 
     - name: Run regression tests

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -7,7 +7,7 @@ runs:
           ./tests/test_SVD
           ./tests/test_Vector
           ./tests/test_Matrix
-          mpirun -n 3 ./tests/test_Matrix
+          mpirun -n 3 --oversubscribe ./tests/test_Matrix
           ./tests/test_DEIM
           ./tests/test_GNAT
           ./tests/test_QDEIM

--- a/README.md
+++ b/README.md
@@ -82,51 +82,7 @@ mpicxx myapp.cpp -I/path/to/libROM/lib -Wl,-rpath,/path/to/libROM/build/lib -L/p
 
 # Using Docker container
 
-Docker container [`librom_env`](https://ghcr.io/LLNL/libROM/librom_env) provides a containerized environment with all the prerequisites for libROM. In order to compile and use libROM in the Docker container, follow these steps:
-
-- Pull `librom_env`, with [Docker Desktop](https://www.docker.com/) installed and running
-```
-docker pull ghcr.io/llnl/librom/librom_env:latest
-```
-- Clone libROM repository
-```
-git clone https://github.com/LLNL/libROM.git
-```
-- Launch the Docker container with the cloned repository
-```
-docker run -it --volume ./libROM:/home/test/libROM dreamer2368/librom_env:latest
-```
-- This will lead to a terminal with the cloned repository mounted at `~/libROM`. Compile libROM with the pre-set environment variables
-```
-mkdir build
-cd build
-cmake ~/libROM -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}
-make -j 4
-```
-
-Some notes about using the Docker container:
-- Any change within the container will not be saved, except those happening in the mounted directory `./libROM`.
-- Any change in `/home/test/libROM` in the container is instantaneously reflected into the actual directory `./libROM`, and vice versa.
-
-## Some details
-
-- Machine architecture: `Linux-x86_64`
-- From: ubuntu:22.04
-- Dependencies:
-  - `cmake-3.22.1`
-  - `hypre-2.20.0`
-  - `parmetis-4.0.3`
-  - `gslib-1.0.7`
-  - `mfem`: latest verified [commit](https://github.com/mfem/mfem/commit/e5231334e6a8175b4f404b877f590b73dee2dedc) on May 02, 2023
-  - `googletest-v1.12.1`: the last release that supports c++11
-- Environmental variables preset for libROM cmake:
-  - `TOOLCHAIN_FILE=/env/dependencies/librom_env.cmake`
-  - `BUILD_TYPE=Optimized`
-  - `USE_MFEM=On`
-  - `MFEM_USE_GSLIB=On`
-- Miscellaneous packages
-  - Debugging tools: `valgrind`, `lldb`, `gdb`
-  - Python packages: `numpy`, `scipy`, `argparse`, `tables`, `PyYAML`, `h5py`, `pybind11`, `pytest`, `mpi4py` 
+Docker container [`librom_env`](https://ghcr.io/llnl/librom/librom_env) provides a containerized environment with all the prerequisites for libROM. For the instruction on how to use it, check out [the wiki page](https://github.com/LLNL/libROM/wiki/Using-Docker-container).
 
 # libROM CI
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mpicxx myapp.cpp -I/path/to/libROM/lib -Wl,-rpath,/path/to/libROM/build/lib -L/p
 
 # Using Docker container
 
-Docker container [`librom_env`](https://ghcr.io/llnl/librom/librom_env) provides a containerized environment with all the prerequisites for libROM. For the instruction on how to use it, check out [the wiki page](https://github.com/LLNL/libROM/wiki/Using-Docker-container).
+Docker container [`librom_env`](https://ghcr.io/llnl/librom/librom_env) provides a containerized environment with all the prerequisites for libROM. For instruction on how to use it, check out [the wiki page](https://github.com/LLNL/libROM/wiki/Using-Docker-container).
 
 # libROM CI
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN sudo apt-get install -yq vim
 RUN sudo apt-get install -yq git-lfs
 RUN sudo apt-get install -yq valgrind
 RUN sudo apt-get install -yq wget
+RUN sudo apt-get install -yq astyle
 
 RUN sudo apt-get clean -q
 

--- a/examples/dmd/heat_conduction_dmdc.cpp
+++ b/examples/dmd/heat_conduction_dmdc.cpp
@@ -94,7 +94,7 @@ using namespace mfem;
  *
  *     du/dt = M^{-1}(b-Ku)
  *
- *  where u is the vector representing the temperature, 
+ *  where u is the vector representing the temperature,
  *  M is the mass matrix, b is the load vector,
  *  and K is the diffusion operator with diffusivity depending on u:
  *  (\kappa + \alpha u).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,7 +53,8 @@ set(module_list
   utils/HDFDatabase
   utils/CSVDatabase
   utils/Utilities
-  utils/ParallelBuffer)
+  utils/ParallelBuffer
+  utils/mpi_utils)
 set(source_files)
 foreach(module IN LISTS module_list)
   list(APPEND source_files ${module}.cpp)

--- a/lib/algo/DMD.cpp
+++ b/lib/algo/DMD.cpp
@@ -548,7 +548,7 @@ DMD::projectInitialCondition(const Vector* init, double t_offset)
     *d_phi_imaginary_squared -= *d_phi_imaginary_squared_2;
 
     double* inverse_input = new double[d_phi_real_squared->numRows() *
-                                       d_phi_real_squared->numColumns() * 2];
+                                                                     d_phi_real_squared->numColumns() * 2];
     for (int i = 0; i < d_phi_real_squared->numRows(); i++)
     {
         int k = 0;

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1037,15 +1037,16 @@ Matrix::distribute(const int &local_num_rows)
     CAROM_VERIFY(d_owns_data);
 
     std::vector<int> row_offsets;
-    int num_total_rows = get_global_offsets(local_num_rows, row_offsets, MPI_COMM_WORLD);
+    int num_total_rows = get_global_offsets(local_num_rows, row_offsets,
+                                            MPI_COMM_WORLD);
     CAROM_VERIFY(num_total_rows == d_num_rows);
     int local_offset = row_offsets[d_rank] * d_num_cols;
     const int new_size = local_num_rows * d_num_cols;
 
     double *d_new_mat = new double [new_size];
-    if (new_size > 0)   
+    if (new_size > 0)
         memcpy(d_new_mat, &d_mat[local_offset], 8 * new_size);
-    
+
     delete [] d_mat;
     d_mat = d_new_mat;
     d_alloc_size = new_size;
@@ -1063,7 +1064,8 @@ Matrix::gather()
     CAROM_VERIFY(d_owns_data);
 
     std::vector<int> row_offsets;
-    const int num_total_rows = get_global_offsets(d_num_rows, row_offsets, MPI_COMM_WORLD);
+    const int num_total_rows = get_global_offsets(d_num_rows, row_offsets,
+                               MPI_COMM_WORLD);
     CAROM_VERIFY(num_total_rows == d_num_distributed_rows);
     const int new_size = d_num_distributed_rows * d_num_cols;
 

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1042,8 +1042,9 @@ Matrix::distribute(const int &local_num_rows)
     int local_offset = row_offsets[d_rank] * d_num_cols;
     const int new_size = local_num_rows * d_num_cols;
 
-    double *d_new_mat = new double [new_size] {0.0};
-    memcpy(d_new_mat, &d_mat[local_offset], 8 * new_size);
+    double *d_new_mat = new double [new_size];
+    if (new_size > 0)   
+        memcpy(d_new_mat, &d_mat[local_offset], 8 * new_size);
     
     delete [] d_mat;
     d_mat = d_new_mat;

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -14,6 +14,7 @@
 
 #include "Matrix.h"
 #include "utils/HDFDatabase.h"
+#include "utils/mpi_utils.h"
 
 #include "mpi.h"
 #include <string.h>
@@ -82,9 +83,11 @@ Matrix::Matrix(
     MPI_Initialized(&mpi_init);
     if (mpi_init) {
         MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+        MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     }
     else {
         d_num_procs = 1;
+        d_rank = 0;
     }
     setSize(num_rows, num_cols);
     if (randomized) {
@@ -116,9 +119,11 @@ Matrix::Matrix(
     MPI_Initialized(&mpi_init);
     if (mpi_init) {
         MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+        MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     }
     else {
         d_num_procs = 1;
+        d_rank = 0;
     }
     if (copy_data) {
         setSize(num_rows, num_cols);
@@ -146,9 +151,11 @@ Matrix::Matrix(
     MPI_Initialized(&mpi_init);
     if (mpi_init) {
         MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+        MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     }
     else {
         d_num_procs = 1;
+        d_rank = 0;
     }
     setSize(other.d_num_rows, other.d_num_cols);
     memcpy(d_mat, other.d_mat, d_alloc_size*sizeof(double));
@@ -1021,6 +1028,66 @@ Matrix::local_read(const std::string& base_file_name, int rank)
     database.getDoubleArray(tmp, d_mat, d_alloc_size);
     d_owns_data = true;
     database.close();
+}
+
+void
+Matrix::distribute(const int &local_num_rows)
+{
+    CAROM_VERIFY(!distributed());
+    CAROM_VERIFY(d_owns_data);
+
+    std::vector<int> row_offsets;
+    int num_total_rows = get_global_offsets(local_num_rows, row_offsets, MPI_COMM_WORLD);
+    CAROM_VERIFY(num_total_rows == d_num_rows);
+    int local_offset = row_offsets[d_rank] * d_num_cols;
+    const int new_size = local_num_rows * d_num_cols;
+
+    double *d_new_mat = new double [new_size] {0.0};
+    memcpy(d_new_mat, &d_mat[local_offset], 8 * new_size);
+    
+    delete [] d_mat;
+    d_mat = d_new_mat;
+    d_alloc_size = new_size;
+
+    d_num_distributed_rows = d_num_rows;
+    d_num_rows = local_num_rows;
+
+    d_distributed = true;
+}
+
+void
+Matrix::gather()
+{
+    CAROM_VERIFY(distributed());
+    CAROM_VERIFY(d_owns_data);
+
+    std::vector<int> row_offsets;
+    int num_total_rows = get_global_offsets(d_num_rows, row_offsets, MPI_COMM_WORLD);
+    CAROM_VERIFY(num_total_rows == d_num_distributed_rows);
+    int local_offset = row_offsets[d_rank] * d_num_cols;
+    const int new_size = d_num_distributed_rows * d_num_cols;
+
+    int *data_offsets = new int[row_offsets.size() - 1];
+    int *data_cnts = new int[row_offsets.size() - 1];
+    for (int k = 0; k < row_offsets.size() - 1; k++)
+    {
+        data_offsets[k] = row_offsets[k] * d_num_cols;
+        data_cnts[k] = d_num_cols * (row_offsets[k+1] - row_offsets[k]);
+    }
+
+    double *d_new_mat = new double [new_size] {0.0};
+    CAROM_VERIFY(MPI_Allgatherv(d_mat, d_alloc_size, MPI_DOUBLE,
+                                d_new_mat, data_cnts, data_offsets, MPI_DOUBLE,
+                                MPI_COMM_WORLD) == MPI_SUCCESS);
+
+    delete [] d_mat;
+    delete [] data_offsets, data_cnts;
+    d_mat = d_new_mat;
+    d_alloc_size = new_size;
+
+    d_num_rows = d_num_distributed_rows;
+
+    d_distributed = false;
 }
 
 void

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1063,7 +1063,7 @@ Matrix::gather()
     CAROM_VERIFY(d_owns_data);
 
     std::vector<int> row_offsets;
-    int num_total_rows = get_global_offsets(d_num_rows, row_offsets, MPI_COMM_WORLD);
+    const int num_total_rows = get_global_offsets(d_num_rows, row_offsets, MPI_COMM_WORLD);
     CAROM_VERIFY(num_total_rows == d_num_distributed_rows);
     const int new_size = d_num_distributed_rows * d_num_cols;
 
@@ -1072,7 +1072,7 @@ Matrix::gather()
     for (int k = 0; k < row_offsets.size() - 1; k++)
     {
         data_offsets[k] = row_offsets[k] * d_num_cols;
-        data_cnts[k] = d_num_rows * d_num_cols;
+        data_cnts[k] = (row_offsets[k+1] - row_offsets[k]) * d_num_cols;
     }
 
     double *d_new_mat = new double [new_size] {0.0};

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1065,7 +1065,6 @@ Matrix::gather()
     std::vector<int> row_offsets;
     int num_total_rows = get_global_offsets(d_num_rows, row_offsets, MPI_COMM_WORLD);
     CAROM_VERIFY(num_total_rows == d_num_distributed_rows);
-    int local_offset = row_offsets[d_rank] * d_num_cols;
     const int new_size = d_num_distributed_rows * d_num_cols;
 
     int *data_offsets = new int[row_offsets.size() - 1];
@@ -1073,7 +1072,7 @@ Matrix::gather()
     for (int k = 0; k < row_offsets.size() - 1; k++)
     {
         data_offsets[k] = row_offsets[k] * d_num_cols;
-        data_cnts[k] = d_num_cols * (row_offsets[k+1] - row_offsets[k]);
+        data_cnts[k] = d_num_rows * d_num_cols;
     }
 
     double *d_new_mat = new double [new_size] {0.0};

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -1063,6 +1063,27 @@ public:
         return d_mat;
     }
 
+    /**
+     * @brief Distribute this matrix rows among MPI processes,
+     * based on the specified local number of rows.
+     * This becomes distributed after this function is executed.
+     * 
+     * @pre !distributed()
+     * @pre d_owns_data
+     * 
+     * @param[in] local_num_rows number of rows for local MPI rank.
+     */
+    void distribute(const int &local_num_rows);
+
+    /**
+     * @brief Gather all the distributed rows among MPI processes.
+     * This becomes not distributed after this function is executed.
+     * 
+     * @pre distributed()
+     * @pre d_owns_data
+     */
+    void gather();
+
 private:
     /**
      * @brief Compute number of rows across all processors.
@@ -1214,6 +1235,11 @@ private:
      * @brief The number of processors being run on.
      */
     int d_num_procs;
+
+    /**
+     * @brief The current MPI rank. If MPI is not initialized, equal to 0.
+     */
+    int d_rank;
 
     /**
      * @brief If true, this object owns its underlying data, d_mat, and

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -1067,10 +1067,10 @@ public:
      * @brief Distribute this matrix rows among MPI processes,
      * based on the specified local number of rows.
      * This becomes distributed after this function is executed.
-     * 
+     *
      * @pre !distributed()
      * @pre d_owns_data
-     * 
+     *
      * @param[in] local_num_rows number of rows for local MPI rank.
      */
     void distribute(const int &local_num_rows);
@@ -1078,7 +1078,7 @@ public:
     /**
      * @brief Gather all the distributed rows among MPI processes.
      * This becomes not distributed after this function is executed.
-     * 
+     *
      * @pre distributed()
      * @pre d_owns_data
      */

--- a/lib/linalg/svd/RandomizedSVD.cpp
+++ b/lib/linalg/svd/RandomizedSVD.cpp
@@ -61,10 +61,9 @@ RandomizedSVD::computeSVD()
         }
     }
     else {
-        int num_transposed_rows;
         std::vector<int> snapshot_transpose_row_offset;
-        num_transposed_rows = split_dimension(num_cols, MPI_COMM_WORLD);
-        int num_cols_check = get_global_offsets(num_transposed_rows,
+        const int num_transposed_rows = split_dimension(num_cols, MPI_COMM_WORLD);
+        const int num_cols_check = get_global_offsets(num_transposed_rows,
                                                 snapshot_transpose_row_offset,
                                                 MPI_COMM_WORLD);
         CAROM_VERIFY(num_cols == num_cols_check);

--- a/lib/linalg/svd/RandomizedSVD.cpp
+++ b/lib/linalg/svd/RandomizedSVD.cpp
@@ -39,8 +39,8 @@ RandomizedSVD::computeSVD()
     d_samples->n = d_num_samples;
     delete_factorizer();
 
-    int num_rows = d_total_dim;
-    int num_cols = d_num_samples;
+    const int num_rows = d_total_dim;
+    const int num_cols = d_num_samples;
     if (d_subspace_dim < 1 || d_subspace_dim > std::min(num_rows, num_cols)) {
         d_subspace_dim = std::min(num_rows, num_cols);
     }
@@ -184,6 +184,14 @@ RandomizedSVD::computeSVD()
         Matrix* temp = d_basis;
         d_basis = d_basis_right;
         d_basis_right = temp;
+
+        int local_rows = -1;
+        if (d_basis->numRows() == d_total_dim)
+            local_rows = d_dim;
+        else
+            local_rows = split_dimension(d_basis->numRows());
+        d_basis->distribute(local_rows);
+        d_basis_right->gather();
     }
 
     d_this_interval_basis_current = true;

--- a/lib/linalg/svd/RandomizedSVD.cpp
+++ b/lib/linalg/svd/RandomizedSVD.cpp
@@ -188,8 +188,11 @@ RandomizedSVD::computeSVD()
         int local_rows = -1;
         if (d_basis->numRows() == d_total_dim)
             local_rows = d_dim;
-        else
+        else {
+            printf("WARNING: RandomizedSVD::d_basis has a subspace dimension %d, different from sample dimension %d\n",
+                   d_basis->numRows(), num_rows);
             local_rows = split_dimension(d_basis->numRows());
+        }
         d_basis->distribute(local_rows);
         d_basis_right->gather();
     }

--- a/lib/linalg/svd/RandomizedSVD.cpp
+++ b/lib/linalg/svd/RandomizedSVD.cpp
@@ -64,8 +64,8 @@ RandomizedSVD::computeSVD()
         std::vector<int> snapshot_transpose_row_offset;
         const int num_transposed_rows = split_dimension(num_cols, MPI_COMM_WORLD);
         const int num_cols_check = get_global_offsets(num_transposed_rows,
-                                                snapshot_transpose_row_offset,
-                                                MPI_COMM_WORLD);
+                                   snapshot_transpose_row_offset,
+                                   MPI_COMM_WORLD);
         CAROM_VERIFY(num_cols == num_cols_check);
 
         snapshot_matrix = new Matrix(num_transposed_rows,

--- a/lib/linalg/svd/RandomizedSVD.h
+++ b/lib/linalg/svd/RandomizedSVD.h
@@ -71,6 +71,13 @@ private:
     computeSVD();
 
     /**
+     * @brief Split a dimension into the number of processes.
+     *        Process-specific dimension is stored in local_dim.
+     *        int[d_num_procs+1] offsets stores the integer offsets.
+     */
+    void split_dimension(const int &dim, int &local_dim, std::vector<int> &offsets);
+
+    /**
      * @brief The number of dimensions of the randomized subspace the
      * snapshot matrix will be projected to.
      */

--- a/lib/linalg/svd/RandomizedSVD.h
+++ b/lib/linalg/svd/RandomizedSVD.h
@@ -26,7 +26,7 @@ namespace CAROM {
 
 /**
  * Class RandomizedSVD implements the Randomized SVD algorithm introduced in
- *    Halko, Nathan, Per-Gunnar Martinsson, and Joel A. Tropp.
+ *    Nathan Halko, Per-Gunnar Martinsson, and Joel A. Tropp.
  *    "Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions."
  *    SIAM review 53.2 (2011): 217-288.
  */

--- a/lib/linalg/svd/RandomizedSVD.h
+++ b/lib/linalg/svd/RandomizedSVD.h
@@ -71,13 +71,6 @@ private:
     computeSVD();
 
     /**
-     * @brief Split a dimension into the number of processes.
-     *        Process-specific dimension is stored in local_dim.
-     *        int[d_num_procs+1] offsets stores the integer offsets.
-     */
-    void split_dimension(const int &dim, int &local_dim, std::vector<int> &offsets);
-
-    /**
      * @brief The number of dimensions of the randomized subspace the
      * snapshot matrix will be projected to.
      */

--- a/lib/linalg/svd/RandomizedSVD.h
+++ b/lib/linalg/svd/RandomizedSVD.h
@@ -26,9 +26,9 @@ namespace CAROM {
 
 /**
  * Class RandomizedSVD implements the Randomized SVD algorithm introduced in
- *    "Finding Structure with Randomness: Probabilistic Algorithms for
- *    Constructing Approximate Matrix Decompositions" by N. Halko, P. G.
- *    Martinsson, and J. A. Tropp
+ *    Halko, Nathan, Per-Gunnar Martinsson, and Joel A. Tropp.
+ *    "Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions."
+ *    SIAM review 53.2 (2011): 217-288.
  */
 class RandomizedSVD : public StaticSVD
 {

--- a/lib/linalg/svd/StaticSVD.cpp
+++ b/lib/linalg/svd/StaticSVD.cpp
@@ -272,15 +272,16 @@ StaticSVD::computeSVD()
         }
 
         initialize_matrix(snapshot_matrix, d_num_samples, d_total_dim,
-                      d_nprow, d_npcol, d_blocksize_tr, d_blocksize_tr);
+                          d_nprow, d_npcol, d_blocksize_tr, d_blocksize_tr);
 
         for (int rank = 0; rank < d_num_procs; ++rank) {
-            transpose_submatrix(snapshot_matrix, 1, d_istarts[static_cast<unsigned>(rank)]+1,
+            transpose_submatrix(snapshot_matrix, 1,
+                                d_istarts[static_cast<unsigned>(rank)]+1,
                                 d_samples.get(), d_istarts[static_cast<unsigned>(rank)]+1, 1,
                                 d_dims[static_cast<unsigned>(rank)], d_num_samples);
         }
     }
-    else{
+    else {
         // use d_samples if sample size <= dimension.
         snapshot_matrix = d_samples.get();
     }
@@ -324,14 +325,14 @@ StaticSVD::computeSVD()
         if (transpose) {
             // V is computed in the transposed order so no reordering necessary.
             gather_block(&d_basis->item(0, 0), d_factorizer->V,
-                        1, d_istarts[static_cast<unsigned>(rank)]+1,
-                        ncolumns, d_dims[static_cast<unsigned>(rank)], rank);
+                         1, d_istarts[static_cast<unsigned>(rank)]+1,
+                         ncolumns, d_dims[static_cast<unsigned>(rank)], rank);
 
             // gather_transposed_block does the same as gather_block, but transposes
             // it; here, it is used to go from column-major to row-major order.
             gather_transposed_block(&d_basis_right->item(0, 0), d_factorizer->U,
                                     1, 1, d_num_samples, ncolumns, rank);
-            
+
         }
         else {
             // gather_transposed_block does the same as gather_block, but transposes
@@ -342,7 +343,7 @@ StaticSVD::computeSVD()
                                     ncolumns, rank);
             // V is computed in the transposed order so no reordering necessary.
             gather_block(&d_basis_right->item(0, 0), d_factorizer->V, 1, 1,
-                        ncolumns, d_num_samples, rank);
+                         ncolumns, d_num_samples, rank);
         }
     }
     for (int i = 0; i < ncolumns; ++i)

--- a/lib/linalg/svd/StaticSVD.cpp
+++ b/lib/linalg/svd/StaticSVD.cpp
@@ -253,10 +253,41 @@ StaticSVD::getSnapshotMatrix()
 void
 StaticSVD::computeSVD()
 {
-    // This block does the actual ScaLAPACK call to do the factorization.
+    // pointer for snapshot matrix or its transpose.
+    SLPK_Matrix *snapshot_matrix = NULL;
+
+    // Finalizes the column size of d_samples.
     d_samples->n = d_num_samples;
+
+    // transpose matrix if sample size > dimension.
+    bool transpose = d_total_dim < d_num_samples;
+
+    if (transpose) {
+        // create a transposed matrix if sample size > dimension.
+        snapshot_matrix = new SLPK_Matrix;
+
+        int d_blocksize_tr = d_num_samples / d_nprow;
+        if (d_num_samples % d_nprow != 0) {
+            d_blocksize_tr += 1;
+        }
+
+        initialize_matrix(snapshot_matrix, d_num_samples, d_total_dim,
+                      d_nprow, d_npcol, d_blocksize_tr, d_blocksize_tr);
+
+        for (int rank = 0; rank < d_num_procs; ++rank) {
+            transpose_submatrix(snapshot_matrix, 1, d_istarts[static_cast<unsigned>(rank)]+1,
+                                d_samples.get(), d_istarts[static_cast<unsigned>(rank)]+1, 1,
+                                d_dims[static_cast<unsigned>(rank)], d_num_samples);
+        }
+    }
+    else{
+        // use d_samples if sample size <= dimension.
+        snapshot_matrix = d_samples.get();
+    }
+
+    // This block does the actual ScaLAPACK call to do the factorization.
     delete_factorizer();
-    svd_init(d_factorizer.get(), d_samples.get());
+    svd_init(d_factorizer.get(), snapshot_matrix);
     d_factorizer->dov = 1;
     factorize(d_factorizer.get());
 
@@ -280,7 +311,6 @@ StaticSVD::computeSVD()
     CAROM_VERIFY(ncolumns >= 0);
 
     // Allocate the appropriate matrices and gather their elements.
-    d_basis = new Matrix(d_dim, ncolumns, true);
     d_S = new Vector(ncolumns, false);
     {
         CAROM_VERIFY(ncolumns >= 0);
@@ -288,17 +318,32 @@ StaticSVD::computeSVD()
         memset(&d_S->item(0), 0, nc*sizeof(double));
     }
 
-    d_basis_right = new Matrix(ncolumns, d_num_samples, false);
+    d_basis = new Matrix(d_dim, ncolumns, true);
+    d_basis_right = new Matrix(d_num_samples, ncolumns, false);
     for (int rank = 0; rank < d_num_procs; ++rank) {
-        // gather_transposed_block does the same as gather_block, but transposes
-        // it; here, it is used to go from column-major to row-major order.
-        gather_transposed_block(&d_basis->item(0, 0), d_factorizer->U,
-                                d_istarts[static_cast<unsigned>(rank)]+1,
-                                1, d_dims[static_cast<unsigned>(rank)],
-                                ncolumns, rank);
-        // V is computed in the transposed order so no reordering necessary.
-        gather_block(&d_basis_right->item(0, 0), d_factorizer->V, 1, 1,
-                     ncolumns, d_num_samples, rank);
+        if (transpose) {
+            // V is computed in the transposed order so no reordering necessary.
+            gather_block(&d_basis->item(0, 0), d_factorizer->V,
+                        1, d_istarts[static_cast<unsigned>(rank)]+1,
+                        ncolumns, d_dims[static_cast<unsigned>(rank)], rank);
+
+            // gather_transposed_block does the same as gather_block, but transposes
+            // it; here, it is used to go from column-major to row-major order.
+            gather_transposed_block(&d_basis_right->item(0, 0), d_factorizer->U,
+                                    1, 1, d_num_samples, ncolumns, rank);
+            
+        }
+        else {
+            // gather_transposed_block does the same as gather_block, but transposes
+            // it; here, it is used to go from column-major to row-major order.
+            gather_transposed_block(&d_basis->item(0, 0), d_factorizer->U,
+                                    d_istarts[static_cast<unsigned>(rank)]+1,
+                                    1, d_dims[static_cast<unsigned>(rank)],
+                                    ncolumns, rank);
+            // V is computed in the transposed order so no reordering necessary.
+            gather_block(&d_basis_right->item(0, 0), d_factorizer->V, 1, 1,
+                        ncolumns, d_num_samples, rank);
+        }
     }
     for (int i = 0; i < ncolumns; ++i)
         d_S->item(i) = d_factorizer->S[static_cast<unsigned>(i)];
@@ -323,6 +368,12 @@ StaticSVD::computeSVD()
                 printf("%8.4E  ", d_factorizer->S[i]);
             printf("\n");
         }
+    }
+
+    if (transpose) {
+        // Delete the transposed snapshot matrix.
+        free_matrix_data(snapshot_matrix);
+        delete snapshot_matrix;
     }
 }
 

--- a/lib/utils/mpi_utils.cpp
+++ b/lib/utils/mpi_utils.cpp
@@ -38,7 +38,8 @@ split_dimension(const int dim, const MPI_Comm &comm)
 }
 
 int
-get_global_offsets(const int local_dim, std::vector<int> &offsets, const MPI_Comm &comm)
+get_global_offsets(const int local_dim, std::vector<int> &offsets,
+                   const MPI_Comm &comm)
 {
     int mpi_init;
     MPI_Initialized(&mpi_init);

--- a/lib/utils/mpi_utils.cpp
+++ b/lib/utils/mpi_utils.cpp
@@ -20,7 +20,7 @@
 namespace CAROM {
 
 int
-split_dimension(const int &dim, const MPI_Comm &comm)
+split_dimension(const int dim, const MPI_Comm &comm)
 {
     int mpi_init;
     MPI_Initialized(&mpi_init);
@@ -38,7 +38,7 @@ split_dimension(const int &dim, const MPI_Comm &comm)
 }
 
 int
-get_global_offsets(const int &local_dim, std::vector<int> &offsets, const MPI_Comm &comm)
+get_global_offsets(const int local_dim, std::vector<int> &offsets, const MPI_Comm &comm)
 {
     int mpi_init;
     MPI_Initialized(&mpi_init);

--- a/lib/utils/mpi_utils.cpp
+++ b/lib/utils/mpi_utils.cpp
@@ -48,20 +48,17 @@ get_global_offsets(const int local_dim, std::vector<int> &offsets, const MPI_Com
     MPI_Comm_rank(comm, &d_rank);
     MPI_Comm_size(comm, &d_num_procs);
 
-    int dim = local_dim;
-    CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
-                                &dim,
-                                1,
-                                MPI_INT,
-                                MPI_SUM,
-                                comm) == MPI_SUCCESS);
-
     offsets.resize(d_num_procs + 1);
-    offsets[d_num_procs] = dim;
     offsets[d_rank] = local_dim;
     CAROM_VERIFY(MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT,
                                &offsets[0], 1, MPI_INT,
                                comm) == MPI_SUCCESS);
+
+    int dim = 0;
+    for (int i = 0; i < d_num_procs; i++)
+        dim += offsets[i];
+    offsets[d_num_procs] = dim;
+
     for (int i = d_num_procs - 1; i >= 0; i--)
         offsets[i] = offsets[i + 1] - offsets[i];
 

--- a/lib/utils/mpi_utils.cpp
+++ b/lib/utils/mpi_utils.cpp
@@ -1,0 +1,73 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2023, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
+// Description: Utility functions for MPI distribution.
+
+#include "mpi_utils.h"
+#include "Utilities.h"
+
+#include <iomanip>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+namespace CAROM {
+
+int
+split_dimension(const int &dim, const MPI_Comm &comm)
+{
+    int mpi_init;
+    MPI_Initialized(&mpi_init);
+    CAROM_VERIFY(mpi_init != 0);
+
+    int d_num_procs, d_rank;
+    MPI_Comm_rank(comm, &d_rank);
+    MPI_Comm_size(comm, &d_num_procs);
+
+    int local_dim = dim / d_num_procs;
+    if (dim % d_num_procs > d_rank)
+        local_dim++;
+
+    return local_dim;
+}
+
+int
+get_global_offsets(const int &local_dim, std::vector<int> &offsets, const MPI_Comm &comm)
+{
+    int mpi_init;
+    MPI_Initialized(&mpi_init);
+    CAROM_VERIFY(mpi_init != 0);
+
+    int d_num_procs, d_rank;
+    MPI_Comm_rank(comm, &d_rank);
+    MPI_Comm_size(comm, &d_num_procs);
+
+    int dim = local_dim;
+    CAROM_VERIFY(MPI_Allreduce(MPI_IN_PLACE,
+                                &dim,
+                                1,
+                                MPI_INT,
+                                MPI_SUM,
+                                comm) == MPI_SUCCESS);
+
+    offsets.resize(d_num_procs + 1);
+    offsets[d_num_procs] = dim;
+    offsets[d_rank] = local_dim;
+    CAROM_VERIFY(MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT,
+                               &offsets[0], 1, MPI_INT,
+                               comm) == MPI_SUCCESS);
+    for (int i = d_num_procs - 1; i >= 0; i--)
+        offsets[i] = offsets[i + 1] - offsets[i];
+
+    CAROM_VERIFY(offsets[0] == 0);
+
+    return dim;
+}
+
+}

--- a/lib/utils/mpi_utils.h
+++ b/lib/utils/mpi_utils.h
@@ -1,0 +1,47 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2013-2023, Lawrence Livermore National Security, LLC
+ * and other libROM project developers. See the top-level COPYRIGHT
+ * file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *
+ *****************************************************************************/
+
+// Description: Utility functions for MPI distribution.
+
+#ifndef included_mpi_utils_h
+#define included_mpi_utils_h
+
+#include "CAROM_config.h"
+#include "mpi.h"
+#include <vector>
+
+namespace CAROM {
+
+/**
+ * @brief Distribute the global size dim into MPI processes as equally as possible.
+ * 
+ * @param[in] dim          Input global size.
+ * @param[in] comm         MPI communicator. == MPI_COMM_WORLD by default.
+ * @param[out] local_dim   Local size assigned to the current MPI process.
+ */
+int
+split_dimension(const int &dim, const MPI_Comm &comm=MPI_COMM_WORLD);
+
+/**
+ * @brief Save integer offsets for each MPI rank under MPI communicator comm,
+ *        where each rank as the size of local_dim.
+ *        the sum of local_dim over all MPI processes is returned as the total dimension.
+ * 
+ * @param[in] local_dim     Local dimension for each MPI rank
+ * @param[in] offsets       Global integer offsets split by local_dim
+ * @param[in] comm          MPI communicator. == MPI_COMM_WORLD by default.
+ * @param[out] dim          Global dimension as the sum of all local_dim.
+ */
+int
+get_global_offsets(const int &local_dim, std::vector<int> &offsets, const MPI_Comm &comm=MPI_COMM_WORLD);
+
+}
+
+#endif

--- a/lib/utils/mpi_utils.h
+++ b/lib/utils/mpi_utils.h
@@ -24,7 +24,7 @@ namespace CAROM {
  * 
  * @param[in] dim          Input global size.
  * @param[in] comm         MPI communicator. default value MPI_COMM_WORLD.
- * @param[out] local_dim   Local size assigned to the current MPI process.
+ * @param[out] local_dim   (Returned value) Local size assigned to the current MPI process.
  */
 int
 split_dimension(const int dim, const MPI_Comm &comm=MPI_COMM_WORLD);
@@ -35,9 +35,9 @@ split_dimension(const int dim, const MPI_Comm &comm=MPI_COMM_WORLD);
  *        the sum of local_dim over all MPI processes is returned as the total dimension.
  * 
  * @param[in] local_dim     Input local dimension specified for each MPI rank.
- * @param[in] offsets       Resulting global integer offsets split by local_dim.
+ * @param[out] offsets      Resulting global integer offsets split by local_dim.
  * @param[in] comm          MPI communicator. default value MPI_COMM_WORLD.
- * @param[out] dim          Global dimension as the sum of all local_dim.
+ * @param[out] dim          (Returned value) Global dimension as the sum of all local_dim.
  */
 int
 get_global_offsets(const int local_dim, std::vector<int> &offsets, const MPI_Comm &comm=MPI_COMM_WORLD);

--- a/lib/utils/mpi_utils.h
+++ b/lib/utils/mpi_utils.h
@@ -23,24 +23,24 @@ namespace CAROM {
  * @brief Distribute the global size dim into MPI processes as equally as possible.
  * 
  * @param[in] dim          Input global size.
- * @param[in] comm         MPI communicator. == MPI_COMM_WORLD by default.
+ * @param[in] comm         MPI communicator. default value MPI_COMM_WORLD.
  * @param[out] local_dim   Local size assigned to the current MPI process.
  */
 int
-split_dimension(const int &dim, const MPI_Comm &comm=MPI_COMM_WORLD);
+split_dimension(const int dim, const MPI_Comm &comm=MPI_COMM_WORLD);
 
 /**
  * @brief Save integer offsets for each MPI rank under MPI communicator comm,
  *        where each rank as the size of local_dim.
  *        the sum of local_dim over all MPI processes is returned as the total dimension.
  * 
- * @param[in] local_dim     Local dimension for each MPI rank
- * @param[in] offsets       Global integer offsets split by local_dim
- * @param[in] comm          MPI communicator. == MPI_COMM_WORLD by default.
+ * @param[in] local_dim     Input local dimension specified for each MPI rank.
+ * @param[in] offsets       Resulting global integer offsets split by local_dim.
+ * @param[in] comm          MPI communicator. default value MPI_COMM_WORLD.
  * @param[out] dim          Global dimension as the sum of all local_dim.
  */
 int
-get_global_offsets(const int &local_dim, std::vector<int> &offsets, const MPI_Comm &comm=MPI_COMM_WORLD);
+get_global_offsets(const int local_dim, std::vector<int> &offsets, const MPI_Comm &comm=MPI_COMM_WORLD);
 
 }
 

--- a/lib/utils/mpi_utils.h
+++ b/lib/utils/mpi_utils.h
@@ -21,7 +21,7 @@ namespace CAROM {
 
 /**
  * @brief Distribute the global size dim into MPI processes as equally as possible.
- * 
+ *
  * @param[in] dim          Input global size.
  * @param[in] comm         MPI communicator. default value MPI_COMM_WORLD.
  * @param[out] local_dim   (Returned value) Local size assigned to the current MPI process.
@@ -33,14 +33,15 @@ split_dimension(const int dim, const MPI_Comm &comm=MPI_COMM_WORLD);
  * @brief Save integer offsets for each MPI rank under MPI communicator comm,
  *        where each rank as the size of local_dim.
  *        the sum of local_dim over all MPI processes is returned as the total dimension.
- * 
+ *
  * @param[in] local_dim     Input local dimension specified for each MPI rank.
  * @param[out] offsets      Resulting global integer offsets split by local_dim.
  * @param[in] comm          MPI communicator. default value MPI_COMM_WORLD.
  * @param[out] dim          (Returned value) Global dimension as the sum of all local_dim.
  */
 int
-get_global_offsets(const int local_dim, std::vector<int> &offsets, const MPI_Comm &comm=MPI_COMM_WORLD);
+get_global_offsets(const int local_dim, std::vector<int> &offsets,
+                   const MPI_Comm &comm=MPI_COMM_WORLD);
 
 }
 

--- a/unit_tests/test_RandomizedSVD.cpp
+++ b/unit_tests/test_RandomizedSVD.cpp
@@ -42,7 +42,7 @@ TEST(RandomizedSVDTest, Test_RandomizedSVD)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 5;
+    constexpr int num_total_rows = 5;
     int d_num_rows = num_total_rows / d_num_procs;
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
@@ -135,8 +135,8 @@ TEST(RandomizedSVDTest, Test_RandomizedSVDTransposed)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 3;
-    int num_samples = 5;
+    constexpr int num_total_rows = 3;
+    constexpr int num_samples = 5;
     int d_num_rows = num_total_rows / d_num_procs;
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
@@ -232,7 +232,7 @@ TEST(RandomizedSVDTest, Test_RandomizedSVDSmallerSubspace)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 5;
+    constexpr int num_total_rows = 5;
     int d_num_rows = num_total_rows / d_num_procs;
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
@@ -323,9 +323,9 @@ TEST(RandomizedSVDTest, Test_RandomizedSVDTransposedSmallerSubspace)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 3;
-    int num_samples = 5;
-    int reduced_rows = 2;
+    constexpr int num_total_rows = 3;
+    constexpr int num_samples = 5;
+    constexpr int reduced_rows = 2;
     int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
     std::vector<int> row_offset;
     int dummy = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);

--- a/unit_tests/test_RandomizedSVD.cpp
+++ b/unit_tests/test_RandomizedSVD.cpp
@@ -328,7 +328,7 @@ TEST(RandomizedSVDTest, Test_RandomizedSVDTransposedSmallerSubspace)
     constexpr int reduced_rows = 2;
     int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
     std::vector<int> row_offset;
-    int dummy = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
+    CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
 
     double* sample1 = new double[5] {0.5377, -1.3077, -1.3499};
     double* sample2 = new double[5] {1.8339, -0.4336, 3.0349};

--- a/unit_tests/test_RandomizedSVD.cpp
+++ b/unit_tests/test_RandomizedSVD.cpp
@@ -43,25 +43,9 @@ TEST(RandomizedSVDTest, Test_RandomizedSVD)
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
     constexpr int num_total_rows = 5;
-    int d_num_rows = num_total_rows / d_num_procs;
-    if (num_total_rows % d_num_procs > d_rank) {
-        d_num_rows++;
-    }
-    int *row_offset = new int[d_num_procs + 1];
-    row_offset[d_num_procs] = num_total_rows;
-    row_offset[d_rank] = d_num_rows;
-
-    MPI_Allgather(MPI_IN_PLACE,
-                  1,
-                  MPI_INT,
-                  row_offset,
-                  1,
-                  MPI_INT,
-                  MPI_COMM_WORLD);
-
-    for (int i = d_num_procs - 1; i >= 0; i--) {
-        row_offset[i] = row_offset[i + 1] - row_offset[i];
-    }
+    int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
+    std::vector<int> row_offset;
+    CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
 
     double* sample1 = new double[5] {0.5377, 1.8339, -2.2588, 0.8622, 0.3188};
     double* sample2 = new double[5] {-1.3077, -0.4336, 0.3426, 3.5784, 2.7694};
@@ -137,25 +121,9 @@ TEST(RandomizedSVDTest, Test_RandomizedSVDTransposed)
 
     constexpr int num_total_rows = 3;
     constexpr int num_samples = 5;
-    int d_num_rows = num_total_rows / d_num_procs;
-    if (num_total_rows % d_num_procs > d_rank) {
-        d_num_rows++;
-    }
-    int *row_offset = new int[d_num_procs + 1];
-    row_offset[d_num_procs] = num_total_rows;
-    row_offset[d_rank] = d_num_rows;
-
-    MPI_Allgather(MPI_IN_PLACE,
-                  1,
-                  MPI_INT,
-                  row_offset,
-                  1,
-                  MPI_INT,
-                  MPI_COMM_WORLD);
-
-    for (int i = d_num_procs - 1; i >= 0; i--) {
-        row_offset[i] = row_offset[i + 1] - row_offset[i];
-    }
+    int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
+    std::vector<int> row_offset;
+    CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
 
     double* sample1 = new double[3] {0.5377, -1.3077, -1.3499};
     double* sample2 = new double[3] {1.8339, -0.4336, 3.0349};
@@ -233,25 +201,9 @@ TEST(RandomizedSVDTest, Test_RandomizedSVDSmallerSubspace)
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
     constexpr int num_total_rows = 5;
-    int d_num_rows = num_total_rows / d_num_procs;
-    if (num_total_rows % d_num_procs > d_rank) {
-        d_num_rows++;
-    }
-    int *row_offset = new int[d_num_procs + 1];
-    row_offset[d_num_procs] = num_total_rows;
-    row_offset[d_rank] = d_num_rows;
-
-    MPI_Allgather(MPI_IN_PLACE,
-                  1,
-                  MPI_INT,
-                  row_offset,
-                  1,
-                  MPI_INT,
-                  MPI_COMM_WORLD);
-
-    for (int i = d_num_procs - 1; i >= 0; i--) {
-        row_offset[i] = row_offset[i + 1] - row_offset[i];
-    }
+    int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
+    std::vector<int> row_offset;
+    CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
 
     double* sample1 = new double[5] {0.5377, 1.8339, -2.2588, 0.8622, 0.3188};
     double* sample2 = new double[5] {-1.3077, -0.4336, 0.3426, 3.5784, 2.7694};

--- a/unit_tests/test_StaticSVD.cpp
+++ b/unit_tests/test_StaticSVD.cpp
@@ -123,8 +123,8 @@ TEST(StaticSVDTest, Test_SLPKTranspose)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 3;
-    int num_total_cols = 5;
+    constexpr int num_total_rows = 3;
+    constexpr int num_total_cols = 5;
     int d_num_rows = num_total_rows / d_num_procs;
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
@@ -204,10 +204,7 @@ TEST(StaticSVDTest, Test_SLPKTranspose)
         }
     }
     printf("original\n");
-    MPI_Barrier(MPI_COMM_WORLD);
     print_debug_info(d_samples);
-
-    MPI_Barrier(MPI_COMM_WORLD);
 
     int d_blocksize_tr = num_total_cols / d_nprow;
     if (num_total_cols % d_nprow != 0) {
@@ -225,7 +222,6 @@ TEST(StaticSVDTest, Test_SLPKTranspose)
     }
 
     printf("transposed\n");
-    MPI_Barrier(MPI_COMM_WORLD);
 
     print_debug_info(transpose);
 
@@ -235,9 +231,7 @@ TEST(StaticSVDTest, Test_SLPKTranspose)
     factorize(d_factorizer);
 
     print_debug_info(d_factorizer->U);
-    MPI_Barrier(MPI_COMM_WORLD);
     print_debug_info(d_factorizer->V);
-    MPI_Barrier(MPI_COMM_WORLD);
 
     int ncolumns = num_total_rows;
     CAROM::Matrix *d_basis = new CAROM::Matrix(d_dims[d_rank], ncolumns, true);
@@ -258,7 +252,6 @@ TEST(StaticSVDTest, Test_SLPKTranspose)
     free_matrix_data(d_samples);
     free_matrix_data(transpose);
     delete d_samples, transpose;
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 TEST(StaticSVDTest, Test_StaticSVDClass)
@@ -273,7 +266,7 @@ TEST(StaticSVDTest, Test_StaticSVDClass)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 5;
+    constexpr int num_total_rows = 5;
     int d_num_rows = num_total_rows / d_num_procs;
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
@@ -329,23 +322,6 @@ TEST(StaticSVDTest, Test_StaticSVDClass)
     const CAROM::Matrix* d_basis_right = sampler.getTemporalBasis();
     const CAROM::Vector* sv = sampler.getSingularValues();
 
-// printf("basis: (%dx%d)\n", d_basis->numRows(), d_basis->numColumns());
-// for (int i = 0; i < d_basis->numRows(); i++)
-// {
-//     for (int j = 0; j < d_basis->numColumns(); j++)
-//         printf("%.3E\t", d_basis->item(i,j));
-//     printf("\n");
-// }
-// printf("\n");
-// printf("basis_right: (%dx%d)\n", d_basis_right->numRows(), d_basis_right->numColumns());
-// for (int i = 0; i < d_basis_right->numRows(); i++)
-// {
-//     for (int j = 0; j < d_basis_right->numColumns(); j++)
-//         printf("%.3E\t", d_basis_right->item(i,j));
-//     printf("\n");
-// }
-// printf("\n");
-
     EXPECT_EQ(d_basis->numRows(), d_num_rows);
     EXPECT_EQ(d_basis->numColumns(), 3);
     EXPECT_EQ(d_basis_right->numRows(), 3);
@@ -381,8 +357,8 @@ TEST(StaticSVDTest, Test_StaticSVDTranspose)
     MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
-    int num_total_rows = 3;
-    int num_total_cols = 5;
+    constexpr int num_total_rows = 3;
+    constexpr int num_total_cols = 5;
     int d_num_rows = num_total_rows / d_num_procs;
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
@@ -441,23 +417,6 @@ TEST(StaticSVDTest, Test_StaticSVDTranspose)
     const CAROM::Matrix* d_basis = sampler.getSpatialBasis();
     const CAROM::Matrix* d_basis_right = sampler.getTemporalBasis();
     const CAROM::Vector* sv = sampler.getSingularValues();
-
-// printf("basis: (%dx%d)\n", d_basis->numRows(), d_basis->numColumns());
-// for (int i = 0; i < d_basis->numRows(); i++)
-// {
-//     for (int j = 0; j < d_basis->numColumns(); j++)
-//         printf("%.3E\t", d_basis->item(i,j));
-//     printf("\n");
-// }
-// printf("\n");
-// printf("basis_right: (%dx%d)\n", d_basis_right->numRows(), d_basis_right->numColumns());
-// for (int i = 0; i < d_basis_right->numRows(); i++)
-// {
-//     for (int j = 0; j < d_basis_right->numColumns(); j++)
-//         printf("%.3E\t", d_basis_right->item(i,j));
-//     printf("\n");
-// }
-// printf("\n");
 
     EXPECT_EQ(d_basis_right->numRows(), num_total_cols);
     EXPECT_EQ(d_basis_right->numColumns(), 3);

--- a/unit_tests/test_StaticSVD.cpp
+++ b/unit_tests/test_StaticSVD.cpp
@@ -126,10 +126,7 @@ TEST(StaticSVDTest, Test_SLPKTranspose)
 
     constexpr int num_total_rows = 3;
     constexpr int num_total_cols = 5;
-    int d_num_rows = num_total_rows / d_num_procs;
-    if (num_total_rows % d_num_procs > d_rank) {
-        d_num_rows++;
-    }
+    int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
     std::vector<int> row_offset(d_num_procs + 1);
     const int total_rows = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
     EXPECT_EQ(total_rows, num_total_rows);
@@ -256,10 +253,7 @@ TEST(StaticSVDTest, Test_StaticSVDClass)
     MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
 
     constexpr int num_total_rows = 5;
-    int d_num_rows = num_total_rows / d_num_procs;
-    if (num_total_rows % d_num_procs > d_rank) {
-        d_num_rows++;
-    }
+    int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
     std::vector<int> row_offset(d_num_procs + 1);
     const int total_rows = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
     EXPECT_EQ(total_rows, num_total_rows);
@@ -336,10 +330,7 @@ TEST(StaticSVDTest, Test_StaticSVDTranspose)
 
     constexpr int num_total_rows = 3;
     constexpr int num_total_cols = 5;
-    int d_num_rows = num_total_rows / d_num_procs;
-    if (num_total_rows % d_num_procs > d_rank) {
-        d_num_rows++;
-    }
+    int d_num_rows = CAROM::split_dimension(num_total_rows, MPI_COMM_WORLD);
     std::vector<int> row_offset(d_num_procs + 1);
     const int total_rows = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
     EXPECT_EQ(total_rows, num_total_rows);

--- a/unit_tests/test_StaticSVD.cpp
+++ b/unit_tests/test_StaticSVD.cpp
@@ -8,6 +8,9 @@
  *
  *****************************************************************************/
 
+#ifdef CAROM_HAS_GTEST
+#include<gtest/gtest.h>
+#include "linalg/scalapack_wrapper.h"
 #include "linalg/BasisGenerator.h"
 #include <algorithm>
 #include <cmath>
@@ -17,9 +20,15 @@
 
 #include "mpi.h"
 
-int main(int argc, char* argv[])
+/**
+ * Simple smoke test to make sure Google Test is properly linked
+ */
+TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
+    SUCCEED();
+}
+
+TEST(StaticSVDTest, Test_StaticSVD)
 {
-    MPI_Init(&argc, &argv);
     int nprocs, rank;
     MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -79,6 +88,10 @@ int main(int argc, char* argv[])
                 MPI_Recv(&U.item(12*src, 0), 48, MPI_DOUBLE, src, MPI_ANY_TAG,
                          MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
+            for (int i = 0; i < totaldim; ++i)
+                for (int j = 0; j < 4; ++j)
+                    EXPECT_NEAR(abs(columns[j][i%12]), abs(U.item(i, j)), 1.0e-12);
+
             printf("Actual U                                        Computed U\n");
             printf("========                                        ==========\n");
             for (int i = 0; i < totaldim; ++i) {
@@ -95,7 +108,397 @@ int main(int argc, char* argv[])
 
     }
 
-    MPI_Finalize();
-
-    return 0;
+    return;
 }
+
+TEST(StaticSVDTest, Test_SLPKTranspose)
+{
+    // Get the rank of this process, and the number of processors.
+    int mpi_init, d_rank, d_num_procs;
+    MPI_Initialized(&mpi_init);
+    if (mpi_init == 0) {
+        MPI_Init(nullptr, nullptr);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+
+    int num_total_rows = 3;
+    int num_total_cols = 5;
+    int d_num_rows = num_total_rows / d_num_procs;
+    if (num_total_rows % d_num_procs > d_rank) {
+        d_num_rows++;
+    }
+    int *row_offset = new int[d_num_procs + 1];
+    row_offset[d_num_procs] = num_total_rows;
+    row_offset[d_rank] = d_num_rows;
+
+    MPI_Allgather(MPI_IN_PLACE,
+                  1,
+                  MPI_INT,
+                  row_offset,
+                  1,
+                  MPI_INT,
+                  MPI_COMM_WORLD);
+
+    for (int i = d_num_procs - 1; i >= 0; i--) {
+        row_offset[i] = row_offset[i + 1] - row_offset[i];
+    }
+
+    double* samples = new double[15] {0.5377, -1.3077, -1.3499,
+                                      1.8339, -0.4336, 3.0349,
+                                      -2.2588, 0.3426, 0.7254,
+                                      0.8622, 3.5784, -0.0631,
+                                      0.3188, 2.7694, 0.7147};
+
+    double* basis_right_true_ans = new double[15] {
+        3.08158946098238906153E-01,	    -9.49897947980619661301E-02,	-4.50691774108525788911E-01,	
+        -1.43697905723455976457E-01,	9.53289043424090820622E-01,	    8.77767692937209131898E-02,	
+        -2.23655845793717528158E-02,	-2.10628953513210204207E-01,	8.42235962392685943989E-01,	
+        -7.29903965154318323805E-01,	-1.90917141788945754488E-01,	-2.77280930877637610266E-01,	
+        -5.92561353877168350834E-01,	-3.74570084880578441089E-02,	5.40928141934190823137E-02,	
+    };
+
+    double* basis_true_ans = new double[9] {
+        -1.78651649346571794741E-01,	5.44387957786310106023E-01,	    -8.19588518467042281834E-01,	
+        -9.49719639253861602768E-01,	-3.13100149275943651084E-01,	-9.50441422536040881122E-04,	
+        -2.57130696341890396805E-01,	7.78209514167382598870E-01,	    5.72951792961765460355E-01,
+    };
+
+    double* sv_true_ans = new double[3] {
+        4.84486375065219387892E+00,     3.66719976398777269821E+00,     2.69114625366671811335E+00,
+    };
+
+    SLPK_Matrix *d_samples = new SLPK_Matrix;
+    std::vector<int> d_dims;
+    d_dims.resize(static_cast<unsigned>(d_num_procs));
+    MPI_Allgather(&d_num_rows, 1, MPI_INT, d_dims.data(), 1, MPI_INT, MPI_COMM_WORLD);
+    int d_total_dim = 0;
+    std::vector<int> d_istarts(static_cast<unsigned>(d_num_procs), 0);
+
+    for (unsigned i = 0; i < static_cast<unsigned>(d_num_procs); ++i) {
+        d_total_dim += d_dims[i];
+        if (i > 0) {
+            d_istarts[i] = d_istarts[i-1] + d_dims[i-1];
+        }
+    }
+
+    /* TODO: Try doing this more intelligently and see if it makes a difference */
+    int d_nprow = d_num_procs;
+    int d_npcol = 1;
+    int d_blocksize = d_total_dim / d_nprow;
+    if (d_total_dim % d_nprow != 0) {
+        d_blocksize += 1;
+    }
+    initialize_matrix(d_samples, d_total_dim, num_total_cols,
+                      d_nprow, d_npcol, d_blocksize, d_blocksize);
+
+    int d_num_samples = 0;
+    for (int s = 0; s < 5; s++)
+    {
+        const double *u_in = &samples[3*s];
+        for (int rank = 0; rank < d_num_procs; ++rank) {
+            scatter_block(d_samples, d_istarts[static_cast<unsigned>(rank)]+1,
+                        s+1, u_in, d_dims[static_cast<unsigned>(rank)],
+                        1, rank);
+        }
+    }
+    printf("original\n");
+    MPI_Barrier(MPI_COMM_WORLD);
+    print_debug_info(d_samples);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int d_blocksize_tr = num_total_cols / d_nprow;
+    if (num_total_cols % d_nprow != 0) {
+        d_blocksize_tr += 1;
+    }
+
+    SLPK_Matrix *transpose = new SLPK_Matrix;
+    initialize_matrix(transpose, num_total_cols, d_total_dim,
+                      d_nprow, d_npcol, d_blocksize_tr, d_blocksize_tr);
+
+    for (int rank = 0; rank < d_num_procs; ++rank) {
+        transpose_submatrix(transpose, 1, d_istarts[static_cast<unsigned>(rank)]+1,
+                            d_samples, d_istarts[static_cast<unsigned>(rank)]+1, 1,
+                            d_dims[static_cast<unsigned>(rank)], num_total_cols);
+    }
+
+    printf("transposed\n");
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    print_debug_info(transpose);
+
+    SVDManager *d_factorizer = new SVDManager;
+    svd_init(d_factorizer, transpose);
+    d_factorizer->dov = 1;
+    factorize(d_factorizer);
+
+    print_debug_info(d_factorizer->U);
+    MPI_Barrier(MPI_COMM_WORLD);
+    print_debug_info(d_factorizer->V);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int ncolumns = num_total_rows;
+    CAROM::Matrix *d_basis = new CAROM::Matrix(d_dims[d_rank], ncolumns, true);
+    CAROM::Matrix *d_basis_right = new CAROM::Matrix(ncolumns, num_total_cols, false);
+
+    for (int rank = 0; rank < d_num_procs; ++rank) {
+        // gather_transposed_block does the same as gather_block, but transposes
+        // it; here, it is used to go from column-major to row-major order.
+        gather_transposed_block(&d_basis_right->item(0, 0), d_factorizer->U,
+                                1, 1, num_total_cols, ncolumns, rank);
+        // V is computed in the transposed order so no reordering necessary.
+        gather_block(&d_basis->item(0, 0), d_factorizer->V,
+                    1, d_istarts[static_cast<unsigned>(rank)]+1,
+                    ncolumns, d_dims[static_cast<unsigned>(rank)], rank);
+    }
+
+    delete d_basis, d_basis_right;
+    free_matrix_data(d_samples);
+    free_matrix_data(transpose);
+    delete d_samples, transpose;
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST(StaticSVDTest, Test_StaticSVDClass)
+{
+    // Get the rank of this process, and the number of processors.
+    int mpi_init, d_rank, d_num_procs;
+    MPI_Initialized(&mpi_init);
+    if (mpi_init == 0) {
+        MPI_Init(nullptr, nullptr);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+
+    int num_total_rows = 5;
+    int d_num_rows = num_total_rows / d_num_procs;
+    if (num_total_rows % d_num_procs > d_rank) {
+        d_num_rows++;
+    }
+    int *row_offset = new int[d_num_procs + 1];
+    row_offset[d_num_procs] = num_total_rows;
+    row_offset[d_rank] = d_num_rows;
+
+    MPI_Allgather(MPI_IN_PLACE,
+                  1,
+                  MPI_INT,
+                  row_offset,
+                  1,
+                  MPI_INT,
+                  MPI_COMM_WORLD);
+
+    for (int i = d_num_procs - 1; i >= 0; i--) {
+        row_offset[i] = row_offset[i + 1] - row_offset[i];
+    }
+
+    double* sample1 = new double[5] {0.5377, 1.8339, -2.2588, 0.8622, 0.3188};
+    double* sample2 = new double[5] {-1.3077, -0.4336, 0.3426, 3.5784, 2.7694};
+    double* sample3 = new double[5] {-1.3499, 3.0349, 0.7254, -0.0631, 0.7147};
+
+    double* basis_true_ans = new double[15] {
+        3.08158946098238906153E-01,      -9.49897947980619661301E-02,      -4.50691774108525788911E-01,
+        -1.43697905723455976457E-01,     9.53289043424090820622E-01,      8.77767692937209131898E-02,
+        -2.23655845793717528158E-02,     -2.10628953513210204207E-01,     8.42235962392685943989E-01,
+        -7.29903965154318323805E-01,     -1.90917141788945754488E-01,     -2.77280930877637610266E-01,
+        -5.92561353877168350834E-01,     -3.74570084880578441089E-02,     5.40928141934190823137E-02
+    };
+
+    double* basis_right_true_ans = new double[9] {
+        -1.78651649346571794741E-01,     5.44387957786310106023E-01,      -8.19588518467042281834E-01,
+        -9.49719639253861602768E-01,     -3.13100149275943651084E-01,     -9.50441422536040881122E-04,
+        -2.57130696341890396805E-01,     7.78209514167382598870E-01,      5.72951792961765460355E-01
+    };
+
+    double* sv_true_ans = new double[3] {
+        4.84486375065219387892E+00,      3.66719976398777269821E+00,      2.69114625366671811335E+00
+    };
+
+    CAROM::Options svd_options = CAROM::Options(d_num_rows, 3, 1);
+    svd_options.setMaxBasisDimension(num_total_rows);
+    svd_options.setDebugMode(true);
+    svd_options.setRandomizedSVD(false);
+    CAROM::BasisGenerator sampler(svd_options, false);
+    sampler.takeSample(&sample1[row_offset[d_rank]], 0, 0);
+    sampler.takeSample(&sample2[row_offset[d_rank]], 0, 0);
+    sampler.takeSample(&sample3[row_offset[d_rank]], 0, 0);
+
+    const CAROM::Matrix* d_basis = sampler.getSpatialBasis();
+    const CAROM::Matrix* d_basis_right = sampler.getTemporalBasis();
+    const CAROM::Vector* sv = sampler.getSingularValues();
+
+// printf("basis: (%dx%d)\n", d_basis->numRows(), d_basis->numColumns());
+// for (int i = 0; i < d_basis->numRows(); i++)
+// {
+//     for (int j = 0; j < d_basis->numColumns(); j++)
+//         printf("%.3E\t", d_basis->item(i,j));
+//     printf("\n");
+// }
+// printf("\n");
+// printf("basis_right: (%dx%d)\n", d_basis_right->numRows(), d_basis_right->numColumns());
+// for (int i = 0; i < d_basis_right->numRows(); i++)
+// {
+//     for (int j = 0; j < d_basis_right->numColumns(); j++)
+//         printf("%.3E\t", d_basis_right->item(i,j));
+//     printf("\n");
+// }
+// printf("\n");
+
+    EXPECT_EQ(d_basis->numRows(), d_num_rows);
+    EXPECT_EQ(d_basis->numColumns(), 3);
+    EXPECT_EQ(d_basis_right->numRows(), 3);
+    EXPECT_EQ(d_basis_right->numColumns(), 3);
+    EXPECT_EQ(sv->dim(), 3);
+
+    double* d_basis_vals = d_basis->getData();
+    double* d_basis_right_vals = d_basis_right->getData();
+
+    for (int i = 0; i < d_num_rows * 3; i++) {
+        EXPECT_NEAR(abs(d_basis_vals[i]),
+                    abs(basis_true_ans[row_offset[d_rank] * 3 + i]), 1e-7);
+    }
+
+    for (int i = 0; i < 9; i++) {
+        EXPECT_NEAR(abs(d_basis_right_vals[i]), abs(basis_right_true_ans[i]), 1e-7);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        EXPECT_NEAR(sv->item(i), sv_true_ans[i], 1e-7);
+    }
+}
+
+TEST(StaticSVDTest, Test_StaticSVDTranspose)
+{
+    // Get the rank of this process, and the number of processors.
+    int mpi_init, d_rank, d_num_procs;
+    MPI_Initialized(&mpi_init);
+    if (mpi_init == 0) {
+        MPI_Init(nullptr, nullptr);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &d_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &d_num_procs);
+
+    int num_total_rows = 3;
+    int num_total_cols = 5;
+    int d_num_rows = num_total_rows / d_num_procs;
+    if (num_total_rows % d_num_procs > d_rank) {
+        d_num_rows++;
+    }
+    int *row_offset = new int[d_num_procs + 1];
+    row_offset[d_num_procs] = num_total_rows;
+    row_offset[d_rank] = d_num_rows;
+
+    MPI_Allgather(MPI_IN_PLACE,
+                  1,
+                  MPI_INT,
+                  row_offset,
+                  1,
+                  MPI_INT,
+                  MPI_COMM_WORLD);
+
+    for (int i = d_num_procs - 1; i >= 0; i--) {
+        row_offset[i] = row_offset[i + 1] - row_offset[i];
+    }
+
+    double* sample1 = new double[5] {0.5377, -1.3077, -1.3499};
+    double* sample2 = new double[5] {1.8339, -0.4336, 3.0349};
+    double* sample3 = new double[5] {-2.2588, 0.3426, 0.7254};
+    double* sample4 = new double[5] {0.8622, 3.5784, -0.0631};
+    double* sample5 = new double[5] {0.3188, 2.7694, 0.7147};
+
+    double* basis_right_true_ans = new double[15] {
+        3.08158946098238906153E-01,	    -9.49897947980619661301E-02,	-4.50691774108525788911E-01,	
+        -1.43697905723455976457E-01,	9.53289043424090820622E-01,	    8.77767692937209131898E-02,	
+        -2.23655845793717528158E-02,	-2.10628953513210204207E-01,	8.42235962392685943989E-01,	
+        -7.29903965154318323805E-01,	-1.90917141788945754488E-01,	-2.77280930877637610266E-01,	
+        -5.92561353877168350834E-01,	-3.74570084880578441089E-02,	5.40928141934190823137E-02,	
+    };
+
+    double* basis_true_ans = new double[9] {
+        -1.78651649346571794741E-01,	5.44387957786310106023E-01,	    -8.19588518467042281834E-01,	
+        -9.49719639253861602768E-01,	-3.13100149275943651084E-01,	-9.50441422536040881122E-04,	
+        -2.57130696341890396805E-01,	7.78209514167382598870E-01,	    5.72951792961765460355E-01,
+    };
+
+    double* sv_true_ans = new double[3] {
+        4.84486375065219387892E+00,     3.66719976398777269821E+00,     2.69114625366671811335E+00,
+    };
+
+    CAROM::Options svd_options = CAROM::Options(d_num_rows, num_total_cols, 1);
+    svd_options.setMaxBasisDimension(num_total_rows);
+    svd_options.setDebugMode(true);
+    svd_options.setRandomizedSVD(false);
+    CAROM::BasisGenerator sampler(svd_options, false);
+    sampler.takeSample(&sample1[row_offset[d_rank]], 0, 0);
+    sampler.takeSample(&sample2[row_offset[d_rank]], 0, 0);
+    sampler.takeSample(&sample3[row_offset[d_rank]], 0, 0);
+    sampler.takeSample(&sample4[row_offset[d_rank]], 0, 0);
+    sampler.takeSample(&sample5[row_offset[d_rank]], 0, 0);
+
+    const CAROM::Matrix* d_basis = sampler.getSpatialBasis();
+    const CAROM::Matrix* d_basis_right = sampler.getTemporalBasis();
+    const CAROM::Vector* sv = sampler.getSingularValues();
+
+// printf("basis: (%dx%d)\n", d_basis->numRows(), d_basis->numColumns());
+// for (int i = 0; i < d_basis->numRows(); i++)
+// {
+//     for (int j = 0; j < d_basis->numColumns(); j++)
+//         printf("%.3E\t", d_basis->item(i,j));
+//     printf("\n");
+// }
+// printf("\n");
+// printf("basis_right: (%dx%d)\n", d_basis_right->numRows(), d_basis_right->numColumns());
+// for (int i = 0; i < d_basis_right->numRows(); i++)
+// {
+//     for (int j = 0; j < d_basis_right->numColumns(); j++)
+//         printf("%.3E\t", d_basis_right->item(i,j));
+//     printf("\n");
+// }
+// printf("\n");
+
+    EXPECT_EQ(d_basis_right->numRows(), num_total_cols);
+    EXPECT_EQ(d_basis_right->numColumns(), 3);
+    EXPECT_EQ(d_basis->numRows(), d_num_rows);
+    EXPECT_EQ(d_basis->numColumns(), 3);
+    EXPECT_EQ(sv->dim(), 3);
+
+    double* d_basis_vals = d_basis->getData();
+    double* d_basis_right_vals = d_basis_right->getData();
+
+    for (int i = 0; i < num_total_cols * num_total_rows; i++) {
+        EXPECT_NEAR(abs(d_basis_right_vals[i]),
+                    abs(basis_right_true_ans[i]), 1e-7);
+    }
+
+    for (int i = 0; i < d_num_rows * num_total_rows; i++) {
+        EXPECT_NEAR(abs(d_basis_vals[i]),
+                    abs(basis_true_ans[row_offset[d_rank] * num_total_rows + i]), 1e-7);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        EXPECT_NEAR(sv->item(i), sv_true_ans[i], 1e-7);
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    MPI_Init(&argc, &argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
+}
+
+#else // #ifndef CAROM_HAS_GTEST
+
+int main()
+{
+    std::cout << "libROM was compiled without Google Test support, so unit "
+              << "tests have been disabled. To enable unit tests, compile "
+              << "libROM with Google Test support." << std::endl;
+}
+
+#endif // #endif CAROM_HAS_GTEST

--- a/unit_tests/test_StaticSVD.cpp
+++ b/unit_tests/test_StaticSVD.cpp
@@ -260,21 +260,9 @@ TEST(StaticSVDTest, Test_StaticSVDClass)
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
     }
-    int *row_offset = new int[d_num_procs + 1];
-    row_offset[d_num_procs] = num_total_rows;
-    row_offset[d_rank] = d_num_rows;
-
-    MPI_Allgather(MPI_IN_PLACE,
-                  1,
-                  MPI_INT,
-                  row_offset,
-                  1,
-                  MPI_INT,
-                  MPI_COMM_WORLD);
-
-    for (int i = d_num_procs - 1; i >= 0; i--) {
-        row_offset[i] = row_offset[i + 1] - row_offset[i];
-    }
+    std::vector<int> row_offset(d_num_procs + 1);
+    const int total_rows = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
+    EXPECT_EQ(total_rows, num_total_rows);
 
     double* sample1 = new double[5] {0.5377, 1.8339, -2.2588, 0.8622, 0.3188};
     double* sample2 = new double[5] {-1.3077, -0.4336, 0.3426, 3.5784, 2.7694};
@@ -352,21 +340,9 @@ TEST(StaticSVDTest, Test_StaticSVDTranspose)
     if (num_total_rows % d_num_procs > d_rank) {
         d_num_rows++;
     }
-    int *row_offset = new int[d_num_procs + 1];
-    row_offset[d_num_procs] = num_total_rows;
-    row_offset[d_rank] = d_num_rows;
-
-    MPI_Allgather(MPI_IN_PLACE,
-                  1,
-                  MPI_INT,
-                  row_offset,
-                  1,
-                  MPI_INT,
-                  MPI_COMM_WORLD);
-
-    for (int i = d_num_procs - 1; i >= 0; i--) {
-        row_offset[i] = row_offset[i + 1] - row_offset[i];
-    }
+    std::vector<int> row_offset(d_num_procs + 1);
+    const int total_rows = CAROM::get_global_offsets(d_num_rows, row_offset, MPI_COMM_WORLD);
+    EXPECT_EQ(total_rows, num_total_rows);
 
     double* sample1 = new double[5] {0.5377, -1.3077, -1.3499};
     double* sample2 = new double[5] {1.8339, -0.4336, 3.0349};


### PR DESCRIPTION
### `StaticSVD` supports the transposed SVD operation
- In the case where the sample size is larger than the system dimension, `StaticSVD::computeSVD` now performs the transposed SVD.
- `test_StaticSVD` now checks a couple of google test routines, and is included in the ci test.

### Minor capability updates
- `lib/utils/mpi_utils.h` have frequently-used MPI-support functions
  - `split_dimension`, `get_global_offsets`
- `Matrix` now can distribute or gather itself among MPI processes, through its member function `Matrix::distribute` and `Matrix::gather`.

### Minor fixes on `StaticSVD` / `RandomizedSVD`
This is related to the issue #223 . **This update may have a potential impact on the previous implementation.**

The notation here refers to a svd operation `A = U * S * V^T` with the snapshot matrix `A` of size `(m, n)` and `p` number of svd modes.
1. So far the size of `d_basis_right` is set to `(p, n)`, which corresponds to the size of `V^T`. However, the actual content of `d_basis_right` in fact corresponds to `V`, not `V^T`, so its size should be `(n, p)`. This is fixed in `StaticSVD::computeSVD` and `RandomizedSVD::computeSVD`.
2. Per discussion in #223 , `RandomizedSVD::computeSVD` always keeps `d_basis` distributed and `d_basis_right` not distributed, whether transposed or not. If smaller subspace dimension is used, then d_basis is distributed according to its own size.

### Minor update on Docker container
- `astyle` added