### PR TITLE
A fix for StaticSVD::ComputeSVD to preserve snapshots

### DIFF
--- a/lib/linalg/Options.h
+++ b/lib/linalg/Options.h
@@ -345,6 +345,11 @@ public:
      *        incremental SVD algorithm.
      */
     double max_sampling_time_step_scale = 5.0;
+
+    /**
+     * @brief Option to preserve snapshot in StaticSVD::computeSVD.
+     */
+    bool static_svd_preserve_snapshot = false;
 };
 
 }

--- a/lib/linalg/svd/StaticSVD.cpp
+++ b/lib/linalg/svd/StaticSVD.cpp
@@ -236,7 +236,8 @@ const Matrix*
 StaticSVD::getSnapshotMatrix()
 {
     if ((!d_preserve_snapshot) && (thisIntervalBasisCurrent()) && (d_basis != 0))
-        CAROM_ERROR("StaticSVD: snapshot matrix is modified after computeSVD. To preserve the snapshots, set Options::static_svd_preserve_snapshot to be true!\n");
+        CAROM_ERROR("StaticSVD: snapshot matrix is modified after computeSVD."
+                    " To preserve the snapshots, set Options::static_svd_preserve_snapshot to be true!\n");
 
     if (d_snapshots) delete d_snapshots;
     d_snapshots = new Matrix(d_dim, d_num_samples, false);

--- a/lib/linalg/svd/StaticSVD.h
+++ b/lib/linalg/svd/StaticSVD.h
@@ -244,6 +244,11 @@ private:
     StaticSVD&
     operator = (
         const StaticSVD& rhs);
+
+    /**
+     * @brief option to preserve snapshot in computeSVD.
+     */
+    bool d_preserve_snapshot;
 };
 
 }


### PR DESCRIPTION
`StaticSVD::ComputeSVD` performs SVD using scalapack's `pdgesvd`, which does not preserve the original snapshot matrix. This can be a potential source of error when running `BasisGenerator::getSnapshotMatrix` after SVD operation (`BasisGenerator::endSamples()`).

`StaticSVD` now has an option to preserve the snapshot. This option is driven by the `bool` option `Options::static_svd_preserve_snapshot`. 

If snapshot preserving option is false, `StaticSVD::computeSVD` uses the original `d_samples` as before, modifying the matrix. `StaticSVD::getSnapshotMatrix` after svd operation will return an error, so that users would not use the modified snapshot matrix.

If snapshot preserving option is true, `StaticSVD::computeSVD` copies from `d_samples` into `snapshot_matrix` either transposed or original, and use `snapshot_matrix` as working matrix for SVD operation, preserving the original snapshot matrix `d_samples`. The working matrix `snapshot_matrix` is destroyed at the end of the function call.