### PR TITLE
Double pass Gram-Schmidt methods

### DIFF
--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1830,28 +1830,32 @@ Matrix::orthogonalize(double zero_tol)
 }
 
 void
-Matrix::orthogonalize_last(int ncols, double zero_tol)
+Matrix::orthogonalize_last(int ncols, bool double_pass, double zero_tol)
 {
     if (ncols == -1) ncols = d_num_cols;
     CAROM_VERIFY((ncols > 0) && (ncols <= d_num_cols));
 
     const int last_col = ncols - 1; // index of column to be orthonormalized
 
-    // Orthogonalize the column.
-    for (int col = 0; col < last_col; ++col)
+    // Orthogonalize the column (twice if double_pass == true).
+    for (int k = 0; k < 2; k++)
     {
-        double factor = 0.0;
-
-        for (int i = 0; i < d_num_rows; ++i)
-            factor += item(i, col) * item(i, last_col);
-
-        if (d_distributed && d_num_procs > 1)
+        for (int col = 0; col < last_col; ++col)
         {
-            CAROM_VERIFY( MPI_Allreduce(MPI_IN_PLACE, &factor, 1, MPI_DOUBLE,
-                                        MPI_SUM, MPI_COMM_WORLD) == MPI_SUCCESS );
+            double factor = 0.0;
+
+            for (int i = 0; i < d_num_rows; ++i)
+                factor += item(i, col) * item(i, last_col);
+
+            if (d_distributed && d_num_procs > 1)
+            {
+                CAROM_VERIFY( MPI_Allreduce(MPI_IN_PLACE, &factor, 1, MPI_DOUBLE,
+                                            MPI_SUM, MPI_COMM_WORLD) == MPI_SUCCESS );
+            }
+            for (int i = 0; i < d_num_rows; ++i)
+                item(i, last_col) -= factor * item(i, col);
         }
-        for (int i = 0; i < d_num_rows; ++i)
-            item(i, last_col) -= factor * item(i, col);
+        if (!double_pass) break;
     }
 
     // Normalize the column.

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1790,10 +1790,12 @@ const
 void
 Matrix::orthogonalize(bool double_pass, double zero_tol)
 {
+    int const num_passes = double_pass ? 2 : 1;
+
     for (int work = 0; work < d_num_cols; ++work)
     {
         // Orthogonalize the column (twice if double_pass == true).
-        for (int k = 0; k < 2; k++)
+        for (int k = 0; k < num_passes; k++)
         {
             for (int col = 0; col < work; ++col)
             {
@@ -1812,7 +1814,6 @@ Matrix::orthogonalize(bool double_pass, double zero_tol)
                 for (int i = 0; i < d_num_rows; ++i)
                     item(i, work) -= factor * item(i, col);
             }
-            if (!double_pass) break;
         }
 
         // Normalize the column.
@@ -1844,8 +1845,10 @@ Matrix::orthogonalize_last(int ncols, bool double_pass, double zero_tol)
 
     const int last_col = ncols - 1; // index of column to be orthonormalized
 
+    int const num_passes = double_pass ? 2 : 1;
+
     // Orthogonalize the column (twice if double_pass == true).
-    for (int k = 0; k < 2; k++)
+    for (int k = 0; k < num_passes; k++)
     {
         for (int col = 0; col < last_col; ++col)
         {
@@ -1857,12 +1860,12 @@ Matrix::orthogonalize_last(int ncols, bool double_pass, double zero_tol)
             if (d_distributed && d_num_procs > 1)
             {
                 CAROM_VERIFY( MPI_Allreduce(MPI_IN_PLACE, &factor, 1, MPI_DOUBLE,
-                                            MPI_SUM, MPI_COMM_WORLD) == MPI_SUCCESS );
+                                            MPI_SUM, MPI_COMM_WORLD)
+                              == MPI_SUCCESS );
             }
             for (int i = 0; i < d_num_rows; ++i)
                 item(i, last_col) -= factor * item(i, col);
         }
-        if (!double_pass) break;
     }
 
     // Normalize the column.

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -946,7 +946,7 @@ public:
      * If the norm of a matrix column is below the value of zero_tol then it
      * is considered to be zero, and we do not divide by it.
      * Therefore, that column is considered to be zero and is not normalized.
-     * By default, zero_tol = 1.0e-15.
+     * By default, zero_tol == 1.0e-15.
      */
     void
     orthogonalize(double zero_tol = 1.0e-15);
@@ -961,13 +961,18 @@ public:
      * This allows one to reorthonormalize the matrix every time a new column
      * is added, assuming the previous columns have remained unchanged.
      *
+     * If double_pass == true, then the column is orthogonalized twice to
+     * limit loss of orthogonality due to numerical errors.
+     * By default, double_pass == false.
+     *
      * If the norm of a matrix column is below the value of zero_tol then it
      * is considered to be zero, and we do not divide by it.
      * Therefore, that column is considered to be zero and is not normalized.
-     * By default, zero_tol = 1.0e-15.
+     * By default, zero_tol == 1.0e-15.
      */
     void
-    orthogonalize_last(int ncols = -1, double zero_tol = 1.0e-15);
+    orthogonalize_last(int ncols = -1, bool double_pass = false,
+                       double zero_tol = 1.0e-15);
 
     /**
      * @brief Rescale every matrix row by its maximum absolute value.

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -943,13 +943,19 @@ public:
     /**
      * @brief Orthonormalizes the matrix.
      *
+     * The method uses the modified Gram-Schmidt algorithm.
+     *
+     * If double_pass == true, then each column is orthogonalized twice to
+     * limit loss of orthogonality due to numerical errors.
+     * By default, double_pass == false.
+     *
      * If the norm of a matrix column is below the value of zero_tol then it
      * is considered to be zero, and we do not divide by it.
      * Therefore, that column is considered to be zero and is not normalized.
      * By default, zero_tol == 1.0e-15.
      */
     void
-    orthogonalize(double zero_tol = 1.0e-15);
+    orthogonalize(bool double_pass = false, double zero_tol = 1.0e-15);
 
     /**
      * @brief Orthonormalizes the matrix's last column, assuming the previous

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -490,6 +490,35 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
 {
     // Matrix data to orthonormalize.
     double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
+                        0.0, 1.9, 8.3, 0.0,
+                        0.0, 0.0, 5.7, 4.6,
+                        0.0, 0.0, 0.0, 3.2
+                       };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize(true);
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize3)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
                         0.0, 1.9, 8.3, 1e-14,
                         0.0, 0.0, 5.7, 1.0+1.0e-14,
                         0.0, 0.0, 0.0, 0.0
@@ -508,6 +537,35 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
     double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize();
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize4)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
+                        0.0, 1.9, 8.3, 1e-14,
+                        0.0, 0.0, 5.7, 1.0+1.0e-14,
+                        0.0, 0.0, 0.0, 0.0
+                       };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 0.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize(true);
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
@@ -547,6 +605,35 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
 TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
 {
     // Matrix data to orthonormalize.
+    double d_mat[16] = {1.0, 0.0, 0.0, 1.3,
+                        0.0, 1.0, 0.0, 4.7,
+                        0.0, 0.0, 1.0, 2.5,
+                        0.0, 0.0, 0.0, 7.3
+                       };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize_last(-1, true);
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
+{
+    // Matrix data to orthonormalize.
     double d_mat[16] = {1.0, 0.0, 3.8, 1.3,
                         0.0, 1.0, 5.6, 4.7,
                         0.0, 0.0, 9.8, 2.5,
@@ -574,7 +661,37 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
                     "(i, j) = (" << i << ", " << j << ")";
 }
 
-TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last4)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {1.0, 0.0, 3.8, 1.3,
+                        0.0, 1.0, 5.6, 4.7,
+                        0.0, 0.0, 9.8, 2.5,
+                        0.0, 0.0, 0.0, 7.3
+                       };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize_last(3, true);
+    matrix.orthogonalize_last(4, true);
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last5)
 {
     // Matrix data to orthonormalize.
     double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
@@ -595,6 +712,36 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
 
     for (int i = 0; i < 4; i++)
         matrix.orthogonalize_last(i+1);
+
+    double abs_error = 1.0e-15; // absolute error threshold
+
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
+                    "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last6)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[16] = {3.5, 7.1, 0.0, 0.0,
+                        0.0, 1.9, 8.3, 0.0,
+                        0.0, 0.0, 5.7, 4.6,
+                        0.0, 0.0, 0.0, 3.2
+                       };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 4, 4, false);
+    CAROM::Matrix target(d_mat2, 4, 4, false);
+
+    for (int i = 0; i < 4; i++)
+        matrix.orthogonalize_last(i+1, true);
 
     double abs_error = 1.0e-15; // absolute error threshold
 

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -476,7 +476,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize();
 
@@ -505,7 +505,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize2)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize(true);
 
@@ -534,7 +534,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize3)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize();
 
@@ -563,7 +563,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize4)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize(true);
 
@@ -592,7 +592,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize_last();
 
@@ -621,7 +621,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last2)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize_last(-1, true);
 
@@ -650,7 +650,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last3)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize_last(3);
     matrix.orthogonalize_last(4);
@@ -680,7 +680,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last4)
     CAROM::Matrix matrix(d_mat, 4, 4, false);
     CAROM::Matrix target(d_mat2, 4, 4, false);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     matrix.orthogonalize_last(3, true);
     matrix.orthogonalize_last(4, true);
@@ -713,7 +713,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last5)
     for (int i = 0; i < 4; i++)
         matrix.orthogonalize_last(i+1);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
@@ -743,7 +743,7 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last6)
     for (int i = 0; i < 4; i++)
         matrix.orthogonalize_last(i+1, true);
 
-    double abs_error = 1.0e-15; // absolute error threshold
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)

--- a/unit_tests/test_Matrix.cpp
+++ b/unit_tests/test_Matrix.cpp
@@ -12,6 +12,7 @@
 // Framework to run unit tests on the CAROM::Matrix class.
 
 #include <iostream>
+#include <cmath>
 
 #ifdef CAROM_HAS_GTEST
 #include<gtest/gtest.h>
@@ -573,6 +574,37 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize4)
                     "(i, j) = (" << i << ", " << j << ")";
 }
 
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize5)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[4] = {0.70000, 0.70711,
+                       0.70001, 0.70711
+                      };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0,
+                         0.0, 1.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 2, 2, false);
+    CAROM::Matrix target(d_mat2, 2, 2, false);
+
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize(true);
+
+    CAROM::Matrix result(2, 2, false);
+    matrix.transposeMult(matrix, result);
+
+    double norm2 = 0.0;
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            norm2 += std::pow(result.item(i, j) - target.item(i, j), 2);
+
+    norm2 = std::sqrt(norm2);
+    EXPECT_TRUE(norm2 < abs_error) << norm2 << " > " << abs_error;
+}
+
 TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last)
 {
     // Matrix data to orthonormalize.
@@ -749,6 +781,37 @@ TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last6)
         for (int j = 0; j < 4; j++)
             EXPECT_NEAR(matrix.item(i, j), target.item(i, j), abs_error) <<
                     "(i, j) = (" << i << ", " << j << ")";
+}
+
+TEST(MatrixSerialTest, Test_Matrix_orthogonalize_last7)
+{
+    // Matrix data to orthonormalize.
+    double d_mat[4] = {0.7071017304418633, 0.70711,
+                       0.7071118318951554, 0.70711
+                      };
+
+    // Target matrix data.
+    double d_mat2[16] = {1.0, 0.0,
+                         0.0, 1.0
+                        };
+
+    CAROM::Matrix matrix(d_mat, 2, 2, false);
+    CAROM::Matrix target(d_mat2, 2, 2, false);
+
+    constexpr double abs_error = 1.0e-15; // absolute error threshold
+
+    matrix.orthogonalize_last(2, true);
+
+    CAROM::Matrix result(2, 2, false);
+    matrix.transposeMult(matrix, result);
+
+    double norm2 = 0.0;
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            norm2 += std::pow(result.item(i, j) - target.item(i, j), 2);
+
+    norm2 = std::sqrt(norm2);
+    EXPECT_TRUE(norm2 < abs_error) << norm2 << " > " << abs_error;
 }
 
 TEST(MatrixSerialTest, Test_pMatrix_mult_reference)


### PR DESCRIPTION
Adds the option of reorthogonalizing each column of the input matrix to the `orthogonalize()` and `orthogonalize_last()` methods of the `Matrix` class. 

The option is added as an input argument which is false by default, thereby not affecting the methods' default behavior. The only change to the existing code is that the orthogonalizing part of the methods is run twice for each column, if the double pass option is true. 

Both the classical and modified Gram-Schmidt numerical algorithms are prone to loss of orthogonality, which can result in output matrices that deviate significantly from being orthonormal. Orthogonalizing each column twice has been shown to mitigate this issue, see [Giraud, Langou & Rozloznik (2005)](https://doi.org/10.1016/j.camwa.2005.08.009).

Adding the double-pass option is motivated by its use in LaghosROM, where it's been found to successfully address the loss of orthogonality issue, improving accuracy.  