### PR TITLE
Fix readthedocs doxygen documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_build:
+      - mv $READTHEDOCS_OUTPUT/html/doxygen/* $READTHEDOCS_OUTPUT/html/
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -33,9 +33,17 @@ if read_the_docs_build:
     from subprocess import call
     call('cd ../.. ; doxygen docs/Doxyfile', shell=True)
 
-    html_extra_path = ['../build/html']
+    # Move doxygen documentation to a subfolder
+    call('mkdir ../build/temp', shell=True)
+    call('mkdir ../build/temp/doxygen', shell=True)
+    call('mv ../build/html/* ../build/temp/doxygen', shell=True)
 
+    # Copy doxygen subfolder to root
+    html_extra_path = ['../build/temp']
 
+    # The subfolder is copied to the root after the build completes in
+    # the .readthedocs.yaml file
+    
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Sphinx documentation is overwriting the doxygen documentation's `index.html` in the latest readthedocs site.  This PR fixes the issue by
- writing the doxygen documentation to a temporary directory (see `conf.py`)
- moving the contents of the temporary directory to the root after the readthedocs build command has been run (see `.readthedocs.yaml`)