### PR TITLE
scalapack bug fix for factorize

### DIFF
--- a/lib/linalg/scalapack_f_wrapper.f90
+++ b/lib/linalg/scalapack_f_wrapper.f90
@@ -534,8 +534,9 @@ subroutine correct_svd_workarray_size(A, desca, descu, descv, dou, dov, work)
     lwmin = 1.0 + 6.0 * sizeb + MAX(watobd, wbdtosvd)
 
     if (size(work) < lwmin) then
-        print *, 'SVD Warning: MPI_COMM_WORLD rank ', mrank, ' work array size is smaller than needed.', &
-                 'Probably an integer overflow happened in scalapack pdgesvd.'
+        write(*, *) 'MPI_COMM_WORLD rank: ', mrank, ' size(work): ', size(work), ' lwmin: ', lwmin
+        write(*, *) 'SVD Warning: work array size is smaller than needed. ',        &
+                    'Probably an integer overflow happened in scalapack pdgesvd.'
         deallocate(work)
         allocate(work(int(lwmin + 1, selected_int_kind(16))))
     end if


### PR DESCRIPTION
The scalapack routine `pdgesvd` performs a workspace query at its initial call in `factorize` in `lib/linalg/scalapack_f_wrapper.f90`, where it returns the required size of working array. If the size exceeds `1e9`, then an overflow occurs and the returned value can be invalid. 

The fortran routine `correct_svd_workarray_size` copied the size calculation part of scalapack `pdgesvd`, and computes the size as double in order to avoid the overflow. This routine is called in `factorize`, where it returns a warning message and resize the working array if the size seems to have experienced an overflow.