### PR TITLE
distribute/gather functions for `Vector`

### DIFF
--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -1094,7 +1094,7 @@ Matrix::gather()
     }
 
     double *d_new_mat = new double [new_size] {0.0};
-    CAROM_VERIFY(MPI_Allgatherv(d_mat, d_alloc_size, MPI_DOUBLE,
+    CAROM_VERIFY(MPI_Allgatherv(d_mat, d_num_rows * d_num_cols, MPI_DOUBLE,
                                 d_new_mat, data_cnts, data_offsets, MPI_DOUBLE,
                                 MPI_COMM_WORLD) == MPI_SUCCESS);
 

--- a/lib/linalg/Vector.cpp
+++ b/lib/linalg/Vector.cpp
@@ -637,6 +637,7 @@ Vector::gather()
     delete [] data_offsets, data_cnts;
     d_vec = d_new_vec;
     d_alloc_size = new_size;
+    d_dim = new_size;
 
     d_distributed = false;
 }

--- a/lib/linalg/Vector.cpp
+++ b/lib/linalg/Vector.cpp
@@ -585,10 +585,11 @@ double Vector::localMin(int nmax)
 }
 
 void
-Vector::distribute(const int &local_dim)
+Vector::distribute(const int local_dim)
 {
     CAROM_VERIFY(!distributed());
     CAROM_VERIFY(d_owns_data);
+    CAROM_VERIFY(local_dim >= 0);
 
     std::vector<int> row_offsets;
     int global_dim = get_global_offsets(local_dim, row_offsets,

--- a/lib/linalg/Vector.cpp
+++ b/lib/linalg/Vector.cpp
@@ -14,6 +14,7 @@
 
 #include "Vector.h"
 #include "utils/HDFDatabase.h"
+#include "utils/mpi_utils.h"
 
 #include "mpi.h"
 

--- a/lib/linalg/Vector.cpp
+++ b/lib/linalg/Vector.cpp
@@ -592,7 +592,7 @@ Vector::distribute(const int &local_dim)
 
     std::vector<int> row_offsets;
     int global_dim = get_global_offsets(local_dim, row_offsets,
-                                            MPI_COMM_WORLD);
+                                        MPI_COMM_WORLD);
     CAROM_VERIFY(global_dim == d_dim);
     int local_offset = row_offsets[d_rank];
     const int new_size = local_dim;
@@ -617,7 +617,7 @@ Vector::gather()
 
     std::vector<int> row_offsets;
     const int global_dim = get_global_offsets(d_dim, row_offsets,
-                               MPI_COMM_WORLD);
+                           MPI_COMM_WORLD);
     const int new_size = global_dim;
 
     int *data_offsets = new int[row_offsets.size() - 1];

--- a/lib/linalg/Vector.h
+++ b/lib/linalg/Vector.h
@@ -759,6 +759,27 @@ public:
      */
     double localMin(int nmax = 0);
 
+    /**
+     * @brief Distribute this vector among MPI processes,
+     * based on the specified local dimension.
+     * This becomes distributed after this function is executed.
+     *
+     * @pre !distributed()
+     * @pre d_owns_data
+     *
+     * @param[in] local_dim dimension for local MPI rank.
+     */
+    void distribute(const int &local_dim);
+
+    /**
+     * @brief Gather all the distributed elements among MPI processes.
+     * This becomes not distributed after this function is executed.
+     *
+     * @pre distributed()
+     * @pre d_owns_data
+     */
+    void gather();
+
 private:
     /**
      * @brief The storage for the Vector's values on this processor.
@@ -789,6 +810,11 @@ private:
      * @brief The number of processors being run on.
      */
     int d_num_procs;
+
+    /**
+     * @brief The current MPI rank. If MPI is not initialized, equal to 0.
+     */
+    int d_rank;
 
     /**
      * @brief If true, this object owns its underlying data, d_vec, and

--- a/lib/linalg/Vector.h
+++ b/lib/linalg/Vector.h
@@ -768,12 +768,14 @@ public:
      * @pre d_owns_data
      *
      * @param[in] local_dim dimension for local MPI rank.
+     *                      Its sum over all processes should be the same as the current dimension.
      */
-    void distribute(const int &local_dim);
+    void distribute(const int local_dim);
 
     /**
      * @brief Gather all the distributed elements among MPI processes.
      * This becomes not distributed after this function is executed.
+     * The data is identical on all processes after the operation.
      *
      * @pre distributed()
      * @pre d_owns_data


### PR DESCRIPTION
This implements `Vector::distribute` and `Vector::gather` analogous to `Matrix` class.

- `Vector::distribute` distributes a non-distributed vector into a locally distributed vector with specified local dimension.
- `Vector::gather` gathers a locally distributed vector into a non-distributed vector.