### PR TITLE
Add source code links in Doxygen

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1119,7 +1119,7 @@ USE_MDFILE_AS_MAINPAGE = README.md
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.


### PR DESCRIPTION
This updates the Doxygen configuration to add source code hyperlinks from the documentation.