### PR TITLE
Changes in Gram-Schmidt functions

### DIFF
--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1818,7 +1818,7 @@ Matrix::orthogonalize()
         // Normalize the column.
         double norm = 0.0;
         tmp = 0.0;
-        
+
         for (int i = 0; i < d_num_rows; ++i)
             tmp += item(i, work) * item(i, work);
 
@@ -1844,7 +1844,7 @@ Matrix::orthogonalize_last(int ncols)
 {
     if (ncols == -1) ncols = d_num_cols;
     CAROM_ASSERT((ncols > 0) && (ncols <= d_num_cols));
-    
+
     const int last_col = ncols - 1; // index of column to be orthonormalized
     double tmp;
 

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1790,44 +1790,51 @@ const
 void
 Matrix::orthogonalize()
 {
-    for (int work = 1; work < d_num_cols; ++work) {
+    for (int work = 0; work < d_num_cols; ++work)
+    {
+        // Orthogonalize the column.
         double tmp;
-        for (int col = 0; col < work; ++col) {
+        for (int col = 0; col < work; ++col)
+        {
             double factor = 0.0;
             tmp = 0.0;
-            for (int i = 0; i < d_num_rows; ++i) {
-                tmp += item(i, col)*item(i, work);
-            }
-            if (d_num_procs > 1) {
-                MPI_Allreduce(&tmp,
-                              &factor,
-                              1,
-                              MPI_DOUBLE,
-                              MPI_SUM,
+
+            for (int i = 0; i < d_num_rows; ++i)
+                tmp += item(i, col) * item(i, work);
+
+            if (d_num_procs > 1)
+            {
+                MPI_Allreduce(&tmp, &factor, 1, MPI_DOUBLE, MPI_SUM,
                               MPI_COMM_WORLD);
             }
-            else {
+            else
+            {
                 factor = tmp;
             }
-
-            for (int i = 0; i < d_num_rows; ++i) {
-                item(i, work) -= factor*item(i, col);
-            }
+            for (int i = 0; i < d_num_rows; ++i)
+                item(i, work) -= factor * item(i, col);
         }
+
+        // Normalize the column.
         double norm = 0.0;
         tmp = 0.0;
-        for (int i = 0; i < d_num_rows; ++i) {
-            tmp += item(i, work)*item(i, work);
-        }
-        if (d_num_procs > 1) {
+        
+        for (int i = 0; i < d_num_rows; ++i)
+            tmp += item(i, work) * item(i, work);
+
+        if (d_num_procs > 1)
+        {
             MPI_Allreduce(&tmp, &norm, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
         }
-        else {
+        else
+        {
             norm = tmp;
         }
-        norm = sqrt(norm);
-        for (int i = 0; i < d_num_rows; ++i) {
-            item(i, work) /= norm;
+        if (norm > 1.0e-15)
+        {
+            norm = 1.0 / sqrt(norm);
+            for (int i = 0; i < d_num_rows; ++i)
+                item(i, work) *= norm;
         }
     }
 }

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1802,7 +1802,7 @@ Matrix::orthogonalize()
             for (int i = 0; i < d_num_rows; ++i)
                 tmp += item(i, col) * item(i, work);
 
-            if (d_num_procs > 1)
+            if (d_distributed && d_num_procs > 1)
             {
                 MPI_Allreduce(&tmp, &factor, 1, MPI_DOUBLE, MPI_SUM,
                               MPI_COMM_WORLD);
@@ -1822,7 +1822,7 @@ Matrix::orthogonalize()
         for (int i = 0; i < d_num_rows; ++i)
             tmp += item(i, work) * item(i, work);
 
-        if (d_num_procs > 1)
+        if (d_distributed && d_num_procs > 1)
         {
             MPI_Allreduce(&tmp, &norm, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
         }
@@ -1857,7 +1857,7 @@ Matrix::orthogonalize_last(int ncols)
         for (int i = 0; i < d_num_rows; ++i)
             tmp += item(i, col) * item(i, last_col);
 
-        if (d_num_procs > 1)
+        if (d_distributed && d_num_procs > 1)
         {
             MPI_Allreduce(&tmp, &factor, 1, MPI_DOUBLE, MPI_SUM,
                           MPI_COMM_WORLD);
@@ -1877,7 +1877,7 @@ Matrix::orthogonalize_last(int ncols)
     for (int i = 0; i < d_num_rows; ++i)
         tmp += item(i, last_col) * item(i, last_col);
 
-    if (d_num_procs > 1)
+    if (d_distributed && d_num_procs > 1)
     {
         MPI_Allreduce(&tmp, &norm, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
     }

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -947,6 +947,19 @@ public:
     orthogonalize();
 
     /**
+     * @brief Orthonormalizes the matrix's last column, assuming the previous
+	 * columns are already orthonormal.
+	 * 
+	 * By default, the function considers the whole matrix.
+	 * If input parameter ncols < d_num_cols, then a subset of the matrix
+	 * is considered. 
+	 * This allows one to reorthonormalize the matrix every time a new column
+	 * is added, assuming the previous columns have remained unchanged.
+     */
+	void
+	orthogonalize_last(int ncols = -1);
+
+    /**
      * @brief Rescale every matrix row by its maximum absolute value.
      */
     void

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -941,23 +941,33 @@ public:
                           int  pivots_requested) const;
 
     /**
-     * @brief Orthogonalizes the matrix.
+     * @brief Orthonormalizes the matrix.
+     *
+     * If the norm of a matrix column is below the value of zero_tol then it
+     * is considered to be zero, and we do not divide by it.
+     * Therefore, that column is considered to be zero and is not normalized.
+     * By default, zero_tol = 1.0e-15.
      */
     void
-    orthogonalize();
+    orthogonalize(double zero_tol = 1.0e-15);
 
     /**
      * @brief Orthonormalizes the matrix's last column, assuming the previous
      * columns are already orthonormal.
      *
-     * By default, the function considers the whole matrix.
-     * If input parameter ncols < d_num_cols, then a subset of the matrix
+     * By default, ncols == -1, and the function considers the whole matrix.
+     * If ncols != -1 and ncols < d_num_cols, then a subset of the matrix
      * is considered.
      * This allows one to reorthonormalize the matrix every time a new column
      * is added, assuming the previous columns have remained unchanged.
+     *
+     * If the norm of a matrix column is below the value of zero_tol then it
+     * is considered to be zero, and we do not divide by it.
+     * Therefore, that column is considered to be zero and is not normalized.
+     * By default, zero_tol = 1.0e-15.
      */
     void
-    orthogonalize_last(int ncols = -1);
+    orthogonalize_last(int ncols = -1, double zero_tol = 1.0e-15);
 
     /**
      * @brief Rescale every matrix row by its maximum absolute value.

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -948,16 +948,16 @@ public:
 
     /**
      * @brief Orthonormalizes the matrix's last column, assuming the previous
-	 * columns are already orthonormal.
-	 * 
-	 * By default, the function considers the whole matrix.
-	 * If input parameter ncols < d_num_cols, then a subset of the matrix
-	 * is considered. 
-	 * This allows one to reorthonormalize the matrix every time a new column
-	 * is added, assuming the previous columns have remained unchanged.
+     * columns are already orthonormal.
+     *
+     * By default, the function considers the whole matrix.
+     * If input parameter ncols < d_num_cols, then a subset of the matrix
+     * is considered.
+     * This allows one to reorthonormalize the matrix every time a new column
+     * is added, assuming the previous columns have remained unchanged.
      */
-	void
-	orthogonalize_last(int ncols = -1);
+    void
+    orthogonalize_last(int ncols = -1);
 
     /**
      * @brief Rescale every matrix row by its maximum absolute value.

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -566,6 +566,34 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
                 "(i, j) = (" << i << ", " << j << ")";
 }
 
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
+                        0.0, 1.9, 8.3, 0.0,
+                        0.0, 0.0, 5.7, 4.6,
+                        0.0, 0.0, 0.0, 3.2};
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0};
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    for (int i = 0; i < 4; i++)
+        matrix.orthogonalize_last(i+1);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
+                "(i, j) = (" << i << ", " << j << ")";
+}
+
 TEST(MatrixSerialTest, Test_pMatrix_mult_reference)
 {
     /**

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -511,6 +511,61 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
                 "(i, j) = (" << i << ", " << j << ")";
 }
 
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {1.0, 0.0, 0.0, 1.3,
+                        0.0, 1.0, 0.0, 4.7,
+                        0.0, 0.0, 1.0, 2.5,
+                        0.0, 0.0, 0.0, 7.3};
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0};
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize_last();
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
+                "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {1.0, 0.0, 3.8, 1.3,
+                        0.0, 1.0, 5.6, 4.7,
+                        0.0, 0.0, 9.8, 2.5,
+                        0.0, 0.0, 0.0, 7.3};
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0};
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize_last(3);
+    matrix.orthogonalize_last(4);
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
+                "(i, j) = (" << i << ", " << j << ")";
+}
+
 TEST(MatrixSerialTest, Test_pMatrix_mult_reference)
 {
     /**

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -463,13 +463,15 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize)
     double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
                         0.0, 1.9, 8.3, 0.0,
                         0.0, 0.0, 5.7, 4.6,
-                        0.0, 0.0, 0.0, 3.2};
+                        0.0, 0.0, 0.0, 3.2
+                       };
 
     // Target matrix data.
     double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
                          0.0, 1.0, 0.0, 0.0,
                          0.0, 0.0, 1.0, 0.0,
-                         0.0, 0.0, 0.0, 1.0};
+                         0.0, 0.0, 0.0, 1.0
+                        };
 
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
@@ -480,8 +482,8 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize)
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
-            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
-                "(i, j) = (" << i << ", " << j << ")";
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
 }
 
 TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
@@ -490,13 +492,15 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
     double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
                         0.0, 1.9, 8.3, 1e-14,
                         0.0, 0.0, 5.7, 1.0+1.0e-14,
-                        0.0, 0.0, 0.0, 0.0};
+                        0.0, 0.0, 0.0, 0.0
+                       };
 
     // Target matrix data.
     double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
                          0.0, 1.0, 0.0, 0.0,
                          0.0, 0.0, 1.0, 0.0,
-                         0.0, 0.0, 0.0, 0.0};
+                         0.0, 0.0, 0.0, 0.0
+                        };
 
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
@@ -507,8 +511,8 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
-            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
-                "(i, j) = (" << i << ", " << j << ")";
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
 }
 
 TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
@@ -517,13 +521,15 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
     double d_mat[16] = {1.0, 0.0, 0.0, 1.3,
                         0.0, 1.0, 0.0, 4.7,
                         0.0, 0.0, 1.0, 2.5,
-                        0.0, 0.0, 0.0, 7.3};
+                        0.0, 0.0, 0.0, 7.3
+                       };
 
     // Target matrix data.
     double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
                          0.0, 1.0, 0.0, 0.0,
                          0.0, 0.0, 1.0, 0.0,
-                         0.0, 0.0, 0.0, 1.0};
+                         0.0, 0.0, 0.0, 1.0
+                        };
 
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
@@ -534,8 +540,8 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
-            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
-                "(i, j) = (" << i << ", " << j << ")";
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
 }
 
 TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
@@ -544,13 +550,15 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
     double d_mat[16] = {1.0, 0.0, 3.8, 1.3,
                         0.0, 1.0, 5.6, 4.7,
                         0.0, 0.0, 9.8, 2.5,
-                        0.0, 0.0, 0.0, 7.3};
+                        0.0, 0.0, 0.0, 7.3
+                       };
 
     // Target matrix data.
     double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
                          0.0, 1.0, 0.0, 0.0,
                          0.0, 0.0, 1.0, 0.0,
-                         0.0, 0.0, 0.0, 1.0};
+                         0.0, 0.0, 0.0, 1.0
+                        };
 
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
@@ -562,8 +570,8 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
-            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
-                "(i, j) = (" << i << ", " << j << ")";
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
 }
 
 TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
@@ -572,13 +580,15 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
     double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
                         0.0, 1.9, 8.3, 0.0,
                         0.0, 0.0, 5.7, 4.6,
-                        0.0, 0.0, 0.0, 3.2};
+                        0.0, 0.0, 0.0, 3.2
+                       };
 
     // Target matrix data.
     double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
                          0.0, 1.0, 0.0, 0.0,
                          0.0, 0.0, 1.0, 0.0,
-                         0.0, 0.0, 0.0, 1.0};
+                         0.0, 0.0, 0.0, 1.0
+                        };
 
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
@@ -590,8 +600,8 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
-            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
-                "(i, j) = (" << i << ", " << j << ")";
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
 }
 
 TEST(MatrixSerialTest, Test_pMatrix_mult_reference)

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -457,6 +457,60 @@ TEST(MatrixSerialTest, Test_Matrix_rescale_cols_max2)
                     "(i, j) = (" << i << ", " << j << ")";
 }
 
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
+                        0.0, 1.9, 8.3, 0.0,
+                        0.0, 0.0, 5.7, 4.6,
+                        0.0, 0.0, 0.0, 3.2};
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0};
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize();
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
+                "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
+                        0.0, 1.9, 8.3, 1e-14,
+                        0.0, 0.0, 5.7, 1.0+1.0e-14,
+                        0.0, 0.0, 0.0, 0.0};
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 0.0};
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize();
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) << 
+                "(i, j) = (" << i << ", " << j << ")";
+}
+
 TEST(MatrixSerialTest, Test_pMatrix_mult_reference)
 {
     /**


### PR DESCRIPTION
This PR includes two main changes. 

1. Fixes issues in the current `orthogonalize` method of the `Matrix` class.
2. Adds an incremental Gram-Schmidt function `orthogonalize_last`, where only the last column of the input matrix is orthonormalized, assuming the previous columns are already orthonormal. 

The above changes are motivated by applications in the Laghos hydrodynamics code.