### PR TITLE
Add timing info to DG local advection prom example

### DIFF
--- a/examples/prom/dg_advection_local_rom_matrix_interp.cpp
+++ b/examples/prom/dg_advection_local_rom_matrix_interp.cpp
@@ -1042,18 +1042,11 @@ int main(int argc, char *argv[])
     // 13. print timing info
     if (myid == 0)
     {
-        if (fom || offline)
-        {
-            printf("Elapsed time for assembling FOM: %e second\n",
-                   assemble_timer.RealTime());
-            printf("Elapsed time for solving FOM: %e second\n", fom_timer.RealTime());
-        }
-        if (online)
-        {
-            printf("Elapsed time for assembling ROM: %e second\n",
-                   assemble_timer.RealTime());
-            printf("Elapsed time for solving ROM: %e second\n", fom_timer.RealTime());
-        }
+        const std::string type = online ? "ROM" : "FOM";
+        std::cout << "Elapsed time for assembling " << type << ": " << std::scientific
+                  << std::setprecision(8) << assemble_timer.RealTime() << " second\n";
+        std::cout << "Elapsed time for solving " << type << ": " << std::scientific <<
+                  std::setprecision(8) << fom_timer.RealTime() << " second\n";
     }
 
     // 16. Free the used memory.

--- a/examples/prom/dg_advection_local_rom_matrix_interp.cpp
+++ b/examples/prom/dg_advection_local_rom_matrix_interp.cpp
@@ -809,14 +809,11 @@ int main(int argc, char *argv[])
             std::vector<CAROM::Matrix*> M_hats;
             std::vector<CAROM::Vector*> b_hats;
             std::vector<CAROM::Vector*> u_init_hats;
-            std::ofstream fout;
-            fout.open("frequencies.txt");
             for(auto it = frequencies.begin(); it != frequencies.end(); it++)
             {
                 CAROM::Vector* point = new CAROM::Vector(1, false);
                 point->item(0) = *it;
                 parameter_points.push_back(point);
-                fout << *it << std::endl;
 
                 std::string parametricBasisName = "basis_" + std::to_string(*it);
                 CAROM::BasisReader reader(parametricBasisName);
@@ -843,7 +840,6 @@ int main(int argc, char *argv[])
                 parametricuinithat->read("u_init_hat_" + std::to_string(*it));
                 u_init_hats.push_back(parametricuinithat);
             }
-            fout.close();
             if (myid == 0) printf("spatial basis dimension is %d x %d\n", numRowRB,
                                       numColumnRB);
 

--- a/examples/prom/dg_advection_local_rom_matrix_interp.cpp
+++ b/examples/prom/dg_advection_local_rom_matrix_interp.cpp
@@ -32,7 +32,7 @@
 //    dg_advection_local_rom_matrix_interp -interp_prep -ff 1.08 -rdim 40
 //    dg_advection_local_rom_matrix_interp -fom -ff 1.05
 //    dg_advection_local_rom_matrix_interp -online_interp -ff 1.05 -rdim 40 (interpolate using a linear solve)
-//    dg_advection_local_rom_matrix_interp -online_interp -ff 1.05 -rdim 40 -im "LP" (interpolate using lagragian polynomials)
+//    dg_advection_local_rom_matrix_interp -online_interp -ff 1.05 -rdim 40 -im "LP" (interpolate using lagrangian polynomials)
 //    dg_advection_local_rom_matrix_interp -online_interp -ff 1.05 -rdim 40 -im "IDW" (interpolate using inverse distance weighting)
 //
 // Sample runs:


### PR DESCRIPTION
This adds a final print statement for the FOM/ROM timings at the end of the DG local advection example prom. A timer for the assemble phase was missing, so that was also added to be consistent with the other examples.

This also fixes an issue when this example is run in parallel with the `-online_interp` option. This issue can be reproduced by running the following commands.
```
mpirun -np 2 ./dg_advection_local_rom_matrix_interp --mesh "../data/periodic-square.mesh" -offline -rs 4 -ff 1.02
mpirun -np 2 ./dg_advection_local_rom_matrix_interp --mesh "../data/periodic-square.mesh" -interp_prep -rs 4 -ff 1.02 -rdim 40
mpirun -np 2 ./dg_advection_local_rom_matrix_interp --mesh "../data/periodic-square.mesh" -offline -rs 4 -ff 1.08
mpirun -np 2 ./dg_advection_local_rom_matrix_interp --mesh "../data/periodic-square.mesh" -interp_prep -rs 4 -ff 1.08 -rdim 40
mpirun -np 2 ./dg_advection_local_rom_matrix_interp --mesh "../data/periodic-square.mesh" -fom -rs 4 -ff 1.05
mpirun -np 2 ./dg_advection_local_rom_matrix_interp --mesh "../data/periodic-square.mesh" -online_interp -rs 4 -ff 1.05 -rdim 40
```