### PR TITLE
Add matrix row/column rescaling methods

### DIFF
--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1832,6 +1832,64 @@ Matrix::orthogonalize()
     }
 }
 
+void 
+Matrix::rescale_rows_max()
+{
+	// Rescale every matrix row by its maximum absolute value.
+	for (int i = 0; i < d_num_rows; i++)
+	{
+		// Find the row's max absolute value.
+		double local_max = fabs(item(i, 0));
+		for (int j = 1; j < d_num_cols; j++)
+		{
+			if (fabs(item(i, j)) > local_max)
+				local_max = fabs(item(i, j));
+		}
+
+		// Get the max of all processes, if applicable.
+		double global_max = local_max;
+		if (d_num_procs > 1)
+			MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX,
+					MPI_COMM_WORLD);
+
+		// Rescale every row entry, if max nonzero.
+		if (global_max > 1.0e-14)
+		{
+			for (int j = 0; j < d_num_cols; j++)
+				item(i, j) /= global_max;
+		}
+	}
+}
+
+void 
+Matrix::rescale_cols_max()
+{
+	// Rescale every matrix column by its maximum absolute value.
+	for (int j = 0; j < d_num_cols; j++)
+	{
+		// Find the column's max absolute value.
+		double local_max = fabs(item(0, j));
+		for (int i = 1; i < d_num_rows; i++)
+		{
+			if (fabs(item(i, j)) > local_max)
+				local_max = fabs(item(i, j));
+		}
+
+		// Get the max of all processes, if applicable.
+		double global_max = local_max;
+		if (d_num_procs > 1)
+			MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX,
+					MPI_COMM_WORLD);
+
+		// Rescale every column entry, if max nonzero.
+		if (global_max > 1.0e-14)
+		{
+			for (int i = 0; i < d_num_rows; i++)
+				item(i, j) /= global_max;
+		}
+	}
+}
+
 Matrix outerProduct(const Vector &v, const Vector &w)
 {
     /*

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1837,7 +1837,7 @@ Matrix::rescale_rows_max()
 {
     // Rescale every matrix row by its maximum absolute value.
     // In the Matrix class, columns are distributed row wise, but rows are
-    // not disctributed; namely, each process acts on a number of full rows.
+    // not distributed; namely, each process acts on a number of full rows.
     // Therefore, no MPI communication is needed.
 
     for (int i = 0; i < d_num_rows; i++)

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1832,62 +1832,56 @@ Matrix::orthogonalize()
     }
 }
 
-void 
+void
 Matrix::rescale_rows_max()
 {
-	// Rescale every matrix row by its maximum absolute value.
-	for (int i = 0; i < d_num_rows; i++)
-	{
-		// Find the row's max absolute value.
-		double local_max = fabs(item(i, 0));
-		for (int j = 1; j < d_num_cols; j++)
-		{
-			if (fabs(item(i, j)) > local_max)
-				local_max = fabs(item(i, j));
-		}
+    // Rescale every matrix row by its maximum absolute value.
+    for (int i = 0; i < d_num_rows; i++)
+    {
+        // Find the row's max absolute value.
+        double row_max = fabs(item(i, 0));
+        for (int j = 1; j < d_num_cols; j++)
+        {
+            if (fabs(item(i, j)) > row_max)
+                row_max = fabs(item(i, j));
+        }
 
-		// Get the max of all processes, if applicable.
-		double global_max = local_max;
-		if (d_num_procs > 1)
-			MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX,
-					MPI_COMM_WORLD);
-
-		// Rescale every row entry, if max nonzero.
-		if (global_max > 1.0e-14)
-		{
-			for (int j = 0; j < d_num_cols; j++)
-				item(i, j) /= global_max;
-		}
-	}
+        // Rescale every row entry, if max nonzero.
+        if (row_max > 1.0e-14)
+        {
+            for (int j = 0; j < d_num_cols; j++)
+                item(i, j) /= row_max;
+        }
+    }
 }
 
-void 
+void
 Matrix::rescale_cols_max()
 {
-	// Rescale every matrix column by its maximum absolute value.
-	for (int j = 0; j < d_num_cols; j++)
-	{
-		// Find the column's max absolute value.
-		double local_max = fabs(item(0, j));
-		for (int i = 1; i < d_num_rows; i++)
-		{
-			if (fabs(item(i, j)) > local_max)
-				local_max = fabs(item(i, j));
-		}
+    // Rescale every matrix column by its maximum absolute value.
+    for (int j = 0; j < d_num_cols; j++)
+    {
+        // Find the column's max absolute value.
+        double local_max = fabs(item(0, j));
+        for (int i = 1; i < d_num_rows; i++)
+        {
+            if (fabs(item(i, j)) > local_max)
+                local_max = fabs(item(i, j));
+        }
 
-		// Get the max of all processes, if applicable.
-		double global_max = local_max;
-		if (d_num_procs > 1)
-			MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX,
-					MPI_COMM_WORLD);
+        // Get the max of all processes, if applicable.
+        double global_max = local_max;
+        if (d_num_procs > 1)
+            MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX,
+                          MPI_COMM_WORLD);
 
-		// Rescale every column entry, if max nonzero.
-		if (global_max > 1.0e-14)
-		{
-			for (int i = 0; i < d_num_rows; i++)
-				item(i, j) /= global_max;
-		}
-	}
+        // Rescale every column entry, if max nonzero.
+        if (global_max > 1.0e-14)
+        {
+            for (int i = 0; i < d_num_rows; i++)
+                item(i, j) /= global_max;
+        }
+    }
 }
 
 Matrix outerProduct(const Vector &v, const Vector &w)

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -947,6 +947,18 @@ public:
     orthogonalize();
 
     /**
+     * @brief Rescale every matrix row by its maximum absolute value.
+     */
+    void
+    rescale_rows_max();
+
+    /**
+     * @brief Rescale every matrix column by its maximum absolute value.
+     */
+    void
+    rescale_cols_max();
+    
+    /**
      * @brief Const Matrix member access. Matrix data is stored in
      * row-major format.
      *

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -957,7 +957,7 @@ public:
      */
     void
     rescale_cols_max();
-    
+
     /**
      * @brief Const Matrix member access. Matrix data is stored in
      * row-major format.


### PR DESCRIPTION
Adds two methods in the `Matrix` class for rescaling the matrix's rows/columns by their maximum absolute value. The methods are used in LaghosROM. 