### PR TITLE
Squared singular values to calculate POD variance

### DIFF
--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -448,7 +448,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name,0,squareSV);
+    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name,0, squareSV);
 }
 
 // TODO: move this to the library?

--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -448,7 +448,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name,0, squareSV);
+    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name, 0, squareSV);
 }
 
 // TODO: move this to the library?

--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -428,7 +428,7 @@ CAROM::Matrix* GetFirstColumns(const int N, const CAROM::Matrix* A)
 
 // TODO: move this to the library?
 void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
-                std::string name)
+                std::string name, bool squareSV)
 {
     MFEM_VERIFY(nparam > 0, "Must specify a positive number of parameter sets");
 
@@ -448,7 +448,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name);
+    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name,0,squaredSV);
 }
 
 // TODO: move this to the library?
@@ -512,6 +512,7 @@ int main(int argc, char *argv[])
     bool use_eqp = false;
     bool writeSampleMesh = false;
     int num_samples_req = -1;
+    bool squareSV;
 
     bool pointwiseSnapshots = false;
     int pwx = 0;
@@ -577,6 +578,8 @@ int main(int argc, char *argv[])
                    "Enable or disable the online phase.");
     args.AddOption(&merge, "-merge", "--merge", "-no-merge", "--no-merge",
                    "Enable or disable the merge phase.");
+    args.AddOption(&squareSV, "-sqsv", "--square-sv", "-no-sqsv", "--no-square-sv",
+                    "Use singular values squared in energy fraction.");
     args.AddOption(&samplingType, "-hrtype", "--hrsamplingtype",
                    "Sampling type for hyperreduction.");
     args.AddOption(&num_samples_req, "-nsr", "--nsr",
@@ -705,13 +708,13 @@ int main(int argc, char *argv[])
         totalTimer.Clear();
         totalTimer.Start();
 
-        MergeBasis(R_space.GetTrueVSize(), nsets, max_num_snapshots, "R");
-        MergeBasis(R_space.GetTrueVSize(), nsets, max_num_snapshots, "FR");
-        MergeBasis(W_space.GetTrueVSize(), nsets, max_num_snapshots, "W");
+        MergeBasis(R_space.GetTrueVSize(), nsets, max_num_snapshots, "R", squareSV);
+        MergeBasis(R_space.GetTrueVSize(), nsets, max_num_snapshots, "FR", squareSV);
+        MergeBasis(W_space.GetTrueVSize(), nsets, max_num_snapshots, "W", squareSV);
 
         if (hyperreduce_source)
         {
-            MergeBasis(W_space.GetTrueVSize(), nsets, max_num_snapshots, "S");
+            MergeBasis(W_space.GetTrueVSize(), nsets, max_num_snapshots, "S", squareSV);
         }
 
         totalTimer.Stop();

--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -579,7 +579,7 @@ int main(int argc, char *argv[])
     args.AddOption(&merge, "-merge", "--merge", "-no-merge", "--no-merge",
                    "Enable or disable the merge phase.");
     args.AddOption(&squareSV, "-sqsv", "--square-sv", "-no-sqsv", "--no-square-sv",
-                    "Use singular values squared in energy fraction.");
+                   "Use singular values squared in energy fraction.");
     args.AddOption(&samplingType, "-hrtype", "--hrsamplingtype",
                    "Sampling type for hyperreduction.");
     args.AddOption(&num_samples_req, "-nsr", "--nsr",

--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -448,7 +448,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name,0,squaredSV);
+    generator.finalSummary(1e-4, cutoff, "mergedSV_" + name,0,squareSV);
 }
 
 // TODO: move this to the library?
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
     bool use_eqp = false;
     bool writeSampleMesh = false;
     int num_samples_req = -1;
-    bool squareSV;
+    bool squareSV = true;
 
     bool pointwiseSnapshots = false;
     int pwx = 0;

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -308,7 +308,7 @@ CAROM::Matrix *GetFirstColumns(const int N, const CAROM::Matrix *A)
 
 // TODO: move this to the library?
 void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
-                std::string name)
+                std::string name, bool squareSV)
 {
     MFEM_VERIFY(nparam > 0, "Must specify a positive number of parameter sets");
 
@@ -328,7 +328,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt");
+    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt",0,squaredSV);
 }
 
 const CAROM::Matrix *GetSnapshotMatrix(const int dimFOM, const int nparam,
@@ -643,11 +643,11 @@ int main(int argc, char *argv[])
         // Merge bases
         if (x_base_only == false)
         {
-            MergeBasis(true_size, nsets, max_num_snapshots, "V");
+            MergeBasis(true_size, nsets, max_num_snapshots, "V",squareSV);
         }
 
-        MergeBasis(true_size, nsets, max_num_snapshots, "X");
-        MergeBasis(true_size, nsets, max_num_snapshots, "H");
+        MergeBasis(true_size, nsets, max_num_snapshots, "X",squareSV);
+        MergeBasis(true_size, nsets, max_num_snapshots, "H",squareSV);
 
         totalTimer.Stop();
         if (myid == 0)

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -328,7 +328,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt",0,squareSV);
+    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt",0, squareSV);
 }
 
 const CAROM::Matrix *GetSnapshotMatrix(const int dimFOM, const int nparam,
@@ -646,11 +646,11 @@ int main(int argc, char *argv[])
         // Merge bases
         if (x_base_only == false)
         {
-            MergeBasis(true_size, nsets, max_num_snapshots, "V",squareSV);
+            MergeBasis(true_size, nsets, max_num_snapshots, "V", squareSV);
         }
 
-        MergeBasis(true_size, nsets, max_num_snapshots, "X",squareSV);
-        MergeBasis(true_size, nsets, max_num_snapshots, "H",squareSV);
+        MergeBasis(true_size, nsets, max_num_snapshots, "X", squareSV);
+        MergeBasis(true_size, nsets, max_num_snapshots, "H", squareSV);
 
         totalTimer.Stop();
         if (myid == 0)

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -328,7 +328,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt",0,squaredSV);
+    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt",0,squareSV);
 }
 
 const CAROM::Matrix *GetSnapshotMatrix(const int dimFOM, const int nparam,
@@ -416,7 +416,7 @@ int main(int argc, char *argv[])
     bool x_base_only = false;
     int num_samples_req = -1;
     const char *samplingType = "gnat";
-    bool squareSV;
+    bool squareSV = true;
 
     int nsets = 0;
     int id_param = 0;

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -328,7 +328,7 @@ void MergeBasis(const int dimFOM, const int nparam, const int max_num_snapshots,
     generator.endSamples(); // save the merged basis file
 
     int cutoff = 0;
-    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt",0, squareSV);
+    generator.finalSummary(1e-7, cutoff, "mergedSV_" + name + ".txt", 0, squareSV);
 }
 
 const CAROM::Matrix *GetSnapshotMatrix(const int dimFOM, const int nparam,

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -480,7 +480,7 @@ int main(int argc, char *argv[])
     args.AddOption(&merge, "-merge", "--merge", "-no-merge", "--no-merge",
                    "Enable or disable the merge phase.");
     args.AddOption(&squareSV, "-sqsv", "--square-sv", "-no-sqsv", "--no-square-sv",
-                    "Use singular values squared in energy fraction.");
+                   "Use singular values squared in energy fraction.");
     args.AddOption(&samplingType, "-hrtype", "--hrsamplingtype",
                    "Sampling type for hyperreduction.");
     args.AddOption(&num_samples_req, "-nsr", "--nsr",

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -416,6 +416,7 @@ int main(int argc, char *argv[])
     bool x_base_only = false;
     int num_samples_req = -1;
     const char *samplingType = "gnat";
+    bool squareSV;
 
     int nsets = 0;
     int id_param = 0;
@@ -478,6 +479,8 @@ int main(int argc, char *argv[])
                    "Enable or disable the online phase.");
     args.AddOption(&merge, "-merge", "--merge", "-no-merge", "--no-merge",
                    "Enable or disable the merge phase.");
+    args.AddOption(&squareSV, "-sqsv", "--square-sv", "-no-sqsv", "--no-square-sv",
+                    "Use singular values squared in energy fraction.");
     args.AddOption(&samplingType, "-hrtype", "--hrsamplingtype",
                    "Sampling type for hyperreduction.");
     args.AddOption(&num_samples_req, "-nsr", "--nsr",

--- a/lib/linalg/BasisGenerator.cpp
+++ b/lib/linalg/BasisGenerator.cpp
@@ -322,7 +322,7 @@ BasisGenerator::finalSummary(
     double sum = 0.0;
     for (int sv = first_sv; sv < sing_vals->dim(); ++sv) {
         const double s = (*sing_vals)(sv);
-         sum += squareSV ? s * s : s;
+        sum += squareSV ? s * s : s;
     }
 
     int p = std::floor(-std::log10(energyFractionThreshold));
@@ -347,7 +347,7 @@ BasisGenerator::finalSummary(
 
     for (int sv = first_sv; sv < sing_vals->dim(); ++sv) {
         const double s = (*sing_vals)(sv);
-         partialSum += squareSV ? s * s : s;
+        partialSum += squareSV ? s * s : s;
         for (int i = count; i < p; ++i)
         {
             if (partialSum / sum > 1.0 - std::pow(10, -1 - i))

--- a/lib/linalg/BasisGenerator.cpp
+++ b/lib/linalg/BasisGenerator.cpp
@@ -312,7 +312,7 @@ BasisGenerator::finalSummary(
     const double energyFractionThreshold,
     int & cutoff,
     const std::string & cutoffOutputPath,
-    const int first_sv)
+    const int first_sv, const bool squareSV)
 {
     const int rom_dim = getSpatialBasis()->numColumns();
     const Vector* sing_vals = getSingularValues();
@@ -321,7 +321,8 @@ BasisGenerator::finalSummary(
 
     double sum = 0.0;
     for (int sv = first_sv; sv < sing_vals->dim(); ++sv) {
-        sum += std::pow((*sing_vals)(sv), 2);
+        const double s = (*sing_vals)(sv);
+         sum += squareSV ? s * s : s;
     }
 
     int p = std::floor(-std::log10(energyFractionThreshold));
@@ -345,7 +346,8 @@ BasisGenerator::finalSummary(
     }
 
     for (int sv = first_sv; sv < sing_vals->dim(); ++sv) {
-        partialSum += std::pow((*sing_vals)(sv),2);
+        const double s = (*sing_vals)(sv);
+         partialSum += squareSV ? s * s : s;
         for (int i = count; i < p; ++i)
         {
             if (partialSum / sum > 1.0 - std::pow(10, -1 - i))

--- a/lib/linalg/BasisGenerator.cpp
+++ b/lib/linalg/BasisGenerator.cpp
@@ -321,7 +321,7 @@ BasisGenerator::finalSummary(
 
     double sum = 0.0;
     for (int sv = first_sv; sv < sing_vals->dim(); ++sv) {
-        sum += (*sing_vals)(sv);
+        sum += std::pow((*sing_vals)(sv), 2);
     }
 
     int p = std::floor(-std::log10(energyFractionThreshold));
@@ -345,7 +345,7 @@ BasisGenerator::finalSummary(
     }
 
     for (int sv = first_sv; sv < sing_vals->dim(); ++sv) {
-        partialSum += (*sing_vals)(sv);
+        partialSum += std::pow((*sing_vals)(sv),2);
         for (int i = count; i < p; ++i)
         {
             if (partialSum / sum > 1.0 - std::pow(10, -1 - i))

--- a/lib/linalg/BasisGenerator.h
+++ b/lib/linalg/BasisGenerator.h
@@ -260,7 +260,7 @@ public:
         const double energyFractionThreshold,
         int & cutoff,
         const std::string & cutoffOutputPath = "",
-        const int first_sv = 0);
+        const int first_sv = 0, const bool squareSV = true);
 
 protected:
     /**


### PR DESCRIPTION
Current libROM implementation of [`BasisGenerator::finalSummary`](https://github.com/LLNL/libROM/blob/321d18f4d5adfa29f0a3de9be2699fee9732f2bf/lib/linalg/BasisGenerator.cpp#L311) sums the singular values to calculate the total POD energy, but this should actually be the sum of squared singular values, compare to [Chatterjee (2000)](https://eng-web1.eng.famu.fsu.edu/~alvi/eml4304/webpage_old/documents/rankine/Proper%20Orthogonal%20Decomposition.pdf) chapter 6.4. This short PR adresses that in libROM.


### Test mixed nonlinear diffusion
To test with mixed nonlinear diffusion, run:

```
./mixed_nonlinear_diffusion -p 1 -offline -id 0 -sh 0.25
./mixed_nonlinear_diffusion -p 1 -offline -id 1 -sh 0.15
// Merge
./mixed_nonlinear_diffusion -p 1 -merge -ns 2
```

On the current master, the file `mergedSV_FR` reads

```
For energy fraction: 0.9, take first 5 of 200 basis vectors
For energy fraction: 0.99, take first 8 of 200 basis vectors
For energy fraction: 0.999, take first 12 of 200 basis vectors
For energy fraction: 0.9999, take first 16 of 200 basis vectors
For energy fraction: 0.99990, take first 16 of 200 basis vectors
```

In this PR, the file reads

```
For energy fraction: 0.9, take first 3 of 200 basis vectors
For energy fraction: 0.99, take first 5 of 200 basis vectors
For energy fraction: 0.999, take first 7 of 200 basis vectors
For energy fraction: 0.9999, take first 8 of 200 basis vectors
For energy fraction: 0.99990, take first 8 of 200 basis vectors
```

### Test nonlinear elasticity
To test with nonlinear elasticity, run:

```
./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 0.9 -id 0
./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.1 -id 1

// Merge:
./nonlinear_elasticity_global_rom -merge -ns 2 -dt 0.01 -tf 5.0
```

On the current master, the file `mergedSV_H.txt` reads

```
For energy fraction: 0.9, take first 12 of 1002 basis vectors
For energy fraction: 0.99, take first 29 of 1002 basis vectors
For energy fraction: 0.999, take first 59 of 1002 basis vectors
For energy fraction: 0.9999, take first 96 of 1002 basis vectors
For energy fraction: 0.99999, take first 134 of 1002 basis vectors
For energy fraction: 0.999999, take first 165 of 1002 basis vectors
For energy fraction: 0.9999999, take first 189 of 1002 basis vectors
For energy fraction: 0.99999990, take first 189 of 1002 basis vectors
```

In this PR, the file reads

```
For energy fraction: 0.9, take first 5 of 1002 basis vectors
For energy fraction: 0.99, take first 11 of 1002 basis vectors
For energy fraction: 0.999, take first 19 of 1002 basis vectors
For energy fraction: 0.9999, take first 26 of 1002 basis vectors
For energy fraction: 0.99999, take first 35 of 1002 basis vectors
For energy fraction: 0.999999, take first 49 of 1002 basis vectors
For energy fraction: 0.9999999, take first 67 of 1002 basis vectors
For energy fraction: 0.99999990, take first 67 of 1002 basis vectors
```

