### PR TITLE
Minor fix in mfem utility function + Hypre version change

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,8 +93,8 @@ WORKDIR $LIB_DIR
 # install mfem
 RUN git clone https://github.com/mfem/mfem.git mfem_parallel
 WORKDIR ./mfem_parallel
-# Latest verified commit on May 2, 2023
-RUN git checkout e5231334e6a8175b4f404b877f590b73dee2dedc
+# v4.5.2-dev commit. This is the mfem version used by PyMFEM v4.5.2.0.
+RUN git checkout 00b2a0705f647e17a1d4ffcb289adca503f28d42
 #RUN tar -zxvf mfem-4.5.tar.gz
 #RUN mv mfem-4.5 mfem_parallel
 #RUN git pull

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV LIB_DIR=/$ENVDIR/dependencies
 WORKDIR $LIB_DIR
 
 #RUN wget -O mfem-4.5.tar.gz https://github.com/mfem/mfem/archive/refs/tags/v4.5.tar.gz
-RUN wget -O hypre-2.20.0.tar.gz https://github.com/hypre-space/hypre/archive/refs/tags/v2.20.0.tar.gz
+RUN wget -O hypre-2.28.0.tar.gz https://github.com/hypre-space/hypre/archive/v2.28.0.tar.gz
 
 # Instead of the original parmetis link (which is often unavailable), use the link to librom master branch:
 # RUN wget -O parmetis-4.0.3.tar.gz http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz
@@ -40,8 +40,8 @@ ENV CPPFLAGS="-fPIC"
 ENV CXXFLAGS="-fPIC"
 
 # install hypre
-RUN tar -zxvf hypre-2.20.0.tar.gz
-RUN mv hypre-2.20.0 hypre
+RUN tar -zxvf hypre-2.28.0.tar.gz
+RUN mv hypre-2.28.0 hypre
 WORKDIR ./hypre/src/
 RUN ./configure --disable-fortran
 RUN make -j

--- a/lib/mfem/Utilities.cpp
+++ b/lib/mfem/Utilities.cpp
@@ -22,7 +22,7 @@ void ComputeCtAB(const HypreParMatrix& A,
 
     const int num_rows = B.numRows();
     const int num_cols = B.numColumns();
-    const int num_rows_A = A.GetNumRows();
+    const int num_rows_A = A.NumRows();
 
     MFEM_VERIFY(C.numRows() == num_rows_A, "");
 
@@ -52,7 +52,7 @@ void ComputeCtAB_vec(const HypreParMatrix& A,
     MFEM_VERIFY(C.distributed() && !CtAB_vec.distributed(),
                 "In ComputeCtAB_vec, C must be distributed, but not CtAB_vec");
 
-    MFEM_VERIFY(C.numRows() == A.GetNumRows(), "");
+    MFEM_VERIFY(C.numRows() == A.NumRows(), "");
     MFEM_VERIFY(B.GlobalSize() == A.GetGlobalNumRows(), "");
 
     HypreParVector* AB = new HypreParVector(B);

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -55,9 +55,9 @@ fi
 # Install HYPRE
 cd $LIB_DIR
 if [ ! -d "hypre" ]; then
-  wget https://github.com/hypre-space/hypre/archive/refs/tags/v2.20.0.tar.gz
-  tar -zxvf v2.20.0.tar.gz
-  mv hypre-2.20.0 hypre
+  wget https://github.com/hypre-space/hypre/archive/v2.28.0.tar.gz
+  tar -zxvf v2.28.0.tar.gz
+  mv hypre-2.28.0 hypre
   cd hypre/src
   ./configure --disable-fortran
   make -j

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -55,6 +55,8 @@ fi
 # Install HYPRE
 cd $LIB_DIR
 if [ ! -d "hypre" ]; then
+  # NOTE(kevin): This is the hypre version used by PyMFEM v4.5.2.0.
+  # This version matching is required to support pylibROM-PyMFEM interface.
   wget https://github.com/hypre-space/hypre/archive/v2.28.0.tar.gz
   tar -zxvf v2.28.0.tar.gz
   mv hypre-2.28.0 hypre
@@ -130,7 +132,9 @@ else
     fi
     if [[ $UPDATE_LIBS == "true" ]]; then
         cd mfem_parallel
-        git pull
+        # NOTE(kevin): v4.5.2-dev commit. This is the mfem version used by PyMFEM v4.5.2.0.
+        # This version matching is required to support pylibROM-PyMFEM interface.
+        git checkout 00b2a0705f647e17a1d4ffcb289adca503f28d42
         make parallel -j 8 STATIC=NO SHARED=YES MFEM_USE_MPI=YES MFEM_USE_GSLIB=${MG} MFEM_USE_METIS=YES MFEM_USE_METIS_5=YES METIS_DIR="$METIS_DIR" METIS_OPT="$METIS_OPT" METIS_LIB="$METIS_LIB"
         check_result $? mfem-parallel-installation
     fi


### PR DESCRIPTION
This PR is in support of pylibROM mfem binding [PR](https://github.com/LLNL/pylibROM/pull/14).

When using mfem functions from python side, a strange seg-fault error happens when `HypreParMatrix::GetNumRows()` is used. This does not happen if the same function is used from c++ side.

Fortunately, there is `HypreParMatrix::NumRows()` which does the same job and does not cause a seg-fault issue on python end. This PR simply replaces `GetNumRows()` with `NumRows()`. 

### Update
The seg-fault error in using Hypre functions on python end, turns out to be because of the version incompatibility between libROM and pymfem.

[PyMFEM](https://github.com/mfem/PyMFEM) uses hypre v2.28.0, while libROM has been using v2.20.0. And when pylibrom accesses to some hypre functions compiled from pymfem (or the other way around), it causes the segmentation fault error.

This error is resolved when the hypre in libROM is updated to v2.28.0. So now the `setup.sh` and `Dockerfile` reflect this version change.

### Another update

Further segmentation fault error is observed, and this was due to the version mismatch of  c++ `mfem` between pylibROM and PyMFEM. To support their interface, we match the mfem version to that from PyMFEM.