### PR TITLE
check integer overflow in `Matrix::setSize`

### DIFF
--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -132,7 +132,7 @@ Matrix::Matrix(
     else {
         // Check integer multiplication overflow
         if (num_rows > INT_MAX / num_cols)
-            CAROM_ERROR("Matrix::setSize- new size exceeds maximum integer value!\n");
+            CAROM_ERROR("Matrix::Matrix- new size exceeds maximum integer value!\n");
 
         d_mat = mat;
         d_alloc_size = num_rows*num_cols;

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -130,6 +130,10 @@ Matrix::Matrix(
         memcpy(d_mat, mat, d_alloc_size*sizeof(double));
     }
     else {
+        // Check integer multiplication overflow
+        if (num_rows > INT_MAX / num_cols)
+            CAROM_ERROR("Matrix::setSize- new size exceeds maximum integer value!\n");
+            
         d_mat = mat;
         d_alloc_size = num_rows*num_cols;
         d_num_cols = num_cols;

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -133,7 +133,7 @@ Matrix::Matrix(
         // Check integer multiplication overflow
         if (num_rows > INT_MAX / num_cols)
             CAROM_ERROR("Matrix::setSize- new size exceeds maximum integer value!\n");
-            
+
         d_mat = mat;
         d_alloc_size = num_rows*num_cols;
         d_num_cols = num_cols;

--- a/lib/linalg/Matrix.h
+++ b/lib/linalg/Matrix.h
@@ -20,6 +20,7 @@
 #include <complex>
 #include <memory>
 #include <string>
+#include <climits>
 
 namespace CAROM {
 
@@ -149,6 +150,10 @@ public:
         int num_rows,
         int num_cols)
     {
+        // Check integer multiplication overflow
+        if (num_rows > INT_MAX / num_cols)
+            CAROM_ERROR("Matrix::setSize- new size exceeds maximum integer value!\n");
+
         int new_size = num_rows*num_cols;
         if (new_size > d_alloc_size) {
             if (!d_owns_data) {


### PR DESCRIPTION
So far, `Matrix` does not check if the new size is overflowed. This returns a memory error far downstream of application, which takes a long time to backtrace.

Now `Matrix::setSize` checks if the `new_size` is overflowed at its execution.