### PR TITLE
Update Dockerfile for ARM

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,4 +65,5 @@ jobs:
           push: true
           context: ${{ env.DOCKERPATH }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,8 +56,9 @@ jobs:
           cat ${{env.DOCKERPATH}}/motd.sh
       - name: Docker Image - Build and push
         if: env.CI_NEEDS_REBUILD
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           context: ${{ env.DOCKERPATH }}
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,9 +17,13 @@ jobs:
     steps:
       - name: test command
         run: echo "docker-ci command"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - uses: Ana06/get-changed-files@v2.2.0       
         id: files
       - name: DockerPATH configuration
@@ -31,7 +35,7 @@ jobs:
           echo "CI_NEEDS_REBUILD=true" >> $GITHUB_ENV
       - name: Log into registry ${{ env.REGISTRY }}
         if: env.CI_NEEDS_REBUILD
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -125,6 +125,7 @@ set(CMAKE_CXX_COMPILER mpicxx)\n\
 set(CMAKE_Fortran_COMPILER mpif90)\n\
 set(LIB_DIR /env/dependencies)\n\
 set(MFEM_DIR ${LIB_DIR}/mfem)\n\
+set(MFEM_INCLUDES ${MFEM_DIR})\n\
 set(HYPRE_DIR ${LIB_DIR}/hypre/src/hypre)\n\
 set(PARMETIS_DIR ${LIB_DIR}/parmetis-4.0.3/build/lib/libparmetis)\n\
 set(METIS_DIR ${LIB_DIR}/parmetis-4.0.3/build/lib/libmetis)' > ./librom_env.cmake
@@ -136,6 +137,7 @@ ENV USE_MFEM=On
 ENV MFEM_USE_GSLIB=On
 ENV MFEM_DIR=$LIB_DIR/mfem
 ENV HYPRE_DIR=$LIB_DIR/hypre/src/hypre
+ENV MFEM_INCLUDES=${MFEM_DIR}
 ENV PARMETIS_DIR=$LIB_DIR/parmetis-4.0.3/build/lib/libparmetis
 ENV METIS_DIR=$LIB_DIR/parmetis-4.0.3/build/lib/libmetis
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,8 +75,7 @@ ENV METIS_OPT=-I${METIS_DIR}/metis/include
 WORKDIR ${METIS_DIR}/build
 # Currently docker cannot save command results to environment variables.
 # These variables are for libROM build.
-ENV MACHINE_ARCH=Linux-x86_64
-RUN ln -s $MACHINE_ARCH lib
+RUN arch=$(uname -m) && ln -s Linux-${arch} lib
 WORKDIR ${METIS_DIR}/build/lib/libparmetis
 RUN ln -s ./ lib
 RUN ln -s ${METIS_DIR}/metis metis


### PR DESCRIPTION
This updates the Dockerfile to use the appropriate machine architecture when building parmetis. This should fix issues creating the docker image on ARM platforms.

### CI workflow for multi-platform docker image building
CI workflow `docker-image` now builds the docker image to support multiple platforms: `amd64` (also known as x86-64) and `arm64`.
This, however, significantly lengthen the building time as it attempts to build the image on the non-host-architecture (which is `amd64`).
Mainly it was to support multiple architectures in an automatic way. However, this slow-down is a significant drawback for fast development and integration. Therefore, building image for `arm64` is disabled for now.

Docker image for `arm64` architecture will be pushed to `ghcr.io/llnl/librom/librom_env:arm64` occasionally.