### PR TITLE
Rationalize CMake and switch to C++17 to accommodate MFEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,133 +110,26 @@ set(CAROM_HAVE_LAPACK ${LAPACK_FOUND})
 set(CAROM_HAVE_HDF5 ${HDF5_FOUND})
 
 if (USE_MFEM)
-    find_library(MFEM mfem "${CMAKE_SOURCE_DIR}/dependencies/mfem" "${MFEM_DIR}/lib")
-    find_library(HYPRE HYPRE "${CMAKE_SOURCE_DIR}/dependencies/hypre/src/hypre/lib" "${HYPRE_DIR}/lib")
-    find_library(PARMETIS parmetis "${CMAKE_SOURCE_DIR}/dependencies/parmetis-4.0.3/build/lib/libparmetis" "${PARMETIS_DIR}/lib")
-    find_library(METIS metis "${CMAKE_SOURCE_DIR}/dependencies/parmetis-4.0.3/build/lib/libmetis" "${METIS_DIR}/lib")
-    find_path(MFEM_INCLUDES mfem.hpp "${CMAKE_SOURCE_DIR}/dependencies/mfem" "${MFEM_DIR}/include")
-    find_path(HYPRE_INCLUDES HYPRE.h "${CMAKE_SOURCE_DIR}/dependencies/hypre/src/hypre/include" "${HYPRE_DIR}/include")
-    find_path(PARMETIS_INCLUDES metis.h "${CMAKE_SOURCE_DIR}/dependencies/parmetis-4.0.3/metis/include" "${PARMETIS_DIR}/metis/include")
+    find_package(mfem REQUIRED NAMES MFEM HINTS "${MFEM_DIR}"
+                  "${MFEM_DIR}/lib/cmake/mfem" NO_DEFAULT_PATH)
+    message(STATUS "Found mfem config in: ${mfem_DIR} (version ${MFEM_VERSION})")
 endif()
+
+set(CAROM_LIBS ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES} MPI::MPI_C ${MPI_FORTRAN_LINK_FLAGS} ${MPI_FORTRAN_LIBRARIES} MPI::MPI_Fortran)
+set(CAROM_INCS ${CMAKE_CURRENT_SOURCE_DIR} ${MPI_C_INCLUDE_DIRS})
 
 add_subdirectory(lib)
 
-# Use the C++11 standard as an entire feature instead of
-# enumerating individual compiler features for simplicity
-target_compile_features(ROM PRIVATE cxx_std_11)
-
 if (ENABLE_EXAMPLES)
+  add_subdirectory(examples/misc)
   if (USE_MFEM)
-    set(examples
-      poisson_global_rom
-      poisson_local_rom_greedy
-      dg_advection_global_rom
-      dg_advection_local_rom_matrix_interp
-      mixed_nonlinear_diffusion
-      nonlinear_elasticity_global_rom
-      linear_elasticity_global_rom
-      maxwell_global_rom
-      de_parametric_maxwell_greedy
-      maxwell_local_rom_greedy     
-      grad_div_global_rom
-      elliptic_eigenproblem_global_rom
-      dg_advection
-      nonlinear_elasticity
-      heat_conduction
-      heat_conduction_dmdc
-      parametric_heat_conduction
-      de_parametric_heat_conduction_greedy
-      de_dg_advection_greedy
-      wave_equation
-      dg_euler
-      local_dw_csv
-      parametric_tw_csv
-      parametric_dw_csv
-      parametric_dmdc_heat_conduction)
-    set(example_directories
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      prom
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd
-      dmd)
-
-    list(LENGTH examples len1)
-    math(EXPR len2 "${len1} - 1")
-
-    foreach(val RANGE ${len2})
-      list(GET examples ${val} name)
-      list(GET example_directories ${val} example_dir)
-      set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples/${example_dir})
-      add_executable(${name} examples/${example_dir}/${name}.cpp)
-
-      target_link_libraries(${name}
-        PRIVATE ROM ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${MPI_FORTRAN_LINK_FLAGS} ${MPI_FORTRAN_LIBRARIES} MPI::MPI_Fortran)
-      target_include_directories(${name}
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-        ${MPI_C_INCLUDE_DIRS})
-      target_compile_features(${name} PRIVATE cxx_std_11)
-    endforeach() # IN LISTS examples
+    add_subdirectory(examples/prom)
+    add_subdirectory(examples/dmd)
     file(COPY examples/data DESTINATION ${CMAKE_BINARY_DIR}/examples)
     file(COPY examples/merlin DESTINATION ${CMAKE_BINARY_DIR}/examples)
     file(COPY examples/dmd/heat_conduction_csv.sh DESTINATION ${CMAKE_BINARY_DIR}/examples/dmd)
     file(COPY examples/dmd/heat_conduction_hdf.sh DESTINATION ${CMAKE_BINARY_DIR}/examples/dmd)
-  endif()
-
-  set(misc_example_names
-    combine_samples)
-
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples/misc)
-
-  foreach(name IN LISTS misc_example_names)
-    add_executable(${name} examples/misc/${name}.cpp)
-
-    target_link_libraries(${name}
-      PRIVATE ROM ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${MPI_FORTRAN_LINK_FLAGS} ${MPI_FORTRAN_LIBRARIES} MPI::MPI_Fortran)
-    target_include_directories(${name}
-      PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-      ${MPI_C_INCLUDE_DIRS})
-    target_compile_features(${name} PRIVATE cxx_std_11)
-  endforeach(name) # IN LISTS misc_exmaple_names
-
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-
-  if (USE_MFEM)
-    set(regression_test_names
-        basisComparator
-        checkError
-        computeSpeedup
-        solutionComparator
-        fileComparator)
-
-    foreach(name IN LISTS regression_test_names)
-      add_executable(${name} regression_tests/${name}.cpp)
-      target_link_libraries(${name}
-        PRIVATE ROM ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${MPI_FORTRAN_LINK_FLAGS} ${MPI_FORTRAN_LIBRARIES} MPI::MPI_Fortran)
-      target_include_directories(${name}
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-        ${MPI_C_INCLUDE_DIRS})
-      target_compile_features(${name} PRIVATE cxx_std_11)
-    endforeach(name) # IN LISTS regression_test_names
+    add_subdirectory(regression_tests)
   endif()
 endif(ENABLE_EXAMPLES)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,9 +110,28 @@ set(CAROM_HAVE_LAPACK ${LAPACK_FOUND})
 set(CAROM_HAVE_HDF5 ${HDF5_FOUND})
 
 if (USE_MFEM)
-    find_package(mfem REQUIRED NAMES MFEM HINTS "${MFEM_DIR}"
-                  "${MFEM_DIR}/lib/cmake/mfem" NO_DEFAULT_PATH)
-    message(STATUS "Found mfem config in: ${mfem_DIR} (version ${MFEM_VERSION})")
+    # Try to find MFEM installed using cmake
+    find_package(mfem NAMES MFEM HINTS "${MFEM_DIR}"
+                "${MFEM_DIR}/lib/cmake/mfem" "${CMAKE_SOURCE_DIR}/dependencies/mfem/lib/cmake/mfem" NO_DEFAULT_PATH QUIET)
+    if (mfem_FOUND)
+       message(STATUS "Found mfem config in: ${mfem_DIR} (version ${MFEM_VERSION})")
+    else()
+       # Try to find MFEM installed using configure
+       find_library(MFEM mfem HINTS "${MFEM_DIR}/lib" "${CMAKE_SOURCE_DIR}/dependencies/mfem")
+       find_library(HYPRE HYPRE HINTS "${HYPRE_DIR}/lib" "${CMAKE_SOURCE_DIR}/dependencies/hypre/src/hypre/lib")
+       find_library(PARMETIS parmetis HINTS "${PARMETIS_DIR}/lib" "${CMAKE_SOURCE_DIR}/dependencies/parmetis-4.0.3/build/lib/libparmetis")
+       find_library(METIS metis HINTS "${METIS_DIR}/lib" "${CMAKE_SOURCE_DIR}/dependencies/parmetis-4.0.3/build/lib/libmetis")
+       find_path(MFEM_INCLUDES mfem.hpp HINTS "${MFEM_DIR}/include" "${CMAKE_SOURCE_DIR}/dependencies/mfem")
+       find_path(HYPRE_INCLUDES HYPRE.h HINTS "${HYPRE_DIR}/include" "${CMAKE_SOURCE_DIR}/dependencies/hypre/src/hypre/include")
+       find_path(PARMETIS_INCLUDES metis.h "${PARMETIS_DIR}/metis/include" "${CMAKE_SOURCE_DIR}/dependencies/parmetis-4.0.3/metis/include")
+
+       if (${MFEM} STREQUAL "MFEM-NOTFOUND")
+          error( "MFEM not found" )
+       else()
+          message(STATUS "MFEM library:" ${MFEM})
+          message(STATUS "MFEM includes:" ${MFEM_INCLUDES})
+       endif()
+    endif()
 endif()
 
 set(CAROM_LIBS ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES} MPI::MPI_C ${MPI_FORTRAN_LINK_FLAGS} ${MPI_FORTRAN_LIBRARIES} MPI::MPI_Fortran)

--- a/examples/dmd/CMakeLists.txt
+++ b/examples/dmd/CMakeLists.txt
@@ -1,0 +1,31 @@
+###############################################################################
+#
+#  Copyright (c) 2013-2024, Lawrence Livermore National Security, LLC
+#  and other libROM project developers. See the top-level COPYRIGHT
+#  file for details.
+#
+#  SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+###############################################################################
+
+set(examples
+      dg_advection
+      nonlinear_elasticity
+      heat_conduction
+      heat_conduction_dmdc
+      parametric_heat_conduction
+      de_parametric_heat_conduction_greedy
+      de_dg_advection_greedy
+      wave_equation
+      dg_euler
+      local_dw_csv
+      parametric_tw_csv
+      parametric_dw_csv
+      parametric_dmdc_heat_conduction)
+
+foreach(name IN LISTS examples)
+   add_executable(${name} ${name}.cpp)
+   target_link_libraries(${name} PRIVATE ROM ${CAROM_LIBS})
+   target_include_directories(${name} PRIVATE ${CAROM_INCS})
+   target_compile_features(${name} PRIVATE cxx_std_17)
+endforeach()

--- a/examples/dmd/de_dg_advection_greedy.cpp
+++ b/examples/dmd/de_dg_advection_greedy.cpp
@@ -72,7 +72,18 @@
 #include "utils/CSVDatabase.h"
 
 
-using namespace std;
+using std::vector;
+using std::cout;
+using std::endl;
+using std::flush;
+using std::max;
+using std::min;
+using std::to_string;
+using std::ifstream;
+using std::ofstream;
+using std::ostringstream;
+using std::setfill;
+using std::setw;
 using namespace mfem;
 
 // Choice for the problem setup. The fluid velocity, initial condition and
@@ -478,7 +489,7 @@ double simulation()
     // Create data collection for solution output: either VisItDataCollection for
     // ascii data files, or SidreDataCollection for binary data files.
     DataCollection *dc = NULL;
-    if (::visit)
+    if (visit)
     {
         if (binary)
         {
@@ -791,7 +802,7 @@ double simulation()
                 sout << "solution\n" << pmesh << u_gf << flush;
             }
 
-            if (::visit)
+            if (visit)
             {
                 dc->SetCycle(ti);
                 dc->SetTime(t);
@@ -946,14 +957,14 @@ double simulation()
         VisItDataCollection dmd_visit_dc("DMD_DG_Advection_Greedy_" +
                                          to_string(f_factor), &pmesh);
         dmd_visit_dc.RegisterField("temperature", &u_gf);
-        if (::visit)
+        if (visit)
         {
             dmd_visit_dc.SetCycle(0);
             dmd_visit_dc.SetTime(0.0);
             dmd_visit_dc.Save();
         }
 
-        if (::visit)
+        if (visit)
         {
             for (int i = 1; i < ts.size(); i++)
             {
@@ -1148,7 +1159,7 @@ int main(int argc, char *argv[])
     args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                    "--no-visualization",
                    "Enable or disable GLVis visualization.");
-    args.AddOption(&::visit, "-visit", "--visit-datafiles", "-no-visit",
+    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
                    "--no-visit-datafiles",
                    "Save data files for VisIt (visit.llnl.gov) visualization.");
     args.AddOption(&paraview, "-paraview", "--paraview-datafiles", "-no-paraview",
@@ -1271,7 +1282,7 @@ int main(int argc, char *argv[])
     else if (build_database)
     {
         MFEM_VERIFY(rdim != -1, "rdim must be set.");
-        MFEM_VERIFY(!::visit
+        MFEM_VERIFY(!visit
                     && !visualization,
                     "visit and visualization must be turned off during the build_database phase.")
         std::ifstream infile(io_dir+"/dg_advection_greedy_parametric_data");

--- a/examples/dmd/de_dg_advection_greedy.cpp
+++ b/examples/dmd/de_dg_advection_greedy.cpp
@@ -478,7 +478,7 @@ double simulation()
     // Create data collection for solution output: either VisItDataCollection for
     // ascii data files, or SidreDataCollection for binary data files.
     DataCollection *dc = NULL;
-    if (visit)
+    if (::visit)
     {
         if (binary)
         {
@@ -791,7 +791,7 @@ double simulation()
                 sout << "solution\n" << pmesh << u_gf << flush;
             }
 
-            if (visit)
+            if (::visit)
             {
                 dc->SetCycle(ti);
                 dc->SetTime(t);
@@ -946,14 +946,14 @@ double simulation()
         VisItDataCollection dmd_visit_dc("DMD_DG_Advection_Greedy_" +
                                          to_string(f_factor), &pmesh);
         dmd_visit_dc.RegisterField("temperature", &u_gf);
-        if (visit)
+        if (::visit)
         {
             dmd_visit_dc.SetCycle(0);
             dmd_visit_dc.SetTime(0.0);
             dmd_visit_dc.Save();
         }
 
-        if (visit)
+        if (::visit)
         {
             for (int i = 1; i < ts.size(); i++)
             {
@@ -1148,7 +1148,7 @@ int main(int argc, char *argv[])
     args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                    "--no-visualization",
                    "Enable or disable GLVis visualization.");
-    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
+    args.AddOption(&::visit, "-visit", "--visit-datafiles", "-no-visit",
                    "--no-visit-datafiles",
                    "Save data files for VisIt (visit.llnl.gov) visualization.");
     args.AddOption(&paraview, "-paraview", "--paraview-datafiles", "-no-paraview",
@@ -1271,7 +1271,7 @@ int main(int argc, char *argv[])
     else if (build_database)
     {
         MFEM_VERIFY(rdim != -1, "rdim must be set.");
-        MFEM_VERIFY(!visit
+        MFEM_VERIFY(!::visit
                     && !visualization,
                     "visit and visualization must be turned off during the build_database phase.")
         std::ifstream infile(io_dir+"/dg_advection_greedy_parametric_data");

--- a/examples/dmd/de_parametric_heat_conduction_greedy.cpp
+++ b/examples/dmd/de_parametric_heat_conduction_greedy.cpp
@@ -70,7 +70,18 @@
 #define mkdir(dir, mode) _mkdir(dir)
 #endif
 
-using namespace std;
+using std::vector;
+using std::cout;
+using std::endl;
+using std::flush;
+using std::max;
+using std::min;
+using std::to_string;
+using std::ifstream;
+using std::ofstream;
+using std::ostringstream;
+using std::setfill;
+using std::setw;
 using namespace mfem;
 
 /** After spatial discretization, the conduction model can be written as:
@@ -306,7 +317,7 @@ double simulation()
                                  to_string(radius) + "_" + to_string(alpha) + "_" + to_string(cx) + "_" +
                                  to_string(cy), pmesh);
     visit_dc.RegisterField("temperature", &u_gf);
-    if (!de && !online && ::visit)
+    if (!de && !online && visit)
     {
         visit_dc.SetCycle(0);
         visit_dc.SetTime(0.0);
@@ -522,7 +533,7 @@ double simulation()
                     sout << "solution\n" << *pmesh << u_gf << flush;
                 }
 
-                if (!de && !online && ::visit)
+                if (!de && !online && visit)
                 {
                     visit_dc.SetCycle(ti);
                     visit_dc.SetTime(t);
@@ -732,14 +743,14 @@ double simulation()
                                          to_string(radius) + "_" + to_string(alpha) + "_" +
                                          to_string(cx) + "_" + to_string(cy), pmesh);
         dmd_visit_dc.RegisterField("temperature", &u_gf);
-        if (::visit)
+        if (visit)
         {
             dmd_visit_dc.SetCycle(0);
             dmd_visit_dc.SetTime(0.0);
             dmd_visit_dc.Save();
         }
 
-        if (::visit)
+        if (visit)
         {
             for (int i = 1; i < ts.size(); i++)
             {
@@ -1017,7 +1028,7 @@ int main(int argc, char *argv[])
     args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                    "--no-visualization",
                    "Enable or disable GLVis visualization.");
-    args.AddOption(&::visit, "-visit", "--visit-datafiles", "-no-visit",
+    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
                    "--no-visit-datafiles",
                    "Save data files for VisIt (visit.llnl.gov) visualization.");
     args.AddOption(&vis_steps, "-vs", "--visualization-steps",
@@ -1054,7 +1065,7 @@ int main(int argc, char *argv[])
     if (build_database)
     {
         MFEM_VERIFY(rdim != -1, "rdim must be set.");
-        MFEM_VERIFY(!::visit
+        MFEM_VERIFY(!visit
                     && !visualization,
                     "visit and visualization must be turned off during the build_database phase.")
         std::ifstream infile("de_parametric_heat_conduction_greedy_data");

--- a/examples/dmd/de_parametric_heat_conduction_greedy.cpp
+++ b/examples/dmd/de_parametric_heat_conduction_greedy.cpp
@@ -306,7 +306,7 @@ double simulation()
                                  to_string(radius) + "_" + to_string(alpha) + "_" + to_string(cx) + "_" +
                                  to_string(cy), pmesh);
     visit_dc.RegisterField("temperature", &u_gf);
-    if (!de && !online && visit)
+    if (!de && !online && ::visit)
     {
         visit_dc.SetCycle(0);
         visit_dc.SetTime(0.0);
@@ -522,7 +522,7 @@ double simulation()
                     sout << "solution\n" << *pmesh << u_gf << flush;
                 }
 
-                if (!de && !online && visit)
+                if (!de && !online && ::visit)
                 {
                     visit_dc.SetCycle(ti);
                     visit_dc.SetTime(t);
@@ -732,14 +732,14 @@ double simulation()
                                          to_string(radius) + "_" + to_string(alpha) + "_" +
                                          to_string(cx) + "_" + to_string(cy), pmesh);
         dmd_visit_dc.RegisterField("temperature", &u_gf);
-        if (visit)
+        if (::visit)
         {
             dmd_visit_dc.SetCycle(0);
             dmd_visit_dc.SetTime(0.0);
             dmd_visit_dc.Save();
         }
 
-        if (visit)
+        if (::visit)
         {
             for (int i = 1; i < ts.size(); i++)
             {
@@ -1017,7 +1017,7 @@ int main(int argc, char *argv[])
     args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                    "--no-visualization",
                    "Enable or disable GLVis visualization.");
-    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
+    args.AddOption(&::visit, "-visit", "--visit-datafiles", "-no-visit",
                    "--no-visit-datafiles",
                    "Save data files for VisIt (visit.llnl.gov) visualization.");
     args.AddOption(&vis_steps, "-vs", "--visualization-steps",
@@ -1054,7 +1054,7 @@ int main(int argc, char *argv[])
     if (build_database)
     {
         MFEM_VERIFY(rdim != -1, "rdim must be set.");
-        MFEM_VERIFY(!visit
+        MFEM_VERIFY(!::visit
                     && !visualization,
                     "visit and visualization must be turned off during the build_database phase.")
         std::ifstream infile("de_parametric_heat_conduction_greedy_data");

--- a/examples/dmd/heat_conduction_dmdc.cpp
+++ b/examples/dmd/heat_conduction_dmdc.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
     //    handle triangular, quadrilateral, tetrahedral and hexahedral meshes
     //    with the same code.
     Mesh *mesh;
-    if (mesh_file == "")
+    if (strcmp(mesh_file, "") == 0 )
     {
         mesh = new Mesh(Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL));
     }

--- a/examples/dmd/parametric_dmdc_heat_conduction.cpp
+++ b/examples/dmd/parametric_dmdc_heat_conduction.cpp
@@ -323,7 +323,7 @@ int main(int argc, char *argv[])
     //    handle triangular, quadrilateral, tetrahedral and hexahedral meshes
     //    with the same code.
     Mesh *mesh;
-    if (mesh_file == "")
+    if (strcmp(mesh_file, "") == 0 )
     {
         mesh = new Mesh(Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL));
     }

--- a/examples/misc/CMakeLists.txt
+++ b/examples/misc/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(examples
+    combine_samples)
+
+foreach(name IN LISTS examples)
+   add_executable(${name} ${name}.cpp)
+   target_link_libraries(${name} PRIVATE ROM ${CAROM_LIBS})
+   target_include_directories(${name} PRIVATE ${CAROM_INCS})
+   target_compile_features(${name} PRIVATE cxx_std_17)
+endforeach()

--- a/examples/prom/CMakeLists.txt
+++ b/examples/prom/CMakeLists.txt
@@ -1,0 +1,28 @@
+###############################################################################
+#
+#  Copyright (c) 2013-2024, Lawrence Livermore National Security, LLC
+#  and other libROM project developers. See the top-level COPYRIGHT
+#  file for details.
+#
+#  SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+###############################################################################
+set(examples
+    poisson_global_rom
+    poisson_local_rom_greedy
+    dg_advection_global_rom
+    dg_advection_local_rom_matrix_interp
+    mixed_nonlinear_diffusion
+    nonlinear_elasticity_global_rom
+    linear_elasticity_global_rom
+    maxwell_global_rom
+    de_parametric_maxwell_greedy
+    maxwell_local_rom_greedy
+    elliptic_eigenproblem_global_rom)
+
+foreach(name IN LISTS examples)
+   add_executable(${name} ${name}.cpp)
+   target_link_libraries(${name} PRIVATE ROM ${CAROM_LIBS})
+   target_include_directories(${name} PRIVATE ${CAROM_INCS})
+   target_compile_features(${name} PRIVATE cxx_std_17)
+endforeach()

--- a/examples/prom/de_parametric_maxwell_greedy.cpp
+++ b/examples/prom/de_parametric_maxwell_greedy.cpp
@@ -388,7 +388,7 @@ double simulation()
 
     // 27. Save data in the VisIt format.
     DataCollection *dc = NULL;
-    if (visit)
+    if (::visit)
     {
         if (offline) dc = new VisItDataCollection("de_maxwell_local", pmesh);
         else if (fom) dc = new VisItDataCollection("de_maxwell_local_fom", pmesh);
@@ -647,7 +647,7 @@ int main(int argc, char *argv[])
                    "--no-partial-assembly", "Enable Partial Assembly.");
     args.AddOption(&device_config, "-d", "--device",
                    "Device configuration string, see Device::Configure().");
-    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
+    args.AddOption(&::visit, "-visit", "--visit-datafiles", "-no-visit",
                    "--no-visit-datafiles",
                    "Save data files for VisIt (visit.llnl.gov) visualization.");
     args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
@@ -738,7 +738,7 @@ int main(int argc, char *argv[])
         MFEM_VERIFY(!offline
                     && !online,
                     "offline and online must be turned off during the build_database phase.");
-        MFEM_VERIFY(!visit
+        MFEM_VERIFY(!::visit
                     && !visualization,
                     "visit and visualization must be turned off during the build_database phase.")
         std::ifstream infile("de_parametric_maxwell_greedy_algorithm_data");

--- a/examples/prom/de_parametric_maxwell_greedy.cpp
+++ b/examples/prom/de_parametric_maxwell_greedy.cpp
@@ -72,7 +72,20 @@
 #define mkdir(dir, mode) _mkdir(dir)
 #endif
 
-using namespace std;
+using std::vector;
+using std::set;
+using std::map;
+using std::make_pair;
+using std::string;
+using std::cout;
+using std::endl;
+using std::flush;
+using std::max;
+using std::min;
+using std::to_string;
+using std::ifstream;
+using std::ofstream;
+using std::ostringstream;
 using namespace mfem;
 
 // Exact solution, E, and r.h.s., f. See below for implementation.
@@ -388,7 +401,7 @@ double simulation()
 
     // 27. Save data in the VisIt format.
     DataCollection *dc = NULL;
-    if (::visit)
+    if (visit)
     {
         if (offline) dc = new VisItDataCollection("de_maxwell_local", pmesh);
         else if (fom) dc = new VisItDataCollection("de_maxwell_local_fom", pmesh);
@@ -647,7 +660,7 @@ int main(int argc, char *argv[])
                    "--no-partial-assembly", "Enable Partial Assembly.");
     args.AddOption(&device_config, "-d", "--device",
                    "Device configuration string, see Device::Configure().");
-    args.AddOption(&::visit, "-visit", "--visit-datafiles", "-no-visit",
+    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
                    "--no-visit-datafiles",
                    "Save data files for VisIt (visit.llnl.gov) visualization.");
     args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
@@ -738,7 +751,7 @@ int main(int argc, char *argv[])
         MFEM_VERIFY(!offline
                     && !online,
                     "offline and online must be turned off during the build_database phase.");
-        MFEM_VERIFY(!::visit
+        MFEM_VERIFY(!visit
                     && !visualization,
                     "visit and visualization must be turned off during the build_database phase.")
         std::ifstream infile("de_parametric_maxwell_greedy_algorithm_data");

--- a/examples/prom/elliptic_eigenproblem_global_rom.cpp
+++ b/examples/prom/elliptic_eigenproblem_global_rom.cpp
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
     //    handle triangular, quadrilateral, tetrahedral and hexahedral meshes
     //    with the same code.
     Mesh *mesh;
-    if (mesh_file == "")
+    if (strcmp(mesh_file, "") == 0 )
     {
         mesh = new Mesh(Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL));
     }

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -591,19 +591,8 @@ int main(int argc, char *argv[])
     //    discontinuous higher-order space. Since x and v are integrated in time
     //    as a system, we group them together in block vector vx, on the unique
     //    parallel degrees of freedom, with offsets given by array true_offset.
-    FiniteElementCollection *fe_coll;
-    NURBSExtension *NURBSext = NULL;
-
-    if (pmesh->NURBSext)
-    {
-       fe_coll = new NURBSFECollection(order);
-       NURBSext = new NURBSExtension(pmesh->NURBSext, order);
-    }
-    else
-    {
-       fe_coll = new H1_FECollection(order, dim);
-    }
-    ParFiniteElementSpace fespace(pmesh, NURBSext, fe_coll, dim);
+    H1_FECollection fe_coll(order, dim);
+    ParFiniteElementSpace fespace(pmesh, &fe_coll, dim);
 
     HYPRE_BigInt glob_size = fespace.GlobalTrueVSize();
     if (myid == 0)
@@ -625,19 +614,8 @@ int main(int argc, char *argv[])
     ParGridFunction x_ref(&fespace);
     pmesh->GetNodes(x_ref);
 
-    FiniteElementCollection *w_fec;
-    NURBSExtension *w_NURBSext = NULL;
-    if (pmesh->NURBSext)
-    {
-       w_fec = new NURBSFECollection(order + 1);
-       w_NURBSext = new NURBSExtension(pmesh->NURBSext, order+1);
-    }
-    else
-    {
-       w_fec = new L2_FECollection(order + 1, dim);
-    }
-
-    ParFiniteElementSpace w_fespace(pmesh, w_NURBSext, w_fec);
+    L2_FECollection w_fec(order + 1, dim);
+    ParFiniteElementSpace w_fespace(pmesh, &w_fec);
     ParGridFunction w_gf(&w_fespace);
 
     // Basis params
@@ -910,7 +888,7 @@ int main(int argc, char *argv[])
         }
 
         if (use_eqp)
-        {std::cout<<911<<std::endl;
+        {
             // EQP setup
             eqpSol = new CAROM::Vector(ir0->GetNPoints() * fespace.GetNE(), true);
             SetupEQP_snapshots(ir0, myid, &fespace, nsets, BV_librom.get(),
@@ -965,10 +943,10 @@ int main(int argc, char *argv[])
                                          num_sample_dofs_per_proc);
             smm->RegisterSampledVariable("H", 0, sample_dofs,
                                          num_sample_dofs_per_proc);
-std::cout<<968<<std::endl;
+
             smm->ConstructSampleMesh();
         }
-std::cout<<971<<std::endl;
+
         w = new CAROM::Vector(rxdim + rvdim, false);
         w_v = new CAROM::Vector(rvdim, false);
         w_x = new CAROM::Vector(rxdim, false);
@@ -1086,20 +1064,20 @@ std::cout<<971<<std::endl;
                 }
             }
         }
-std::cout<<1089<<std::endl;
+
         if (myid == 0)
         {
             if (!use_eqp)
-            {std::cout<<1093<<std::endl;
+            {
                 // Define operator in sample space
                 soper = new HyperelasticOperator(*sp_XV_space, ess_tdof_list_sp, visc, mu, K);
             }
             else
-            {std::cout<<1098<<std::endl;
+            {
                 soper = new HyperelasticOperator(fespace, ess_tdof_list, visc, mu, K);
             }
         }
-std::cout<<1102<<std::endl;
+
         if (!use_eqp)
         {
             romop = new RomOperator(&oper, soper, rvdim, rxdim, hdim, smm, w_v0, w_x0,
@@ -1114,7 +1092,7 @@ std::cout<<1102<<std::endl;
                                     myid,
                                     num_samples_req != -1, hyperreduce, x_base_only, use_eqp, eqpSol, ir0, model);
         }
-std::cout<<1117<<std::endl;
+
         // Print lifted initial energies
         BroadcastUndistributedRomVector(w);
 
@@ -1141,7 +1119,7 @@ std::cout<<1117<<std::endl;
             cout << "Lifted initial energies, EE = " << ee
                  << ", KE = " << ke << ", ΔTE = " << (ee + ke) - (ee0 + ke0) << endl;
         }
-std::cout<<1144<<std::endl;
+
         ode_solver->Init(*romop);
     }
     else
@@ -1415,8 +1393,6 @@ std::cout<<1144<<std::endl;
     delete eqpSol_S;
     delete window_ids;
     delete load_eqpsol;
-    delete w_fec;
-    delete fe_coll;
 
     totalTimer.Stop();
     if (myid == 0)
@@ -1475,14 +1451,14 @@ HyperelasticOperator::HyperelasticOperator(ParFiniteElementSpace &f,
     const double ref_density = 1.0; // density in the reference configuration
     ConstantCoefficient rho0(ref_density);
 
-    M = new ParBilinearForm(&fespace);std::cout<<1478<<std::endl;
-    M->AddDomainIntegrator(new VectorMassIntegrator(rho0));std::cout<<1479<<std::endl;
-    M->Assemble(skip_zero_entries);std::cout<<1480<<std::endl;
-    M->Finalize(skip_zero_entries);std::cout<<1481<<std::endl;
-    Mmat = M->ParallelAssemble();std::cout<<1482<<std::endl;
+    M = new ParBilinearForm(&fespace);
+    M->AddDomainIntegrator(new VectorMassIntegrator(rho0));
+    M->Assemble(skip_zero_entries);
+    M->Finalize(skip_zero_entries);
+    Mmat = M->ParallelAssemble();
     HypreParMatrix *Me = Mmat->EliminateRowsCols(ess_tdof_list);
     delete Me;
-std::cout<<1485<<std::endl;
+
     M_solver.iterative_mode = false;
     M_solver.SetRelTol(rel_tol);
     M_solver.SetAbsTol(0.0);
@@ -1502,7 +1478,7 @@ std::cout<<1485<<std::endl;
     S->AddDomainIntegrator(new VectorDiffusionIntegrator(visc_coeff));
     S->Assemble(skip_zero_entries);
     S->Finalize(skip_zero_entries);
-    S->FormSystemMatrix(ess_tdof_list, Smat);std::cout<<1505<<std::endl;
+    S->FormSystemMatrix(ess_tdof_list, Smat);
 }
 
 void HyperelasticOperator::Mult(const Vector &vx, Vector &dvx_dt) const

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -591,8 +591,19 @@ int main(int argc, char *argv[])
     //    discontinuous higher-order space. Since x and v are integrated in time
     //    as a system, we group them together in block vector vx, on the unique
     //    parallel degrees of freedom, with offsets given by array true_offset.
-    H1_FECollection fe_coll(order, dim);
-    ParFiniteElementSpace fespace(pmesh, &fe_coll, dim);
+    FiniteElementCollection *fe_coll;
+    NURBSExtension *NURBSext = NULL;
+
+    if (pmesh->NURBSext)
+    {
+       fe_coll = new NURBSFECollection(order);
+       NURBSext = new NURBSExtension(pmesh->NURBSext, order);
+    }
+    else
+    {
+       fe_coll = new H1_FECollection(order, dim);
+    }
+    ParFiniteElementSpace fespace(pmesh, NURBSext, fe_coll, dim);
 
     HYPRE_BigInt glob_size = fespace.GlobalTrueVSize();
     if (myid == 0)
@@ -614,8 +625,19 @@ int main(int argc, char *argv[])
     ParGridFunction x_ref(&fespace);
     pmesh->GetNodes(x_ref);
 
-    L2_FECollection w_fec(order + 1, dim);
-    ParFiniteElementSpace w_fespace(pmesh, &w_fec);
+    FiniteElementCollection *w_fec;
+    NURBSExtension *w_NURBSext = NULL;
+    if (pmesh->NURBSext)
+    {
+       w_fec = new NURBSFECollection(order + 1);
+       w_NURBSext = new NURBSExtension(pmesh->NURBSext, order+1);
+    }
+    else
+    {
+       w_fec = new L2_FECollection(order + 1, dim);
+    }
+
+    ParFiniteElementSpace w_fespace(pmesh, w_NURBSext, w_fec);
     ParGridFunction w_gf(&w_fespace);
 
     // Basis params
@@ -1393,6 +1415,8 @@ int main(int argc, char *argv[])
     delete eqpSol_S;
     delete window_ids;
     delete load_eqpsol;
+    delete w_fec;
+    delete fe_coll;
 
     totalTimer.Stop();
     if (myid == 0)

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -910,7 +910,7 @@ int main(int argc, char *argv[])
         }
 
         if (use_eqp)
-        {
+        {std::cout<<911<<std::endl;
             // EQP setup
             eqpSol = new CAROM::Vector(ir0->GetNPoints() * fespace.GetNE(), true);
             SetupEQP_snapshots(ir0, myid, &fespace, nsets, BV_librom.get(),
@@ -965,10 +965,10 @@ int main(int argc, char *argv[])
                                          num_sample_dofs_per_proc);
             smm->RegisterSampledVariable("H", 0, sample_dofs,
                                          num_sample_dofs_per_proc);
-
+std::cout<<968<<std::endl;
             smm->ConstructSampleMesh();
         }
-
+std::cout<<971<<std::endl;
         w = new CAROM::Vector(rxdim + rvdim, false);
         w_v = new CAROM::Vector(rvdim, false);
         w_x = new CAROM::Vector(rxdim, false);
@@ -1086,20 +1086,20 @@ int main(int argc, char *argv[])
                 }
             }
         }
-
+std::cout<<1089<<std::endl;
         if (myid == 0)
         {
             if (!use_eqp)
-            {
+            {std::cout<<1093<<std::endl;
                 // Define operator in sample space
                 soper = new HyperelasticOperator(*sp_XV_space, ess_tdof_list_sp, visc, mu, K);
             }
             else
-            {
+            {std::cout<<1098<<std::endl;
                 soper = new HyperelasticOperator(fespace, ess_tdof_list, visc, mu, K);
             }
         }
-
+std::cout<<1102<<std::endl;
         if (!use_eqp)
         {
             romop = new RomOperator(&oper, soper, rvdim, rxdim, hdim, smm, w_v0, w_x0,
@@ -1114,7 +1114,7 @@ int main(int argc, char *argv[])
                                     myid,
                                     num_samples_req != -1, hyperreduce, x_base_only, use_eqp, eqpSol, ir0, model);
         }
-
+std::cout<<1117<<std::endl;
         // Print lifted initial energies
         BroadcastUndistributedRomVector(w);
 
@@ -1141,7 +1141,7 @@ int main(int argc, char *argv[])
             cout << "Lifted initial energies, EE = " << ee
                  << ", KE = " << ke << ", ΔTE = " << (ee + ke) - (ee0 + ke0) << endl;
         }
-
+std::cout<<1144<<std::endl;
         ode_solver->Init(*romop);
     }
     else
@@ -1475,14 +1475,14 @@ HyperelasticOperator::HyperelasticOperator(ParFiniteElementSpace &f,
     const double ref_density = 1.0; // density in the reference configuration
     ConstantCoefficient rho0(ref_density);
 
-    M = new ParBilinearForm(&fespace);
-    M->AddDomainIntegrator(new VectorMassIntegrator(rho0));
-    M->Assemble(skip_zero_entries);
-    M->Finalize(skip_zero_entries);
-    Mmat = M->ParallelAssemble();
+    M = new ParBilinearForm(&fespace);std::cout<<1478<<std::endl;
+    M->AddDomainIntegrator(new VectorMassIntegrator(rho0));std::cout<<1479<<std::endl;
+    M->Assemble(skip_zero_entries);std::cout<<1480<<std::endl;
+    M->Finalize(skip_zero_entries);std::cout<<1481<<std::endl;
+    Mmat = M->ParallelAssemble();std::cout<<1482<<std::endl;
     HypreParMatrix *Me = Mmat->EliminateRowsCols(ess_tdof_list);
     delete Me;
-
+std::cout<<1485<<std::endl;
     M_solver.iterative_mode = false;
     M_solver.SetRelTol(rel_tol);
     M_solver.SetAbsTol(0.0);
@@ -1502,7 +1502,7 @@ HyperelasticOperator::HyperelasticOperator(ParFiniteElementSpace &f,
     S->AddDomainIntegrator(new VectorDiffusionIntegrator(visc_coeff));
     S->Assemble(skip_zero_entries);
     S->Finalize(skip_zero_entries);
-    S->FormSystemMatrix(ess_tdof_list, Smat);
+    S->FormSystemMatrix(ess_tdof_list, Smat);std::cout<<1505<<std::endl;
 }
 
 void HyperelasticOperator::Mult(const Vector &vx, Vector &dvx_dt) const

--- a/examples/prom/poisson_global_rom.cpp
+++ b/examples/prom/poisson_global_rom.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &myid);
 
     // 2. Parse command-line options.
-    const char *mesh_file = "../data/square-nurbs.mesh";
+    const char *mesh_file = "../data/star.mesh";
     int order = 1;
     bool static_cond = false;
     bool pa = false;
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     {
         int ref_levels =
             (int)floor(log(10000./mesh.GetNE())/log(2.)/dim);
-        for (int l = 0; l < ref_levels+2; l++)
+        for (int l = 0; l < ref_levels; l++)
         {
             mesh.UniformRefinement();
         }
@@ -172,26 +172,20 @@ int main(int argc, char *argv[])
     //    parallel mesh is defined, the serial mesh can be deleted.
     ParMesh pmesh(MPI_COMM_WORLD, mesh);
     mesh.Clear();
-   /* {
+    {
         int par_ref_levels = 2;
         for (int l = 0; l < par_ref_levels; l++)
         {
             pmesh.UniformRefinement();
         }
-    }*/
+    }
 
     // 7. Define a parallel finite element space on the parallel mesh. Here we
     //    use continuous Lagrange finite elements of the specified order. If
     //    order < 1, we instead use an isoparametric/isogeometric space.
     FiniteElementCollection *fec;
-    NURBSExtension *NURBSext = NULL;
     bool delete_fec;
-    if (pmesh.NURBSext)
-    {
-      fec = new NURBSFECollection(order);
-      NURBSext = new NURBSExtension(pmesh.NURBSext, order);
-    }
-    else if (order > 0)
+    if (order > 0)
     {
         fec = new H1_FECollection(order, dim);
         delete_fec = true;
@@ -210,7 +204,7 @@ int main(int argc, char *argv[])
         fec = new H1_FECollection(order = 1, dim);
         delete_fec = true;
     }
-    ParFiniteElementSpace fespace(&pmesh, NURBSext, fec);
+    ParFiniteElementSpace fespace(&pmesh, fec);
     HYPRE_Int size = fespace.GlobalTrueVSize();
     if (myid == 0)
     {

--- a/examples/prom/poisson_global_rom.cpp
+++ b/examples/prom/poisson_global_rom.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &myid);
 
     // 2. Parse command-line options.
-    const char *mesh_file = "../data/star.mesh";
+    const char *mesh_file = "../data/square-nurbs.mesh";
     int order = 1;
     bool static_cond = false;
     bool pa = false;
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     {
         int ref_levels =
             (int)floor(log(10000./mesh.GetNE())/log(2.)/dim);
-        for (int l = 0; l < ref_levels; l++)
+        for (int l = 0; l < ref_levels+2; l++)
         {
             mesh.UniformRefinement();
         }
@@ -172,20 +172,26 @@ int main(int argc, char *argv[])
     //    parallel mesh is defined, the serial mesh can be deleted.
     ParMesh pmesh(MPI_COMM_WORLD, mesh);
     mesh.Clear();
-    {
+   /* {
         int par_ref_levels = 2;
         for (int l = 0; l < par_ref_levels; l++)
         {
             pmesh.UniformRefinement();
         }
-    }
+    }*/
 
     // 7. Define a parallel finite element space on the parallel mesh. Here we
     //    use continuous Lagrange finite elements of the specified order. If
     //    order < 1, we instead use an isoparametric/isogeometric space.
     FiniteElementCollection *fec;
+    NURBSExtension *NURBSext = NULL;
     bool delete_fec;
-    if (order > 0)
+    if (pmesh.NURBSext)
+    {
+      fec = new NURBSFECollection(order);
+      NURBSext = new NURBSExtension(pmesh.NURBSext, order);
+    }
+    else if (order > 0)
     {
         fec = new H1_FECollection(order, dim);
         delete_fec = true;
@@ -204,7 +210,7 @@ int main(int argc, char *argv[])
         fec = new H1_FECollection(order = 1, dim);
         delete_fec = true;
     }
-    ParFiniteElementSpace fespace(&pmesh, fec);
+    ParFiniteElementSpace fespace(&pmesh, NURBSext, fec);
     HYPRE_Int size = fespace.GlobalTrueVSize();
     if (myid == 0)
     {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -97,9 +97,9 @@ if (BLAS_LIBRARIES MATCHES ".*mkl.*")
   find_package(MKL COMPONENTS BLACS ScaLAPACK)
   if (NOT MKL_ScaLAPACK_FOUND)
     find_package(ScaLAPACK REQUIRED)
-    target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES})
+    target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES} ${MFEM_LIBRARIES})
   else()
-    target_link_libraries(ROM PUBLIC ${MKL_ScaLAPACK_LIBRARY} ${MKL_BLACS_LIBRARY} ${MKL_LIBRARIES})
+    target_link_libraries(ROM PUBLIC ${MKL_ScaLAPACK_LIBRARY} ${MKL_BLACS_LIBRARY} ${MKL_LIBRARIES} ${MFEM_LIBRARIES})
     target_include_directories(ROM PUBLIC ${MKL_INCLUDE_DIRS})
   endif()
 else() # BLAS or LAPACK isn't MKL
@@ -112,7 +112,7 @@ else() # BLAS or LAPACK isn't MKL
     set(ENV{PATH} "${CMAKE_SOURCE_DIR}/dependencies/scalapack-2.2.0:$ENV{PATH}")
     find_package(ScaLAPACK REQUIRED)
   endif()
-  target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES})
+  target_link_libraries(ROM PUBLIC ${ScaLAPACK_LIBRARIES} ${MFEM_LIBRARIES})
 endif()
 
 # PUBLIC dependencies are transitive; these dependencies are used in
@@ -131,7 +131,7 @@ endif()
 # 3.0.
 target_link_libraries(ROM
   PUBLIC ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${MPI_FORTRAN_LINK_FLAGS} ${MPI_FORTRAN_LIBRARIES} MPI::MPI_Fortran ${HDF5_LIBRARIES}
-  ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MFEM} ${HYPRE} ${PARMETIS} ${METIS}
+  ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MFEM} ${HYPRE} ${PARMETIS} ${METIS} ${MFEM_LIBRARIES}
   PRIVATE ${ZLIB_LIBRARIES} ZLIB::ZLIB)
 
 target_include_directories(ROM PUBLIC
@@ -143,6 +143,8 @@ target_include_directories(ROM PUBLIC
   ${MPI_C_INCLUDE_DIRS}
   ${MFEM_C_INCLUDE_DIRS}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_features(ROM PRIVATE cxx_std_17)
 
 # Find headers from the source file list that need to be installed
 set(HEADERS "")

--- a/lib/algo/greedy/GreedySampler.h
+++ b/lib/algo/greedy/GreedySampler.h
@@ -254,7 +254,7 @@ public:
     /**
      * @brief Destructor.
      */
-    ~GreedySampler();
+    virtual ~GreedySampler();
 
     /**
      * @brief Returns the next parameter point for which sampling is required.

--- a/lib/linalg/Matrix.cpp
+++ b/lib/linalg/Matrix.cpp
@@ -816,7 +816,8 @@ Matrix::gather()
                                 MPI_COMM_WORLD) == MPI_SUCCESS);
 
     delete [] d_mat;
-    delete [] data_offsets, data_cnts;
+    delete [] data_offsets;
+    delete [] data_cnts;
     d_mat = d_new_mat;
     d_alloc_size = new_size;
 

--- a/lib/linalg/Vector.cpp
+++ b/lib/linalg/Vector.cpp
@@ -507,7 +507,8 @@ Vector::gather()
                                 MPI_COMM_WORLD) == MPI_SUCCESS);
 
     delete [] d_vec;
-    delete [] data_offsets, data_cnts;
+    delete [] data_offsets;
+    delete [] data_cnts;
     d_vec = d_new_vec;
     d_alloc_size = new_size;
     d_dim = new_size;

--- a/lib/linalg/svd/IncrementalSVD.h
+++ b/lib/linalg/svd/IncrementalSVD.h
@@ -62,7 +62,7 @@ public:
     bool
     takeSample(
         double* u_in,
-        bool add_without_increase = false)override;
+        bool add_without_increase = false) override;
 
     /**
      * @brief Returns the basis vectors for the current time interval as a

--- a/lib/linalg/svd/IncrementalSVD.h
+++ b/lib/linalg/svd/IncrementalSVD.h
@@ -62,7 +62,7 @@ public:
     bool
     takeSample(
         double* u_in,
-        bool add_without_increase = false);
+        bool add_without_increase = false)override;
 
     /**
      * @brief Returns the basis vectors for the current time interval as a

--- a/lib/linalg/svd/IncrementalSVDBrand.h
+++ b/lib/linalg/svd/IncrementalSVDBrand.h
@@ -142,7 +142,7 @@ private:
     addLinearlyDependentSample(
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma);
+        const Matrix & sigma) override;
 
     /**
      * @brief Add a new, unique sample to the SVD.
@@ -157,7 +157,7 @@ private:
         const Vector & j,
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma);
+        const Matrix & sigma) override;
 
     /**
      * @brief The matrix U'. U' is not distributed and the entire matrix

--- a/lib/linalg/svd/IncrementalSVDFastUpdate.h
+++ b/lib/linalg/svd/IncrementalSVDFastUpdate.h
@@ -98,7 +98,7 @@ private:
     addLinearlyDependentSample(
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma);
+        const Matrix & sigma)override;
 
     /**
      * @brief Add a new, unique sample to the SVD.
@@ -113,7 +113,7 @@ private:
         const Vector & j,
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma);
+        const Matrix & sigma)override;
 
     /**
      * @brief The matrix U'. U' is not distributed and the entire matrix

--- a/lib/linalg/svd/IncrementalSVDFastUpdate.h
+++ b/lib/linalg/svd/IncrementalSVDFastUpdate.h
@@ -98,7 +98,7 @@ private:
     addLinearlyDependentSample(
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma)override;
+        const Matrix & sigma) override;
 
     /**
      * @brief Add a new, unique sample to the SVD.
@@ -113,7 +113,7 @@ private:
         const Vector & j,
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma)override;
+        const Matrix & sigma) override;
 
     /**
      * @brief The matrix U'. U' is not distributed and the entire matrix

--- a/lib/linalg/svd/IncrementalSVDStandard.h
+++ b/lib/linalg/svd/IncrementalSVDStandard.h
@@ -97,7 +97,7 @@ private:
     addLinearlyDependentSample(
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma);
+        const Matrix & sigma) override;
 
     /**
      * @brief Add a new, unique sample to the SVD.
@@ -112,7 +112,7 @@ private:
         const Vector & j,
         const Matrix & A,
         const Matrix & W,
-        const Matrix & sigma);
+        const Matrix & sigma) override;
 };
 
 }

--- a/lib/linalg/svd/StaticSVD.h
+++ b/lib/linalg/svd/StaticSVD.h
@@ -51,7 +51,7 @@ public:
     bool
     takeSample(
         double* u_in,
-        bool add_without_increase = false);
+        bool add_without_increase = false) override;
 
     /**
      * @brief Returns the basis vectors for the current time interval as a

--- a/lib/mfem/PointwiseSnapshot.cpp
+++ b/lib/mfem/PointwiseSnapshot.cpp
@@ -1,6 +1,8 @@
 #include "PointwiseSnapshot.hpp"
 
 #ifdef MFEM_USE_GSLIB
+using std::cout;
+using std::endl;
 namespace CAROM {
 
 PointwiseSnapshot::PointwiseSnapshot(const int sdim, const int *dims_)

--- a/lib/mfem/PointwiseSnapshot.hpp
+++ b/lib/mfem/PointwiseSnapshot.hpp
@@ -14,7 +14,6 @@
 #include "mfem.hpp"
 
 using namespace mfem;
-using namespace std;
 #ifdef MFEM_USE_GSLIB
 
 namespace CAROM {

--- a/lib/mfem/SampleMesh.cpp
+++ b/lib/mfem/SampleMesh.cpp
@@ -10,6 +10,14 @@
 
 #include "SampleMesh.hpp"
 
+using std::vector;
+using std::set;
+using std::map;
+using std::make_pair;
+using std::string;
+using std::cout;
+using std::endl;
+
 namespace CAROM {
 
 #define FULL_DOF_STENCIL
@@ -899,7 +907,7 @@ void ParaViewPrintAttributes(const string &fname,
                              const Array<int> *el_number=nullptr,
                              const Array<int> *vert_number=nullptr)
 {
-    ofstream out(fname + ".vtu");
+    std::ofstream out(fname + ".vtu");
 
     out << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\"";
     out << " byte_order=\"" << VTKByteOrder() << "\">\n";
@@ -1221,8 +1229,8 @@ void SampleMeshManager::ConstructSampleMesh()
         spaceTOS[i+1] = spaceTOS[i] + fespace[i]->GetTrueVSize();
     }
 
-    SetSampleMaps();
-    CreateSampleMesh();
+    SetSampleMaps();std::cout<<1224 <<std::endl;
+    CreateSampleMesh();std::cout<<1225 <<std::endl;
 
     if (myid == 0)
     {
@@ -1317,7 +1325,7 @@ void SampleMeshManager::WriteVariableSampleMap(const string variable,
         string file_name) const
 {
     const int var = GetVariableIndex(variable);
-    ofstream file;
+    std::ofstream file;
     file.open(file_name);
     for (int i=0; i<s2sp_var[var].size(); ++i)
     {
@@ -1577,20 +1585,23 @@ void SampleMeshManager::CreateSampleMesh()
     Mesh *sample_mesh = 0;
     BuildSampleMesh(*pmesh, fespace, elems, sample_mesh, sprows, elemLocalIndices,
                     elemLocalIndicesInverse);
-
+std::cout<<1580 <<std::endl;
     MFEM_VERIFY(sample_mesh->GetNE() == elemLocalIndices.size(), "");
 
     if (myid == 0)
     {
         sample_pmesh = new ParMesh(root_comm, *sample_mesh);
         delete sample_mesh;
-
+        for (int i=0; i<nspaces; ++i)
+           std::cout<<fespace[i]->GetNURBSext()<<std::endl;
         // Create fespaces on sample mesh
         for (int i=0; i<nspaces; ++i)
-            spfespace[i] = new ParFiniteElementSpace(sample_pmesh, fespace[i]->FEColl(),
+            spfespace[i] = new ParFiniteElementSpace(sample_pmesh,
+                    fespace[i]->GetNURBSext(),
+                    fespace[i]->FEColl(),
                     fespace[i]->GetVDim());
     }
-
+std::cout<<1593 <<std::endl;
     vector<int> spNtrue(nspaces);
     for (int i=0; i<nspaces; ++i)
         spNtrue[i] = myid == 0 ? spfespace[i]->TrueVSize() : 0;
@@ -1604,7 +1615,7 @@ void SampleMeshManager::CreateSampleMesh()
     Finish_s2sp_augmented(myid, nprocs, fespace, sample_dofs_block,
                           sample_dofs_sub_to_sample_dofs, local_num_sample_dofs_sub, true, s2sp);
 #endif
-
+std::cout<<1607 <<std::endl;
     // Prepare for setting st2sp
 
     const int numStencil = sprows.size();
@@ -1785,7 +1796,7 @@ void SampleDOFSelector::ReadMapFromFile(const string variable, string file_name)
     vmap[variable] = nvar;
 
     vector<int> v;
-    ifstream file;
+    std::ifstream file;
     file.open(file_name);
     string line;
     while(getline(file, line)) {

--- a/lib/mfem/SampleMesh.cpp
+++ b/lib/mfem/SampleMesh.cpp
@@ -10,12 +10,7 @@
 
 #include "SampleMesh.hpp"
 
-using std::vector;
-using std::set;
-using std::map;
 using std::make_pair;
-using std::string;
-using std::cout;
 using std::endl;
 
 namespace CAROM {
@@ -1229,8 +1224,8 @@ void SampleMeshManager::ConstructSampleMesh()
         spaceTOS[i+1] = spaceTOS[i] + fespace[i]->GetTrueVSize();
     }
 
-    SetSampleMaps();std::cout<<1224 <<std::endl;
-    CreateSampleMesh();std::cout<<1225 <<std::endl;
+    SetSampleMaps();
+    CreateSampleMesh();
 
     if (myid == 0)
     {
@@ -1585,7 +1580,7 @@ void SampleMeshManager::CreateSampleMesh()
     Mesh *sample_mesh = 0;
     BuildSampleMesh(*pmesh, fespace, elems, sample_mesh, sprows, elemLocalIndices,
                     elemLocalIndicesInverse);
-std::cout<<1580 <<std::endl;
+
     MFEM_VERIFY(sample_mesh->GetNE() == elemLocalIndices.size(), "");
 
     if (myid == 0)
@@ -1593,7 +1588,7 @@ std::cout<<1580 <<std::endl;
         sample_pmesh = new ParMesh(root_comm, *sample_mesh);
         delete sample_mesh;
         for (int i=0; i<nspaces; ++i)
-           std::cout<<fespace[i]->GetNURBSext()<<std::endl;
+
         // Create fespaces on sample mesh
         for (int i=0; i<nspaces; ++i)
             spfespace[i] = new ParFiniteElementSpace(sample_pmesh,
@@ -1601,7 +1596,7 @@ std::cout<<1580 <<std::endl;
                     fespace[i]->FEColl(),
                     fespace[i]->GetVDim());
     }
-std::cout<<1593 <<std::endl;
+
     vector<int> spNtrue(nspaces);
     for (int i=0; i<nspaces; ++i)
         spNtrue[i] = myid == 0 ? spfespace[i]->TrueVSize() : 0;
@@ -1615,7 +1610,7 @@ std::cout<<1593 <<std::endl;
     Finish_s2sp_augmented(myid, nprocs, fespace, sample_dofs_block,
                           sample_dofs_sub_to_sample_dofs, local_num_sample_dofs_sub, true, s2sp);
 #endif
-std::cout<<1607 <<std::endl;
+
     // Prepare for setting st2sp
 
     const int numStencil = sprows.size();

--- a/lib/mfem/SampleMesh.cpp
+++ b/lib/mfem/SampleMesh.cpp
@@ -10,8 +10,10 @@
 
 #include "SampleMesh.hpp"
 
-using std::make_pair;
 using std::endl;
+using std::make_pair;
+using std::ofstream;
+using std::ifstream;
 
 namespace CAROM {
 
@@ -902,7 +904,7 @@ void ParaViewPrintAttributes(const string &fname,
                              const Array<int> *el_number=nullptr,
                              const Array<int> *vert_number=nullptr)
 {
-    std::ofstream out(fname + ".vtu");
+    ofstream out(fname + ".vtu");
 
     out << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\"";
     out << " byte_order=\"" << VTKByteOrder() << "\">\n";
@@ -1320,7 +1322,7 @@ void SampleMeshManager::WriteVariableSampleMap(const string variable,
         string file_name) const
 {
     const int var = GetVariableIndex(variable);
-    std::ofstream file;
+    ofstream file;
     file.open(file_name);
     for (int i=0; i<s2sp_var[var].size(); ++i)
     {
@@ -1587,13 +1589,10 @@ void SampleMeshManager::CreateSampleMesh()
     {
         sample_pmesh = new ParMesh(root_comm, *sample_mesh);
         delete sample_mesh;
-        for (int i=0; i<nspaces; ++i)
 
         // Create fespaces on sample mesh
         for (int i=0; i<nspaces; ++i)
-            spfespace[i] = new ParFiniteElementSpace(sample_pmesh,
-                    fespace[i]->GetNURBSext(),
-                    fespace[i]->FEColl(),
+            spfespace[i] = new ParFiniteElementSpace(sample_pmesh, fespace[i]->FEColl(),
                     fespace[i]->GetVDim());
     }
 
@@ -1791,7 +1790,7 @@ void SampleDOFSelector::ReadMapFromFile(const string variable, string file_name)
     vmap[variable] = nvar;
 
     vector<int> v;
-    std::ifstream file;
+    ifstream file;
     file.open(file_name);
     string line;
     while(getline(file, line)) {

--- a/lib/mfem/SampleMesh.hpp
+++ b/lib/mfem/SampleMesh.hpp
@@ -20,7 +20,10 @@
 #include "linalg/Matrix.h"
 
 using namespace mfem;
-using namespace std;
+using std::vector;
+using std::set;
+using std::map;
+using std::string;
 
 namespace CAROM {
 

--- a/lib/mfem/Utilities.hpp
+++ b/lib/mfem/Utilities.hpp
@@ -15,7 +15,6 @@
 #include "linalg/Matrix.h"
 
 using namespace mfem;
-using namespace std;
 
 namespace CAROM {
 

--- a/lib/utils/CSVDatabase.h
+++ b/lib/utils/CSVDatabase.h
@@ -77,7 +77,7 @@ public:
      * @return True if the file close was successful.
      */
     bool
-    close();
+    close() override;
 
     /**
      * @brief Writes an array of integers associated with the supplied filename.

--- a/lib/utils/HDFDatabase.h
+++ b/lib/utils/HDFDatabase.h
@@ -125,7 +125,7 @@ public:
         const std::string& key,
         const double* const data,
         int nelements,
-        const bool distributed=false)override;
+        const bool distributed=false) override;
 
     /**
      * @brief Writes a vector of doubles associated with the supplied key to
@@ -149,7 +149,7 @@ public:
         const std::string& key,
         const std::vector<double>& data,
         int nelements,
-        const bool distributed=false)override;
+        const bool distributed=false) override;
 
     /**
      * @brief Reads an array of integers associated with the supplied key
@@ -172,7 +172,7 @@ public:
         const std::string& key,
         int* data,
         int nelements,
-        const bool distributed=false)override;
+        const bool distributed=false) override;
 
     /**
      * @brief Count the number of elements in an array of doubles associated
@@ -184,7 +184,7 @@ public:
      */
     virtual
     int
-    getDoubleArraySize(const std::string& key)override;
+    getDoubleArraySize(const std::string& key) override;
 
     /**
      * @brief Reads an array of doubles associated with the supplied key
@@ -207,7 +207,7 @@ public:
         const std::string& key,
         double* data,
         int nelements,
-        const bool distributed=false)override;
+        const bool distributed=false) override;
 
     /**
      * @brief Reads a sub-array of doubles associated with the supplied key
@@ -232,7 +232,7 @@ public:
         double* data,
         int nelements,
         const std::vector<int>& idx,
-        const bool distributed=false)override;
+        const bool distributed=false) override;
 
     /**
      * @brief Reads an array of doubles associated with the supplied key
@@ -264,7 +264,7 @@ public:
         int offset,
         int block_size,
         int stride,
-        const bool distributed=false)override;
+        const bool distributed=false) override;
 
 protected:
 

--- a/lib/utils/HDFDatabase.h
+++ b/lib/utils/HDFDatabase.h
@@ -77,7 +77,7 @@ public:
      */
     virtual
     bool
-    close();
+    close() override;
 
     /**
      * @brief Writes an array of integers associated with the supplied key to
@@ -101,7 +101,7 @@ public:
         const std::string& key,
         const int* const data,
         int nelements,
-        const bool distributed=false);
+        const bool distributed=false) override;
 
     /**
      * @brief Writes an array of doubles associated with the supplied key to
@@ -125,7 +125,7 @@ public:
         const std::string& key,
         const double* const data,
         int nelements,
-        const bool distributed=false);
+        const bool distributed=false)override;
 
     /**
      * @brief Writes a vector of doubles associated with the supplied key to
@@ -149,7 +149,7 @@ public:
         const std::string& key,
         const std::vector<double>& data,
         int nelements,
-        const bool distributed=false);
+        const bool distributed=false)override;
 
     /**
      * @brief Reads an array of integers associated with the supplied key
@@ -172,7 +172,7 @@ public:
         const std::string& key,
         int* data,
         int nelements,
-        const bool distributed=false);
+        const bool distributed=false)override;
 
     /**
      * @brief Count the number of elements in an array of doubles associated
@@ -184,7 +184,7 @@ public:
      */
     virtual
     int
-    getDoubleArraySize(const std::string& key);
+    getDoubleArraySize(const std::string& key)override;
 
     /**
      * @brief Reads an array of doubles associated with the supplied key
@@ -207,7 +207,7 @@ public:
         const std::string& key,
         double* data,
         int nelements,
-        const bool distributed=false);
+        const bool distributed=false)override;
 
     /**
      * @brief Reads a sub-array of doubles associated with the supplied key
@@ -232,7 +232,7 @@ public:
         double* data,
         int nelements,
         const std::vector<int>& idx,
-        const bool distributed=false);
+        const bool distributed=false)override;
 
     /**
      * @brief Reads an array of doubles associated with the supplied key
@@ -264,7 +264,7 @@ public:
         int offset,
         int block_size,
         int stride,
-        const bool distributed=false);
+        const bool distributed=false)override;
 
 protected:
 

--- a/regression_tests/CMakeLists.txt
+++ b/regression_tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+###############################################################################
+#
+#  Copyright (c) 2013-2024, Lawrence Livermore National Security, LLC
+#  and other libROM project developers. See the top-level COPYRIGHT
+#  file for details.
+#
+#  SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+###############################################################################
+
+set(regression_test_names
+        basisComparator
+        checkError
+        computeSpeedup
+        solutionComparator
+        fileComparator)
+
+foreach(name IN LISTS regression_test_names)
+   add_executable(${name} ${name}.cpp)
+   target_link_libraries(${name} PRIVATE ROM ${CAROM_LIBS})
+   target_include_directories(${name} PRIVATE ${CAROM_INCS})
+   target_compile_features(${name} PRIVATE cxx_std_17)
+endforeach()
+
+


### PR DESCRIPTION
This PR does three related things -- in order of impact/controversialness(sic):

1. It rationalized/simplifies the CMake routines. 
- In the old routines the MFEM library defaulted to dependencies/mfem even if another mfem was provided
- The mfem is imported as a packages, this simplifies things
- Examples and tests are handled in there own directory, this simplifies the routines
2. Switched to c++23 to accommodate MFEM
 - This created issues with std
 - Removed `using namespace std` from the library and examples
3. Fixed some other (pedantic) compiler errors
 - Added some override statements
 - Made a constructor virtual
 - Separate delete statement for different variables
 - Corrected a string comparison