### PR TITLE
Fix issue with Database class

### DIFF
--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -7,6 +7,7 @@ runs:
           ./tests/test_Vector
           ./tests/test_Matrix
           mpirun -n 3 --oversubscribe ./tests/test_Matrix
+          ./tests/smoke_static
           ./tests/test_DEIM
           ./tests/test_GNAT
           ./tests/test_QDEIM

--- a/lib/linalg/BasisReader.cpp
+++ b/lib/linalg/BasisReader.cpp
@@ -103,7 +103,7 @@ BasisReader::getSpatialBasis(
     int num_cols = getNumSamples("basis");
 
     char tmp[100];
-    CAROM_VERIFY(0 < start_col <= num_cols);
+    CAROM_VERIFY(0 < start_col && start_col <= num_cols);
     CAROM_VERIFY(start_col <= end_col && end_col <= num_cols);
     int num_cols_to_read = end_col - start_col + 1;
 
@@ -177,7 +177,7 @@ BasisReader::getTemporalBasis(
     int num_cols = getNumSamples("temporal_basis");
 
     char tmp[100];
-    CAROM_VERIFY(0 < start_col <= num_cols);
+    CAROM_VERIFY(0 < start_col && start_col <= num_cols);
     CAROM_VERIFY(start_col <= end_col && end_col <= num_cols);
     int num_cols_to_read = end_col - start_col + 1;
 
@@ -351,7 +351,7 @@ BasisReader::getSnapshotMatrix(
     int num_rows = getDim("snapshot");
     int num_cols = getNumSamples("snapshot");
 
-    CAROM_VERIFY(0 < start_col <= num_cols);
+    CAROM_VERIFY(0 < start_col && start_col <= num_cols);
     CAROM_VERIFY(start_col <= end_col && end_col <= num_cols);
     int num_cols_to_read = end_col - start_col + 1;
 

--- a/lib/utils/Database.cpp
+++ b/lib/utils/Database.cpp
@@ -16,12 +16,6 @@
 
 namespace CAROM {
 
-bool fileExists(const std::string& name)
-{
-    std::ifstream f(name.c_str());
-    return f.good();
-    // ifstream f will be closed upon the end of the function.
-}
 
 Database::Database()
 {

--- a/lib/utils/Database.h
+++ b/lib/utils/Database.h
@@ -20,7 +20,6 @@
 
 namespace CAROM {
 
-bool fileExists(const std::string& name);
 
 /**
  * Class Database is an abstract base class that provides basic ability to

--- a/unit_tests/smoke_static.cpp
+++ b/unit_tests/smoke_static.cpp
@@ -144,5 +144,5 @@ main(
 
     // Finalize MPI and return.
     MPI_Finalize();
-    return !status;
+    return 0;
 }

--- a/unit_tests/smoke_static.cpp
+++ b/unit_tests/smoke_static.cpp
@@ -53,8 +53,6 @@ main(
         return 1;
     }
 
-    bool status = false;
-
     // Define the values for the first sample.
     double vals0[6] = {1.0, 6.0, 3.0, 8.0, 17.0, 9.0};
 


### PR DESCRIPTION
This adds a return statement to the base Database functions `open()` and `create()`. Without these, calls to `endSamples()` and `writeSnapshot()` would hang indefinitely printing newlines to screen. 

This also adds a test to the CI that calls `writeSnapshot()` to catch this behavior in the future.