### PR TITLE
Add varying rdim for DMD time windowing

### DIFF
--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -533,26 +533,33 @@ int main(int argc, char *argv[])
 
         for (int window = 0; window < numWindows; ++window)
         {
-            if (rdim != -1 || use_rdim_windows)
+            if (window_list.size() > 0)
             {
-                int window_rdim = use_rdim_windows ? window_list[window] : rdim;
+                if (use_rdim_windows) {
+                    rdim = window_list[window];
+                } else {
+                    ef = window_list[window];
+                }
+            }
+
+            if (rdim != -1)
+            {
                 if (myid == 0)
                 {
-                    cout << "Creating DMD model #" << window << " with rdim: " << window_rdim <<
+                    cout << "Creating DMD model #" << window << " with rdim: " << rdim <<
                          endl;
                 }
-                CAROM_VERIFY(window_rdim <= windowNumSamples);
-                dmd[window]->train(window_rdim);
+                CAROM_VERIFY(rdim <= windowNumSamples);
+                dmd[window]->train(rdim);
             }
-            else if (ef != -1 || window_list.size() > 0)
+            else if (ef != -1)
             {
-                double window_ef = window_list.size() > 0 ? window_list[window] : ef;
                 if (myid == 0)
                 {
                     cout << "Creating DMD model #" << window << " with energy fraction: "
-                         << window_ef << endl;
+                         << ef << endl;
                 }
-                dmd[window]->train(window_ef);
+                dmd[window]->train(ef);
             }
             dmd[window]->save(outputPath + "/window" + to_string(window));
             if (myid == 0)

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -211,48 +211,6 @@ int main(int argc, char *argv[])
         db = new CAROM::HDFDatabase();
     }
 
-    // Load window RDIM/EF file if given
-    vector<string> window_str_list;
-    vector<double> window_list;
-    bool use_rdim_windows = false;
-    csv_db.getStringVector(string(list_dir) + "/" + string(window_file) + ".csv",
-                           window_str_list, false);
-    if (window_str_list.size() > 0)
-    {
-        if (numWindows > 0)
-        {
-            CAROM_VERIFY(numWindows == window_str_list.size() - 1);
-        }
-
-        if (window_str_list[0] == "RDIM")
-        {
-            use_rdim_windows = true;
-        }
-
-        CAROM_VERIFY(window_str_list[0] == "RDIM" || window_str_list[0] == "EF");
-
-        for (int i = 1; i < window_str_list.size(); i++)
-        {
-            std::string tmp;
-            std::stringstream window_ss(window_str_list[i]);
-            getline(window_ss, tmp, ',');
-            getline(window_ss, tmp, ',');
-            window_list.push_back(stod(tmp));
-        }
-
-        numWindows = window_list.size();
-
-        if (myid == 0)
-        {
-            std::cout << "Read window file with " << window_list.size() << " windows:\n";
-            for (int i = 0; i < window_list.size(); i++)
-            {
-                std::cout << "  Window " << i << ": " << (use_rdim_windows ? "RDIM = " :
-                          "EF = ") << window_list[i] << "\n";
-            }
-        }
-    }
-
     string variable = string(var_name);
     int nelements = 0;
 
@@ -310,6 +268,48 @@ int main(int argc, char *argv[])
             {
                 cout << "Read indicator range partition with " << numWindows
                      << " windows." << endl;
+            }
+        }
+    }
+
+    // Load window RDIM/EF file if given
+    vector<string> window_str_list;
+    vector<double> window_list;
+    bool use_rdim_windows = false;
+    csv_db.getStringVector(string(list_dir) + "/" + string(window_file) + ".csv",
+                           window_str_list, false);
+    if (window_str_list.size() > 0)
+    {
+        if (numWindows > 0)
+        {
+            CAROM_VERIFY(numWindows == window_str_list.size() - 1);
+        }
+
+        if (window_str_list[0] == "RDIM")
+        {
+            use_rdim_windows = true;
+        }
+
+        CAROM_VERIFY(window_str_list[0] == "RDIM" || window_str_list[0] == "EF");
+
+        for (int i = 1; i < window_str_list.size(); i++)
+        {
+            std::string tmp;
+            std::stringstream window_ss(window_str_list[i]);
+            getline(window_ss, tmp, ',');
+            getline(window_ss, tmp, ',');
+            window_list.push_back(stod(tmp));
+        }
+
+        numWindows = window_list.size();
+
+        if (myid == 0)
+        {
+            std::cout << "Read window file with " << window_list.size() << " windows:\n";
+            for (int i = 0; i < window_list.size(); i++)
+            {
+                std::cout << "  Window " << i << ": " << (use_rdim_windows ? "RDIM = " :
+                          "EF = ") << window_list[i] << "\n";
             }
         }
     }

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -54,6 +54,7 @@
 #include "linalg/Matrix.h"
 #include "utils/HDFDatabase.h"
 #include "utils/CSVDatabase.h"
+#include "utils/Utilities.h"
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -100,7 +101,7 @@ int main(int argc, char *argv[])
     const char *test_list = "dmd_test";
     const char *temporal_idx_list = "temporal_idx";
     const char *spatial_idx_list = "spatial_idx";
-    const char *window_file = "dmd_windows";
+    const char *window_file = "";
     const char *hdf_name = "dmd.hdf";
     const char *snap_pfx = "step";
     const char *basename = "";
@@ -151,7 +152,8 @@ int main(int argc, char *argv[])
     args.AddOption(&spatial_idx_list, "-x-idx", "--spatial-index",
                    "Name of the file indicating spatial indices.");
     args.AddOption(&window_file, "-window-set", "--window-set-name",
-                   "Name of the file containing a rdim/ef list for each window within the list directory.");
+                   "Name of the file containing a rdim/ef list for each window"
+                   " within the list directory.");
     args.AddOption(&snap_pfx, "-snap-pfx", "--snapshot-prefix",
                    "Prefix of snapshots.");
     args.AddOption(&basename, "-o", "--outputfile-name",
@@ -276,10 +278,19 @@ int main(int argc, char *argv[])
     vector<string> window_str_list;
     vector<double> window_list;
     bool use_rdim_windows = false;
-    csv_db.getStringVector(string(list_dir) + "/" + string(window_file) + ".csv",
-                           window_str_list, false);
-    if (window_str_list.size() > 0)
+    if (string(window_file).size() > 0)
     {
+        const string window_file_path = string(list_dir) + "/" +
+                                        string(window_file) + ".csv";
+        if (!CAROM::Utilities::file_exist(window_file_path))
+        {
+            throw std::runtime_error(string("Specified window rdim/ef file, but file '" +
+                                            window_file_path + "' does not exist!"));
+        }
+        csv_db.getStringVector(window_file_path, window_str_list, false);
+
+        CAROM_VERIFY(window_str_list.size() > 0);
+
         if (numWindows > 0)
         {
             CAROM_VERIFY(numWindows == window_str_list.size() - 1);
@@ -298,7 +309,16 @@ int main(int argc, char *argv[])
             std::stringstream window_ss(window_str_list[i]);
             getline(window_ss, tmp, ',');
             getline(window_ss, tmp, ',');
-            window_list.push_back(stod(tmp));
+            double window_rdim_ef = stod(tmp);
+            if (use_rdim_windows)
+            {
+                CAROM_VERIFY(int(window_rdim_ef) > 0);
+            }
+            else
+            {
+                CAROM_VERIFY(window_rdim_ef > 0.0 && window_rdim_ef <= 1.0);
+            }
+            window_list.push_back(window_rdim_ef);
         }
 
         numWindows = window_list.size();

--- a/examples/dmd/local_tw_csv.cpp
+++ b/examples/dmd/local_tw_csv.cpp
@@ -293,12 +293,9 @@ int main(int argc, char *argv[])
     vector<double> indicator_val;
     if (!train || numWindows > 0)
     {
-        int indicator_val_size = 0;
-        db->getInteger("indicator_val_size", indicator_val_size);
-        indicator_val.resize(indicator_val_size);
-        db->getDoubleArray(string(outputPath) + "/indicator_val.csv",
-                           indicator_val.data(),
-                           indicator_val_size);
+        csv_db.getDoubleVector(string(outputPath) + "/indicator_val.csv", indicator_val,
+                               false);
+
         if (indicator_val.size() > 0)
         {
             if (numWindows > 0)


### PR DESCRIPTION
This adds an option to the DMD time windowing examples `local_tw_csv` and `parametric_tw_csv` for specifying an additional input file containing a reduced dimension or energy fraction value for each window, rather than using the same `-rdim` or `-ef` value for all windows.

Example csv input file specifying rdims for each window index:
```
RDIM
0,6
1,7
2,8
3,10
4,9
```

The csv input file is assumed to be in the DMD list directory, similar to the other inputs used by `local_tw_csv` and `parametric_tw_csv`. The above example can be modified to specify energy fraction values by using `EF` in the header.



