### PR TITLE
ScaLAPACK dependency installation

### DIFF
--- a/cmake/toolchains/simple.cmake
+++ b/cmake/toolchains/simple.cmake
@@ -1,0 +1,9 @@
+set(CMAKE_C_COMPILER mpicc)
+set(CMAKE_CXX_COMPILER mpicxx)
+set(CMAKE_Fortran_COMPILER mpif90)
+
+# Use environment variables.
+set(MFEM_DIR $ENV{MFEM_DIR})
+set(HYPRE_DIR $ENV{HYPRE_DIR})
+set(PARMETIS_DIR $ENV{PARMETIS_DIR})
+set(METIS_DIR $ENV{METIS_DIR})

--- a/dependencies/SLmake.inc
+++ b/dependencies/SLmake.inc
@@ -26,6 +26,11 @@ CDEFS         = -DAdd_
 #  The fortran and C compilers, loaders, and their flags
 #
 
+# LIBROM instruction: copy this file to scalapack-2.2.0 directory and type make.
+
+# -fallow-argument-mismatch is needed to compile some legacy fortran code that does not conform to modern gnu compiler standard.
+# -fPIC is needed to build the static scalapack library.
+
 FC            = mpif90
 CC            = mpicc 
 NOOPT         = -O0 -fallow-argument-mismatch -fPIC

--- a/dependencies/SLmake.inc
+++ b/dependencies/SLmake.inc
@@ -1,0 +1,60 @@
+############################################################################
+#
+#  Program:         ScaLAPACK
+#
+#  Module:          SLmake.inc
+#
+#  Purpose:         Top-level Definitions
+#
+#  Creation date:   February 15, 2000
+#
+#  Modified:        October 13, 2011
+#
+#  Send bug reports, comments or suggestions to scalapack@cs.utk.edu
+#
+############################################################################
+#
+#  C preprocessor definitions:  set CDEFS to one of the following:
+#
+#     -DNoChange (fortran subprogram names are lower case without any suffix)
+#     -DUpCase   (fortran subprogram names are upper case without any suffix)
+#     -DAdd_     (fortran subprogram names are lower case with "_" appended)
+
+CDEFS         = -DAdd_
+
+#
+#  The fortran and C compilers, loaders, and their flags
+#
+
+FC            = mpif90
+CC            = mpicc 
+NOOPT         = -O0 -fallow-argument-mismatch -fPIC
+FCFLAGS       = -O3 -fallow-argument-mismatch -fPIC
+CCFLAGS       = -O3 -fPIC
+FCLOADER      = $(FC)
+CCLOADER      = $(CC)
+FCLOADFLAGS   = $(FCFLAGS)
+CCLOADFLAGS   = $(CCFLAGS)
+
+#
+#  The archiver and the flag(s) to use when building archive (library)
+#  Also the ranlib routine.  If your system has no ranlib, set RANLIB = echo
+#
+
+ARCH          = ar
+ARCHFLAGS     = cr
+RANLIB        = ranlib
+
+#
+#  The name of the ScaLAPACK library to be created
+#
+
+SCALAPACKLIB  = libscalapack.a
+
+#
+#  BLAS, LAPACK (and possibly other) libraries needed for linking test programs
+#
+
+BLASLIB       = -lblas
+LAPACKLIB     = -llapack
+LIBS          = $(LAPACKLIB) $(BLASLIB)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -99,7 +99,12 @@ if (BLAS_LIBRARIES MATCHES ".*mkl.*")
 else() # BLAS or LAPACK isn't MKL
   find_package(ScaLAPACK)
   if (NOT ScaLAPACK_FOUND)
-    find_package(ScaLAPACK REQUIRED HINTS "${CMAKE_SOURCE_DIR}/dependencies/scalapack-2.2.0")
+    # Attempt to use manually-built scalapack in dependencies.
+    # CMake files in scalapack directory disrupts find_package using PATHS/HINTS.
+    # Here we prepend environment PATH variable.
+    # This changed PATH variable applies only to this libROM compilation.
+    set(ENV{PATH} "${CMAKE_SOURCE_DIR}/dependencies/scalapack-2.2.0:$ENV{PATH}")
+    find_package(ScaLAPACK REQUIRED)
   endif()
   target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES})
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -97,7 +97,10 @@ if (BLAS_LIBRARIES MATCHES ".*mkl.*")
     target_include_directories(ROM PUBLIC ${MKL_INCLUDE_DIRS})
   endif()
 else() # BLAS or LAPACK isn't MKL
-  find_package(ScaLAPACK REQUIRED HINTS "${CMAKE_SOURCE_DIR}/dependencies/scalapack-2.2.0")
+  find_package(ScaLAPACK)
+  if (NOT ScaLAPACK_FOUND)
+    find_package(ScaLAPACK REQUIRED HINTS "${CMAKE_SOURCE_DIR}/dependencies/scalapack-2.2.0")
+  endif()
   target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES})
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -97,7 +97,7 @@ if (BLAS_LIBRARIES MATCHES ".*mkl.*")
     target_include_directories(ROM PUBLIC ${MKL_INCLUDE_DIRS})
   endif()
 else() # BLAS or LAPACK isn't MKL
-  find_package(ScaLAPACK REQUIRED)
+  find_package(ScaLAPACK REQUIRED HINTS "${CMAKE_SOURCE_DIR}/dependencies/scalapack-2.2.0")
   target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES})
 endif()
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -88,7 +88,8 @@ if [[ $MFEM_USE_GSLIB == "On" ]] && [[ ! -d "$HOME_DIR/dependencies/gslib" ]]; t
 fi
 export MFEM_USE_GSLIB
 
-REPO_PREFIX=$(git rev-parse --show-toplevel)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_PREFIX=$( dirname $SCRIPT_DIR )
 
 if [[ $USE_MFEM == "On" ]]; then
     . ${REPO_PREFIX}/scripts/setup.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,6 +10,9 @@ check_result () {
   fi
 }
 
+# Take the first argument as option for installing ScaLAPACK.
+INSTALL_SCALAPACK=$1
+
 # Check whether Homebrew or wget is installed
 if [ "$(uname)" == "Darwin" ]; then
   which -s brew > /dev/null
@@ -34,10 +37,9 @@ export CFLAGS="-fPIC"
 export CPPFLAGS="-fPIC"
 export CXXFLAGS="-fPIC"
 
-# Install ScaLAPACK if library is not located
+# Install ScaLAPACK if specified.
 cd $LIB_DIR
-SCALAPACK_PATH=$(whereis libscalapack | awk '{print $2}')
-if [ -z "$SCALAPACK_PATH" ]; then
+if [[ $INSTALL_SCALAPACK == "true" ]]; then
   if [ -f "scalapack-2.2.0/libscalapack.a" ]; then
     echo "Using dependencies/scalapack-2.2.0/libscalapack.a"
   else

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+check_result () {
+  # $1: Result output of the previous command ($?)
+  # $2: Name of the previous command
+  if [ $1 -eq 0 ]; then
+      echo "$2 succeeded"
+  else
+      echo "$2 failed"
+      exit -1
+  fi
+}
 
 # Check whether Homebrew or wget is installed
 if [ "$(uname)" == "Darwin" ]; then
@@ -36,6 +46,7 @@ if [ -z "$SCALAPACK_PATH" ]; then
     cp SLmake.inc scalapack-2.2.0/
     cd scalapack-2.2.0/
     make
+    check_result $? ScaLAPACK-installation
   fi
 fi
 
@@ -48,6 +59,7 @@ if [ ! -d "hypre" ]; then
   cd hypre/src
   ./configure --disable-fortran
   make -j
+  check_result $? hypre-installation
 fi
 
 # Install GSLIB
@@ -63,6 +75,7 @@ if [ $MFEM_USE_GSLIB == "On" ] && [ ! -d "gslib" ]; then
   mv gslib-1.0.7 gslib
   cd gslib
   make CC=mpicc -j
+  check_result $? gslib-installation
 fi
 
 # Install PARMETIS 4.0.3
@@ -72,12 +85,15 @@ if [ ! -d "parmetis-4.0.3" ]; then
   tar -zxvf parmetis-4.0.3.tar.gz
   cd parmetis-4.0.3
   make config
+  check_result $? parmetis-config
   make
+  check_result $? parmetis-installation
   METIS_DIR=$LIB_DIR/parmetis-4.0.3
   METIS_OPT=-I${METIS_DIR}/metis/include
   cd ${METIS_DIR}/build
   MACHINE_ARCH=$(ls)
   ln -s $MACHINE_ARCH lib
+  check_result $? parmetis-link
 fi
 
 unset CFLAGS
@@ -99,10 +115,12 @@ if [[ $BUILD_TYPE == "Debug" ]]; then
         cd mfem_debug
         git pull
         make pdebug -j 8 STATIC=NO SHARED=YES MFEM_USE_MPI=YES MFEM_USE_GSLIB=${MG} MFEM_USE_METIS=YES MFEM_USE_METIS_5=YES METIS_DIR="$METIS_DIR" METIS_OPT="$METIS_OPT" METIS_LIB="$METIS_LIB"
+        check_result $? mfem-debug-installation
     fi
     cd $LIB_DIR
     rm mfem
     ln -s mfem_debug mfem
+    check_result $? mfem-debug-link
 else
     if [ ! -d "mfem_parallel" ]; then
       UPDATE_LIBS=true
@@ -112,8 +130,10 @@ else
         cd mfem_parallel
         git pull
         make parallel -j 8 STATIC=NO SHARED=YES MFEM_USE_MPI=YES MFEM_USE_GSLIB=${MG} MFEM_USE_METIS=YES MFEM_USE_METIS_5=YES METIS_DIR="$METIS_DIR" METIS_OPT="$METIS_OPT" METIS_LIB="$METIS_LIB"
+        check_result $? mfem-parallel-installation
     fi
     cd $LIB_DIR
     rm mfem
     ln -s mfem_parallel mfem
+    check_result $? mfem-parallel-link
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,6 +24,17 @@ export CFLAGS="-fPIC"
 export CPPFLAGS="-fPIC"
 export CXXFLAGS="-fPIC"
 
+# Install ScaLAPACK if library is not located
+cd $LIB_DIR
+SCALAPACK_PATH=$(whereis libscalapack | awk '{print $2}')
+if [ -z "$SCALAPACK_PATH" ]; then
+    echo "ScaLAPACK is needed!"
+    tar -zxvf scalapack-2.2.0.tar.gz
+    cp SLmake.inc scalapack-2.2.0/
+    cd scalapack-2.2.0/
+    make
+fi
+
 # Install HYPRE
 cd $LIB_DIR
 if [ ! -d "hypre" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,11 +28,15 @@ export CXXFLAGS="-fPIC"
 cd $LIB_DIR
 SCALAPACK_PATH=$(whereis libscalapack | awk '{print $2}')
 if [ -z "$SCALAPACK_PATH" ]; then
+  if [ -f "scalapack-2.2.0/libscalapack.a" ]; then
+    echo "Using dependencies/scalapack-2.2.0/libscalapack.a"
+  else
     echo "ScaLAPACK is needed!"
     tar -zxvf scalapack-2.2.0.tar.gz
     cp SLmake.inc scalapack-2.2.0/
     cd scalapack-2.2.0/
     make
+  fi
 fi
 
 # Install HYPRE


### PR DESCRIPTION
This is in support of [pylibROM installation](https://github.com/michael-barrow-llnl/pylibROM/pull/12) using `pip` on quartz.

Current `libROM` compilation using `mkl` module in `quartz` has an issue, as the shared object of `libROM` cannot resolve the relative path of `mkl`, as the shared object is packed into the pip installation procedure. (For a detail, see the issue from [pybind/cmake_example](https://github.com/pybind/cmake_example/issues/11)).

- `scripts/setup.sh` is adjusted so that it can manually install a static `libscalapack.a` library. There are two options to specify manual installation,
 1. specify `-s` flag for `scripts/compile.sh`
 2. pass `true` as an argument after `scripts/setup.sh`
- Required source code and input file is stored in `dependencies`.
- `lib/CMakeLists.txt` provides `HINTS` to `find_package(ScaLAPACK REQUIRED)`, pointing to `dependencies/scalapack-2.2.0`.

A miscellaneous addition:
- `cmake/toolchains/simple.cmake`: it simply takes the path to `mfem`, `hypre`, `parmetis` and `metis` from the environment variables (which need to be pre-set).