### PR TITLE
Add no hyper reduction mode to Mixed Nonlinear Diffusion

### DIFF
--- a/examples/prom/mixed_nonlinear_diffusion.cpp
+++ b/examples/prom/mixed_nonlinear_diffusion.cpp
@@ -348,7 +348,8 @@ public:
                 const double newton_rel_tol, const double newton_abs_tol, const int newton_iter,
                 std::shared_ptr<CAROM::Matrix> S_,
                 const std::shared_ptr<CAROM::Matrix> & Ssinv_,
-                const int myid, const bool hyperreduce_source_, const bool oversampling_,
+                const int myid, const bool hyperreduce_,
+                const bool hyperreduce_source_, const bool oversampling_,
                 const bool use_eqp, const CAROM::Vector & eqpSol,
                 const CAROM::Vector & eqpSol_S, const IntegrationRule *ir_eqp_);
 
@@ -469,6 +470,7 @@ int main(int argc, char *argv[])
     bool online = false;
     const char *samplingType = "deim";
     bool use_eqp = false;
+    bool hyperreduce = true;
     bool writeSampleMesh = false;
     int num_samples_req = -1;
     bool squareSV = true;
@@ -545,6 +547,8 @@ int main(int argc, char *argv[])
                    "Number of samples for the sampling algorithm to select.");
     args.AddOption(&use_eqp, "-eqp", "--eqp", "-no-eqp", "--no-eqp",
                    "Use EQP instead of DEIM for the hyperreduction.");
+    args.AddOption(&hyperreduce, "-hyp", "--hyperreduce", "-no-hyp",
+                   "--no-hyperreduce", "Hyper reduce nonlinear term");
     args.AddOption(&writeSampleMesh, "-smesh", "--sample-mesh", "-no-smesh",
                    "--no-sample-mesh", "Write the sample mesh to file.");
     args.AddOption(&preconditionNNLS, "-preceqp", "--preceqp", "-no-preceqp",
@@ -1071,7 +1075,7 @@ int main(int argc, char *argv[])
         romop = new RomOperator(&oper, soper.get(), rrdim, rwdim, nldim, smm,
                                 BR_librom, FR_librom, BW_librom,
                                 Bsinv, newton_rel_tol, newton_abs_tol, newton_iter,
-                                S_librom, Ssinv, myid, hyperreduce_source,
+                                S_librom, Ssinv, myid, hyperreduce, hyperreduce_source,
                                 num_samples_req != -1, use_eqp, *eqpSol, *eqpSol_S, ir0);
 
         ode_solver.Init(*romop);
@@ -1653,7 +1657,8 @@ RomOperator::RomOperator(NonlinearDiffusionOperator *fom_,
                          const double newton_abs_tol, const int newton_iter,
                          std::shared_ptr<CAROM::Matrix> S_,
                          const shared_ptr<CAROM::Matrix> & Ssinv_,
-                         const int myid, const bool hyperreduce_source_,
+                         const int myid, const bool hyperreduce_,
+                         const bool hyperreduce_source_,
                          const bool oversampling_, const bool use_eqp,
                          const CAROM::Vector & eqpSol, const CAROM::Vector & eqpSol_S,
                          const IntegrationRule *ir_eqp_)
@@ -1667,7 +1672,8 @@ RomOperator::RomOperator(NonlinearDiffusionOperator *fom_,
       zN(std::max(nsamp_R, 1), false), J(height),
       zS(std::max(nsamp_S, 1), false), zT(std::max(nsamp_S, 1), false), Ssinv(Ssinv_),
       VTCS_W(rwdim, std::max(nsamp_S, 1), false), S(S_),
-      VtzR(rrdim_, false), hyperreduce_source(hyperreduce_source_),
+      VtzR(rrdim_, false), hyperreduce(hyperreduce_),
+      hyperreduce_source(hyperreduce_source_),
       oversampling(oversampling_), eqp(use_eqp),
       ir_eqp(ir_eqp_), p_gf(&(fom_->fespace_W)), rhs_gf(&(fom_->fespace_W)),
       p_coeff(&p_gf), a_coeff(&p_coeff, NonlinearCoefficient),
@@ -1744,7 +1750,6 @@ RomOperator::RomOperator(NonlinearDiffusionOperator *fom_,
         }
     }
 
-    hyperreduce = true;
     sourceFOM = false;
 
     if (!hyperreduce || sourceFOM)
@@ -1764,7 +1769,7 @@ RomOperator::RomOperator(NonlinearDiffusionOperator *fom_,
                                               true, false));
 
         zfomR.SetSize(fom->zR.Size());
-        zfomR_librom.reset(new CAROM::Vector(zfomR.GetData(), zfomR.Size(), false,
+        zfomR_librom.reset(new CAROM::Vector(zfomR.GetData(), zfomR.Size(), true,
                                              false));
 
         zfomW.SetSize(fom->zW.Size());

--- a/examples/prom/nonlinear_elasticity_global_rom.cpp
+++ b/examples/prom/nonlinear_elasticity_global_rom.cpp
@@ -859,13 +859,15 @@ int main(int argc, char *argv[])
         {
             hdim = H_librom->numColumns();
         }
+        if (!hyperreduce) // Set hdim to 1 to reduce loading time for basis
+            hdim = 1;
         CAROM::Matrix *Hsinv = new CAROM::Matrix(hdim, hdim, false);
         MFEM_VERIFY(H_librom->numColumns() >= hdim, "");
 
         if (H_librom->numColumns() > hdim)
             H_librom = H_librom->getFirstNColumns(hdim);
 
-        if (myid == 0)
+        if (myid == 0 && hyperreduce)
             printf("reduced H dim = %d\n", hdim);
 
         // Setup hyperreduction, using either EQP or sampled DOFs and a sample mesh.
@@ -901,6 +903,9 @@ int main(int argc, char *argv[])
         }
         else
         {
+            if (!hyperreduce) // Enforce full size of sampling mesh (crashes otherwise)
+                num_samples_req = static_cast<int>(glob_size);
+
             vector<int> num_sample_dofs_per_proc(num_procs);
 
             if (num_samples_req != -1)


### PR DESCRIPTION
This PR adds a no hyper reduction mode for Mixed Nonlinear Diffusion with a command line argument, similar to the nonlinear elasticity example. It also adds some small performance improvements and guardrails for no hyper reduction mode in nonlinear elasticity.

Reproductive example for mixed nonlinear diffusion (has been tested for predictive example too)
```
# Offline phase:
./mixed_nonlinear_diffusion -p 1 -offline -id 0 -sh 0.2

# Merge phase:
./mixed_nonlinear_diffusion -p 1 -merge -ns 1

# Comparison data:
./mixed_nonlinear_diffusion -p 1 -offline -id 1 -sh 0.2

# Online phase:
./mixed_nonlinear_diffusion -online -rrdim 16 -rwdim 16 -p 1 -sh 0.2 -no-hyp

./mixed_nonlinear_diffusion -online -rrdim 16 -rwdim 16 -p 1 -sh 0.2 -nldim 2 -hrtype deim
```

Reproductive example for nonlinear elasticity (has been tested for predictive example too)
```
# Offline phase:
./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.0 -id 0

# Merge phase:
./nonlinear_elasticity_global_rom -merge -ns 1 -dt 0.01 -tf 5.0

# Comparison data:
./nonlinear_elasticity_global_rom -offline -dt 0.01 -tf 5.0 -s 14 -vs 100 -sc 1.0 -id 1

# Online phase:
./nonlinear_elasticity_global_rom -online -dt 0.01 -tf 5.0 -s 14 -vs 100 -no-hyp -rvdim 40 -rxdim 10 -sc 1.0
./nonlinear_elasticity_global_rom -online -dt 0.01 -tf 5.0 -s 14 -vs 100 -hyp -hrtype qdeim -rvdim 40 -rxdim 10 -hdim 71 -nsr 100 -sc 1.0
```